### PR TITLE
Add continuous queries

### DIFF
--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -59,9 +59,7 @@ void ship_results(stateful_actor<exporter_state>* self) {
   self->send(self->state.sink, msg);
 }
 
-void shutdown(stateful_actor<exporter_state>* self) {
-  if (rank(self->state.unprocessed) > 0 || !self->state.results.empty())
-    return;
+void report_statistics(stateful_actor<exporter_state>* self) {
   timespan runtime = steady_clock::now() - self->state.start;
   self->state.stats.runtime = runtime;
   VAST_DEBUG(self, "completed in", runtime);
@@ -79,10 +77,19 @@ void shutdown(stateful_actor<exporter_state>* self) {
     self->send(self->state.accountant, "exporter.selectivity", selectivity);
     self->send(self->state.accountant, "exporter.runtime", runtime);
   }
+}
+
+void shutdown(stateful_actor<exporter_state>* self) {
+  if (rank(self->state.unprocessed) > 0 || !self->state.results.empty()
+      || has_continuous_option(self->state.opts))
+    return;
+  report_statistics(self);
   self->send_exit(self, exit_reason::normal);
 }
 
 void request_more_hits(stateful_actor<exporter_state>* self) {
+  if (!has_historical_option(self->state.opts))
+    return;
   auto waiting_for_hits =
     self->state.stats.received == self->state.stats.scheduled;
   auto need_more_results = self->state.stats.requested > 0;
@@ -102,16 +109,31 @@ void request_more_hits(stateful_actor<exporter_state>* self) {
 } // namespace <anonymous>
 
 behavior exporter(stateful_actor<exporter_state>* self, expression expr,
-                  query_options) {
+                  query_options opts) {
   auto eu = self->system().dummy_execution_unit();
   self->state.sink = actor_pool::make(eu, actor_pool::broadcast());
   if (auto a = self->system().registry().get(accountant_atom::value))
     self->state.accountant = actor_cast<accountant_type>(a);
+  self->state.opts = opts;
+  if (has_continuous_option(opts)) {
+    VAST_DEBUG(self, "has continuous query option");
+  }
   self->set_exit_handler(
     [=](const exit_msg& msg) {
       self->send(self->state.sink, sys_atom::value, delete_atom::value);
       self->send_exit(self->state.sink, msg.reason);
       self->quit(msg.reason);
+      if (msg.reason != exit_reason::kill)
+        report_statistics(self);
+    }
+  );
+  self->set_down_handler(
+    [=](const down_msg& msg) {
+      VAST_DEBUG(self, "received DOWN from", msg.source);
+      if (has_continuous_option(self->state.opts)
+          && (msg.source == self->state.archive
+              || msg.source == self->state.index))
+        report_statistics(self);
     }
   );
   return {
@@ -153,6 +175,7 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
     [=](std::vector<event>& candidates) {
       VAST_DEBUG(self, "got batch of", candidates.size(), "events");
       bitmap mask;
+      auto sender = self->current_sender();
       for (auto& candidate : candidates) {
         auto& checker = self->state.checkers[candidate.type()];
         // Construct a candidate checker if we don't have one for this type.
@@ -173,11 +196,14 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
           self->state.results.push_back(std::move(candidate));
         else
           VAST_DEBUG(self, "ignores false positive:", candidate);
-        mask.append_bits(false, candidate.id() - mask.size());
-        mask.append_bit(true);
+        if (sender == self->state.archive) {
+          mask.append_bits(false, candidate.id() - mask.size());
+          mask.append_bit(true);
+        }
       }
       self->state.stats.processed += candidates.size();
-      self->state.unprocessed -= mask;
+      if (sender == self->state.archive)
+        self->state.unprocessed -= mask;
       ship_results(self);
       request_more_hits(self);
       if (self->state.stats.received == self->state.stats.expected)
@@ -207,18 +233,31 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
     [=](const archive_type& archive) {
       VAST_DEBUG(self, "registers archive", archive);
       self->state.archive = archive;
+      if (has_continuous_option(self->state.opts))
+        self->monitor(archive);
     },
     [=](index_atom, const actor& index) {
       VAST_DEBUG(self, "registers index", index);
       self->state.index = index;
+      if (has_continuous_option(self->state.opts))
+        self->monitor(index);
     },
     [=](sink_atom, const actor& sink) {
       VAST_DEBUG(self, "registers index", sink);
       self->send(self->state.sink, sys_atom::value, put_atom::value, sink);
+      self->monitor(self->state.sink);
+    },
+    [=](importer_atom, const std::vector<actor>& importers) {
+      // Register for events at running IMPORTERs.
+      if (has_continuous_option(self->state.opts))
+        for (auto& i : importers)
+          self->send(i, exporter_atom::value, self);
     },
     [=](run_atom) {
       VAST_INFO(self, "executes query", expr);
       self->state.start = steady_clock::now();
+      if (!has_historical_option(self->state.opts))
+        return;
       self->request(self->state.index, infinite, expr).then(
         [=](const uuid& lookup, size_t partitions, size_t scheduled) {
           VAST_DEBUG(self, "got lookup handle", lookup << ", scheduled",

--- a/libvast/src/system/spawn.cpp
+++ b/libvast/src/system/spawn.cpp
@@ -11,6 +11,8 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
+#include <iterator>
+
 #include <caf/all.hpp>
 
 #include "vast/config.hpp"
@@ -54,7 +56,8 @@ expected<actor> spawn_archive(local_actor* self, options& opts) {
   return actor_cast<actor>(a);
 }
 
-expected<actor> spawn_exporter(local_actor* self, options& opts) {
+expected<actor> spawn_exporter(stateful_actor<node_state>* self,
+                               options& opts) {
   auto limit = uint64_t{0};
   auto r = opts.params.extract_opts({
     {"continuous,c", "marks a query as continuous"},
@@ -92,10 +95,27 @@ expected<actor> spawn_exporter(local_actor* self, options& opts) {
     anon_send(exp, extract_atom::value, limit);
   else
     anon_send(exp, extract_atom::value);
+  // Send the running IMPORTERs to the EXPORTER if it handles a continous query.
+  if (has_continuous_option(query_opts)) {
+    self->request(self->state.tracker, infinite, get_atom::value).then(
+      [=](registry& reg) mutable {
+        VAST_DEBUG(self, "looks for importers");
+        auto& local = reg.components[self->state.name];
+        const std::string wanted = "importer";
+        std::vector<actor> importers;
+        for (auto& comp : local)
+          if (std::equal(wanted.begin(), wanted.end(), comp.first.begin()))
+            importers.push_back(comp.second.actor);
+        if (!importers.empty())
+          self->send(exp, importer_atom::value, std::move(importers));
+      }
+    );
+  }
   return exp;
 }
 
-expected<actor> spawn_importer(local_actor* self, options& opts) {
+expected<actor> spawn_importer(stateful_actor<node_state>* self,
+                               options& opts) {
   auto ids = size_t{128};
   auto r = opts.params.extract_opts({
     {"ids,n", "number of initial IDs to request", ids},
@@ -103,6 +123,7 @@ expected<actor> spawn_importer(local_actor* self, options& opts) {
   opts.params = r.remainder;
   if (!r.error.empty())
     return make_error(ec::syntax_error, r.error);
+  // FIXME: Notify exporters with a continuous query.
   return self->spawn(importer, opts.dir / opts.label, ids);
 }
 

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -16,9 +16,10 @@
 #include "vast/query_options.hpp"
 
 #include "vast/system/archive.hpp"
-#include "vast/system/archive.hpp"
 #include "vast/system/exporter.hpp"
+#include "vast/system/importer.hpp"
 #include "vast/system/index.hpp"
+#include "vast/system/replicated_store.hpp"
 
 #define SUITE export
 #include "test.hpp"
@@ -30,7 +31,7 @@ using namespace std::chrono;
 
 FIXTURE_SCOPE(exporter_tests, fixtures::actor_system_and_events)
 
-TEST(exporter) {
+TEST(exporter historical) {
   auto i = self->spawn(system::index, directory / "index", 1000, 5, 5);
   auto a = self->spawn(system::archive, directory / "archive", 1, 1024);
   MESSAGE("ingesting conn.log");
@@ -38,7 +39,7 @@ TEST(exporter) {
   self->send(a, bro_conn_log);
   auto expr = to<expression>("service == \"http\" && :addr == 212.227.96.110");
   REQUIRE(expr);
-  MESSAGE("issueing query");
+  MESSAGE("issueing historical query");
   auto e = self->spawn(system::exporter, *expr, historical);
   self->send(e, a);
   self->send(e, system::index_atom::value, i);
@@ -59,6 +60,132 @@ TEST(exporter) {
   CHECK_EQUAL(results.back().id(), 8354u);
   self->send_exit(i, exit_reason::user_shutdown);
   self->send_exit(a, exit_reason::user_shutdown);
+}
+
+TEST(exporter continuous -- exporter only) {
+  auto i = self->spawn(system::index, directory / "index", 1000, 5, 5);
+  auto a = self->spawn(system::archive, directory / "archive", 1, 1024);
+  auto expr = to<expression>("service == \"http\" && :addr == 212.227.96.110");
+  REQUIRE(expr);
+  MESSAGE("issueing continuous query");
+  auto e = self->spawn(system::exporter, *expr, continuous);
+  self->send(e, a);
+  self->send(e, system::index_atom::value, i);
+  self->send(e, system::sink_atom::value, self);
+  self->send(e, system::run_atom::value);
+  self->send(e, system::extract_atom::value);
+  MESSAGE("ingesting conn.log");
+  self->send(e, bro_conn_log);
+  MESSAGE("waiting for results");
+  std::vector<event> results;
+  self->do_receive(
+    [&](std::vector<event>& xs) {
+      std::move(xs.begin(), xs.end(), std::back_inserter(results));
+    },
+    error_handler()
+  ).until([&] { return results.size() == 28; });
+  MESSAGE("sanity checking result correctness");
+  CHECK_EQUAL(results.front().id(), 105u);
+  CHECK_EQUAL(results.front().type().name(), "bro::conn");
+  CHECK_EQUAL(results.back().id(), 8354u);
+  self->send_exit(i, exit_reason::user_shutdown);
+  self->send_exit(a, exit_reason::user_shutdown);
+}
+
+TEST(exporter continuous -- with importer) {
+  using namespace system;
+  auto ind = self->spawn(system::index, directory / "index", 1000, 5, 5);
+  auto arc = self->spawn(archive, directory / "archive", 1, 1024);
+  auto imp = self->spawn(importer, directory / "importer", 128);
+  auto con = self->spawn(raft::consensus, directory / "consensus");
+  self->send(con, run_atom::value);
+  meta_store_type ms = self->spawn(replicated_store<std::string, data>, con);
+  auto expr = to<expression>("service == \"http\" && :addr == 212.227.96.110");
+  REQUIRE(expr);
+  MESSAGE("issueing continuous query");
+  auto exp = self->spawn(exporter, *expr, continuous);
+  self->send(exp, arc);
+  self->send(exp, index_atom::value, ind);
+  self->send(exp, sink_atom::value, self);
+  self->send(exp, run_atom::value);
+  self->send(exp, extract_atom::value);
+  self->send(imp, arc);
+  self->send(imp, index_atom::value, ind);
+  self->send(imp, ms);
+  self->send(imp, exporter_atom::value, exp);
+  MESSAGE("ingesting conn.log");
+  self->send(imp, bro_conn_log);
+  MESSAGE("waiting for results");
+  std::vector<event> results;
+  self->do_receive(
+    [&](std::vector<event>& xs) {
+      std::move(xs.begin(), xs.end(), std::back_inserter(results));
+    },
+    error_handler()
+  ).until([&] { return results.size() == 28; });
+  MESSAGE("sanity checking result correctness");
+  CHECK_EQUAL(results.front().id(), 105u);
+  CHECK_EQUAL(results.front().type().name(), "bro::conn");
+  CHECK_EQUAL(results.back().id(), 8354u);
+  self->send_exit(ind, exit_reason::user_shutdown);
+  self->send_exit(arc, exit_reason::user_shutdown);
+  self->send_exit(imp, exit_reason::user_shutdown);
+  self->send_exit(con, exit_reason::user_shutdown);
+}
+
+TEST(exporter universal) {
+  using namespace system;
+  auto ind = self->spawn(system::index, directory / "index", 1000, 5, 5);
+  auto arc = self->spawn(archive, directory / "archive", 1, 1024);
+  auto imp = self->spawn(importer, directory / "importer", 128);
+  auto con = self->spawn(raft::consensus, directory / "consensus");
+  self->send(con, run_atom::value);
+  meta_store_type ms = self->spawn(replicated_store<std::string, data>, con);
+  auto expr = to<expression>("service == \"http\" && :addr == 212.227.96.110");
+  REQUIRE(expr);
+  self->send(imp, arc);
+  self->send(imp, index_atom::value, ind);
+  self->send(imp, ms);
+  MESSAGE("ingesting conn.log for historical query part");
+  self->send(ind, bro_conn_log);
+  self->send(arc, bro_conn_log);
+  MESSAGE("issueing universal query");
+  auto exp = self->spawn(exporter, *expr, continuous + historical);
+  self->send(exp, arc);
+  self->send(exp, index_atom::value, ind);
+  self->send(exp, sink_atom::value, self);
+  self->send(exp, run_atom::value);
+  self->send(exp, extract_atom::value);
+  self->send(imp, exporter_atom::value, exp);
+  MESSAGE("waiting for results");
+  std::vector<event> results;
+  self->do_receive(
+    [&](std::vector<event>& xs) {
+      std::move(xs.begin(), xs.end(), std::back_inserter(results));
+    },
+    error_handler()
+  ).until([&] { return results.size() == 28; });
+  MESSAGE("sanity checking result correctness");
+  CHECK_EQUAL(results.front().id(), 105u);
+  CHECK_EQUAL(results.front().type().name(), "bro::conn");
+  CHECK_EQUAL(results.back().id(), 8354u);
+  results.clear();
+  MESSAGE("ingesting conn.log for continuous query part");
+  self->send(imp, bro_conn_log);
+  self->do_receive(
+    [&](std::vector<event>& xs) {
+      std::move(xs.begin(), xs.end(), std::back_inserter(results));
+    },
+    error_handler()
+  ).until([&] { return results.size() == 28; });
+  MESSAGE("sanity checking result correctness");
+  CHECK_EQUAL(results.front().id(), 105u);
+  CHECK_EQUAL(results.front().type().name(), "bro::conn");
+  CHECK_EQUAL(results.back().id(), 8354u);
+  self->send_exit(ind, exit_reason::user_shutdown);
+  self->send_exit(arc, exit_reason::user_shutdown);
+  self->send_exit(imp, exit_reason::user_shutdown);
+  self->send_exit(con, exit_reason::user_shutdown);
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/vast/system/atoms.hpp
+++ b/libvast/vast/system/atoms.hpp
@@ -99,6 +99,8 @@ using subscriber_atom = caf::atom_constant<caf::atom("subscriber")>;
 using supervisor_atom = caf::atom_constant<caf::atom("supervisor")>;
 using search_atom = caf::atom_constant<caf::atom("search")>;
 using tracker_atom = caf::atom_constant<caf::atom("tracker")>;
+using exporter_atom = caf::atom_constant<caf::atom("exporter")>;
+using importer_atom = caf::atom_constant<caf::atom("importer")>;
 
 } // namespace vast::system
 

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -43,6 +43,7 @@ struct exporter_state {
   std::vector<event> results;
   std::chrono::steady_clock::time_point start;
   query_statistics stats;
+  query_options opts;
   uuid id;
   static inline const char* name = "exporter";
 };

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -40,6 +40,7 @@ struct importer_state {
   size_t batch_size;
   std::chrono::steady_clock::time_point last_replenish;
   std::vector<event> remainder;
+  std::vector<caf::actor> continuous_queries;
   path dir;
   static inline const char* name = "importer";
 };

--- a/libvast/vast/system/node.hpp
+++ b/libvast/vast/system/node.hpp
@@ -18,17 +18,9 @@
 
 #include "vast/filesystem.hpp"
 
-#include "vast/system/tracker.hpp"
+#include "vast/system/node_state.hpp"
 
 namespace vast::system {
-
-/// A container for VAST components.
-struct node_state {
-  path dir;
-  tracker_type tracker;
-  std::unordered_map<std::string, int> labels;
-  std::string name;
-};
 
 /// Spawns a node.
 /// @param self The actor handle

--- a/libvast/vast/system/node_state.hpp
+++ b/libvast/vast/system/node_state.hpp
@@ -1,0 +1,23 @@
+#ifndef VAST_SYSTEM_NODE_STATE_HPP
+#define VAST_SYSTEM_NODE_STATE_HPP
+
+#include "vast/expression.hpp"
+#include "vast/filesystem.hpp"
+
+#include "vast/system/tracker.hpp"
+
+namespace vast {
+namespace system {
+
+/// A container for VAST components.
+struct node_state {
+  path dir;
+  tracker_type tracker;
+  std::unordered_map<std::string, int> labels;
+  std::string name = "node";
+};
+
+} // namespace system
+} // namespace vast
+
+#endif

--- a/libvast/vast/system/spawn.hpp
+++ b/libvast/vast/system/spawn.hpp
@@ -21,6 +21,8 @@
 #include "vast/expected.hpp"
 #include "vast/filesystem.hpp"
 
+#include "vast/system/node_state.hpp"
+
 namespace vast::system {
 
 struct options {
@@ -29,19 +31,20 @@ struct options {
   std::string label;
 };
 
-expected<caf::actor> spawn_archive(caf::local_actor* self, options& opts);
+expected<caf::actor> spawn_archive(caf::local_actor* self,
+                                   options& opts);
 
-expected<caf::actor> spawn_exporter(caf::local_actor* self, options& opts);
+expected<caf::actor> spawn_exporter(caf::stateful_actor<node_state>* self,
+                                    options& opts);
 
-expected<caf::actor> spawn_importer(caf::local_actor* self, options& opts);
+expected<caf::actor> spawn_importer(caf::stateful_actor<node_state>* self,
+                                    options& opts);
 
 expected<caf::actor> spawn_index(caf::local_actor* self, options& opts);
 
 expected<caf::actor> spawn_metastore(caf::local_actor* self, options& opts);
 
 expected<caf::actor> spawn_profiler(caf::local_actor* self, options& opts);
-
-expected<caf::actor> spawn_source(caf::local_actor* self, options& opts);
 
 expected<caf::actor> spawn_source(caf::local_actor* self, options& opts);
 


### PR DESCRIPTION
This PR addresses #131. The idea is to let the NODE identify when it spawns an exporter with a continuous query. It then sends the actor handle to each running IMPORTER, which monitors the actor and forwards it the same data it forwards to the ARCHIVE and INDEX.

There are some unresolved issues for now, which can be discussed in this thread.

- [x] Enable continuous queries
- [x] Don't interfere with historic queries
- [x] Enable universal queries
- [x] Provide tests
- [ ] Enable NODEs to pass cont. queries to newly spawn IMPORTERs

I'd argue that continuous queries already work. I am not sure about the interference with historic queries, though.

I didn't get the test for universal queries to work as I wanted to. I tried to recreate a VAST node with an IMPORTER, ARCHIVE and INDEX. However, sending data to the IMPORTER doesn't seem to index everything ... That's why I opted for sending the data to the ARCHIVE and INDEX directly. Looks a bit dodgy to me. I can't tell if this is a problem with my changes to the IMPORTER or the test itself.