### PR TITLE
Integrate VAST and Apache Arrow

### DIFF
--- a/aux/README.md
+++ b/aux/README.md
@@ -7,9 +7,9 @@ This directory contains the third-party software VAST uses. We manage it via
 Repositories
 ------------
 
-- **date**: `git@github.com:HowardHinnant/date.git`
-- **lz4**: `git@github.com:lz4/lz4.git`
-- **xxHash**: `git@github.com:Cyan4973/xxHash.git`
+- [date](https:/github.com/HowardHinnant/date): git@github.com:HowardHinnant/date.git
+- [lz4](https:/github.com/lz4/lz4): git@github.com:lz4/lz4.git
+- [xxHash](https:/github.com/Cyan4973/xxHash): git@github.com:Cyan4973/xxHash.git
 
 Adding a New Repository
 -----------------------


### PR DESCRIPTION
This PR bundles the effort of integrating [Apache Arrow](https://arrow.apache.org) with VAST. The corresponding integration branch is `topic/arrow`.

### Converting VAST Events into Arrow

- [x] Find Arrow and Plasma via CMake
- [ ] Write an Arrow format that implements the writer concept
  - [x] Create a writer scaffold
  - [ ] Convert events
    - [ ] Convert the event types from a `vector<event>` into an Arrow schema
    - [ ] Transpose `vector<event>` into an `arrow::RecordBatch`

### Storing Arrow Data in Plasma

After the events have been transposed into record batches, we store them in Plasma to make them available for other tools.

- [ ] Store record batches in Plasma
  - [ ] Connect to a running Plasma store
  - [ ] Copy batches into a Plasma buffer and display object ID on standard output

Displaying object IDs on standard output should be fine for the prototype, but we need a more convenient solution in the future that allows other programs to obtain the object IDs. 

### Write Python PoC Example

- [ ] Write proof-of-concept Python script that takes events via Plasma