### PR TITLE
Support Apache Arrow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,20 @@ if (CAF_LIBRARY_OPENSSL)
 endif ()
 set(CAF_FOUND ${CAF_FOUND_SAVE})
 
+if (NOT ARROW_ROOT_DIR AND VAST_PREFIX)
+  set(ARROW_ROOT_DIR ${VAST_PREFIX})
+endif ()
+find_package(ARROW COMPONENTS core plasma QUIET)
+if (ARROW_CORE_FOUND)
+  message(STATUS "Found Apache Arrow (core library)")
+endif ()
+if (ARROW_PLASMA_FOUND)
+  message(STATUS "Found Apache Arrow (Plasma store)")
+endif ()
+if (ARROW_CORE_FOUND AND ARROW_PLASMA_FOUND)
+  set(VAST_HAVE_ARROW true)
+endif ()
+
 if (BROKER_ROOT_DIR)
   find_package(BROKER REQUIRED)
   set(VAST_HAVE_BROKER true)
@@ -578,6 +592,7 @@ endif ()
 
 display(CAF_FOUND ${caf_dir} caf_summary)
 display(BROKER_FOUND "${broker_dir}" broker_summary)
+display(VAST_HAVE_ARROW "${ARROW_CORE_INCLUDE_DIR}" arrow_summary)
 display(SNAPPY_FOUND "${SNAPPY_INCLUDE_DIR}" snappy_summary)
 display(PCAP_FOUND "${PCAP_INCLUDE_DIR}" pcap_summary)
 display(GPERFTOOLS_FOUND "${GPERFTOOLS_INCLUDE_DIR}" perftools_summary)
@@ -615,6 +630,7 @@ set(summary
     "\nLDFLAGS:             ${LDFLAGS}"
     "\n"
     "\nCAF:                 ${caf_summary}"
+    "\nArrow:               ${arrow_summary}"
     "\nBroker:              ${broker_summary}"
     "\nSnappy               ${snappy_summary}"
     "\nPCAP:                ${pcap_summary}"

--- a/cmake/FindArrow.cmake
+++ b/cmake/FindArrow.cmake
@@ -1,0 +1,103 @@
+# Tries to find Apache Arrow.
+#
+# Usage:
+#
+#     find_package(ARROW)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  ARROW_ROOT_DIR  Set this variable to the root installation of
+#                  Arrow if the module has problems finding
+#                  the proper installation path. If Arrow wasn't install
+#                  system-wide, set this variable to the local build dir.
+#
+# Variables defined by this module:
+#
+#  ARROW_CORE_FOUND         System has (at least) Arrow C++ libs/headers
+#  ARROW_CORE_LIBRARIES     The Arrow C++ libraries
+#  ARROW_CORE_INCLUDE_DIR   The location of Arrow C++ headers
+#  ARROW_PLASMA_FOUND       System has Plasma libs/headers
+#  ARROW_PLASMA_LIBRARIES   The Plasma libraries
+#  ARROW_PLASMA_INCLUDE_DIR The location of Plasma headers
+#  ARROW_PLASMA_EXECUTABLE  The Plasma store executable
+
+foreach (comp ${ARROW_FIND_COMPONENTS})
+  string(TOUPPER "${comp}" UPPERCOMP)
+  # Arrow puts all build files in a directory named as the build type.
+  set(library_hints_for_build_directory
+    ${ARROW_ROOT_DIR}/debug
+    ${ARROW_ROOT_DIR}/release
+    ${ARROW_ROOT_DIR}/relwithdebinfo
+    ${ARROW_ROOT_DIR}/minsizerel)
+  set(header_hints_for_build_directory
+    ${ARROW_ROOT_DIR}/../src)
+  if ("${comp}" STREQUAL "core")
+    find_library(ARROW_CORE_LIBRARIES
+      NAMES arrow
+      HINTS
+        ${ARROW_ROOT_DIR}/lib
+        ${library_hints_for_build_directory})
+    find_path(ARROW_CORE_INCLUDE_DIR
+      NAMES arrow/api.h
+      HINTS
+        ${ARROW_ROOT_DIR}/include
+        ${header_hints_for_build_directory})
+    if (ARROW_CORE_LIBRARIES AND ARROW_CORE_INCLUDE_DIR)
+      set(ARROW_CORE_FOUND true)
+    endif ()
+  elseif ("${comp}" STREQUAL "plasma")
+    find_library(ARROW_PLASMA_LIBRARIES
+      NAMES plasma
+      HINTS
+        ${ARROW_ROOT_DIR}
+        ${ARROW_ROOT_DIR}/lib
+        ${library_hints_for_build_directory})
+    find_path(ARROW_PLASMA_INCLUDE_DIR
+      NAMES plasma/client.h
+      HINTS
+        ${ARROW_ROOT_DIR}/include
+        ${header_hints_for_build_directory})
+    find_program(ARROW_PLASMA_EXECUTABLE
+      plasma_store_server
+      HINTS
+        ${ARROW_ROOT_DIR}/bin
+        ${library_hints_for_build_directory})
+    if (ARROW_PLASMA_LIBRARIES AND ARROW_PLASMA_INCLUDE_DIR AND
+        ARROW_PLASMA_EXECUTABLE)
+      set(ARROW_PLASMA_FOUND true)
+    endif ()
+  else ()
+    MESSAGE(FATAL_ERROR "invalid component: ${comp}")
+  endif ()
+endforeach ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  ARROW
+  REQUIRED_VARS ARROW_CORE_FOUND
+  HANDLE_COMPONENTS)
+
+mark_as_advanced(
+  ARROW_ROOT_DIR
+  ARROW_CORE_LIBRARIES
+  ARROW_CORE_INCLUDE_DIR
+  ARROW_PLASMA_LIBRARIES
+  ARROW_PLASMA_INCLUDE_DIR
+  ARROW_PLASMA_EXECUTABLE)
+
+# create IMPORTED target
+if (ARROW_CORE_FOUND AND NOT TARGET arrow::core)
+  add_library(arrow::core UNKNOWN IMPORTED)
+  set_target_properties(arrow::core PROPERTIES
+    IMPORTED_LOCATION ${ARROW_CORE_LIBRARIES})
+  set_target_properties(arrow::core PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${ARROW_CORE_INCLUDE_DIR}")
+endif()
+if (ARROW_PLASMA_FOUND AND NOT TARGET arrow::plasma)
+  add_library(arrow::plasma UNKNOWN IMPORTED)
+  set_target_properties(arrow::plasma PROPERTIES
+    IMPORTED_LOCATION ${ARROW_PLASMA_LIBRARIES})
+  set_target_properties(arrow::plasma PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${ARROW_PLASMA_INCLUDE_DIR}")
+endif()

--- a/configure
+++ b/configure
@@ -47,6 +47,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --with-caf=PATH         path to CAF install root or build directory
 
   Optional packages in non-standard locations:
+    --with-arrow=PATH       path to Arrow install root or build directory
     --with-broker=PATH      path to Broker install root
     --with-snappy=PATH      path to Snappy install root
     --with-pcap=PATH        path to libpcap install root
@@ -149,6 +150,9 @@ while [ $# -ne 0 ]; do
       ;;
     --with-caf=*)
       append_cache_entry CAF_ROOT_DIR PATH "$optarg"
+      ;;
+    --with-arrow=*)
+      append_cache_entry ARROW_ROOT_DIR PATH "$optarg"
       ;;
     --with-broker=*)
       append_cache_entry BROKER_ROOT_DIR PATH "$optarg"

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -125,6 +125,12 @@ set(libvast_sources
   src/wah_bitmap.cpp
 )
 
+if (VAST_HAVE_ARROW)
+  set(libvast_sources ${libvast_sources}
+      src/format/arrow.cpp
+  )
+endif ()
+
 if (PCAP_FOUND)
   set(libvast_sources ${libvast_sources}
     src/system/pcap_reader_command.cpp
@@ -155,6 +161,14 @@ endif ()
 if (VAST_ENABLE_ASSERTIONS)
   target_include_directories(libvast PUBLIC ${Backtrace_INCLUDE_DIRECTORIES})
   target_link_libraries(libvast PUBLIC ${Backtrace_LIBRARIES})
+endif ()
+
+if (ARROW_CORE_FOUND)
+  target_link_libraries(libvast PUBLIC arrow::core)
+endif ()
+
+if (ARROW_PLASMA_FOUND)
+  target_link_libraries(libvast PUBLIC arrow::plasma)
 endif ()
 
 if (SNAPPY_FOUND)
@@ -277,7 +291,11 @@ set(tests
   test/word.cpp
 )
 
-if (PCAP_FOUND)
+if (VAST_HAVE_ARROW)
+  set(tests ${tests} test/format/arrow.cpp)
+endif ()
+
+if (VAST_HAVE_PCAP)
   set(tests ${tests} test/format/pcap.cpp)
 endif ()
 

--- a/libvast/src/format/arrow.cpp
+++ b/libvast/src/format/arrow.cpp
@@ -13,31 +13,84 @@
 
 #include "vast/format/arrow.hpp"
 
-#include <arrow/buffer.h>
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <arrow/ipc/api.h>
 #include <plasma/common.h>
+
 
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/event.hpp"
 #include "vast/concept/printable/vast/uuid.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/overload.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/span.hpp"
+#include "vast/view.hpp"
 
 namespace vast::format::arrow {
 
 namespace {
 
+// TODO: implement this function.
+std::shared_ptr<::arrow::DataType> make_data_type(const type& t) {
+  auto factory = detail::overload(
+    [&](const boolean_type&) {
+      return ::arrow::boolean();
+    },
+    [&](const auto&) -> std::shared_ptr<::arrow::DataType> {
+      return nullptr;
+    }
+  );
+  return caf::visit(factory, t);
+}
+
+std::shared_ptr<::arrow::Field> make_field(const record_field& field) {
+  return ::arrow::field(field.name, make_data_type(field.type));
+}
+
+std::shared_ptr<::arrow::Schema> make_schema(const record_type& layout) {
+  std::vector<std::shared_ptr<::arrow::Field>> fields;
+  fields.reserve(layout.fields.size());
+  for (auto& field : layout.fields)
+    fields.push_back(make_field(field));
+  return ::arrow::schema(std::move(fields));
+}
+
+caf::error append(const type& t, data_view v, ::arrow::ArrayBuilder* builder) {
+  auto f = detail::overload(
+    [&](const boolean_type&) -> caf::error {
+      auto ptr = static_cast<::arrow::BooleanBuilder*>(builder);
+      auto status = caf::visit(detail::overload(
+        [&](caf::none_t) { return ptr->AppendNull(); },
+        [&](boolean x) { return ptr->Append(x); },
+        [&](auto&&) { return ::arrow::Status::UnknownError("invalid data"); }
+      ), v);
+      if (!status.ok())
+        return make_error(ec::format_error, status.ToString());
+      return caf::none;
+    },
+    // TODO: implement overloads for all types. Ideally this should happen not
+    // by duplication of the above lambda, but instead via a single lambda that
+    // takes a meta function to find the corresponding builder type for a given
+    // VAST type.
+    [](const auto&) {
+      return make_error(ec::format_error, "not yet implemented");
+    }
+  );
+  return caf::visit(f, t);
+}
+
 plasma::ObjectID make_random_object_id() {
-  // FIXME: properly generate a random number; eventually one for a record
-  // batch.
+  // TODO: properly generate a sequence of random 20 bytes
   auto random_uuid = to_string(uuid::random());
   random_uuid.resize(plasma::kUniqueIDSize);
   return plasma::ObjectID::from_binary(random_uuid);
 }
 
-caf::error create_object(plasma::PlasmaClient& client, const plasma::ObjectID oid,
-                         span<const byte> bytes) {
+caf::error make_object(plasma::PlasmaClient& client, const plasma::ObjectID oid,
+                       span<const byte> bytes) {
   auto size = static_cast<int64_t>(bytes.size());
   std::shared_ptr<::arrow::Buffer> buffer;
   auto status = client.Create(oid, size, nullptr, 0, &buffer);
@@ -74,21 +127,74 @@ writer::~writer() {
     VAST_ERROR(name(), "failed to disconnect from plasma store");
 }
 
-caf::expected<void> writer::write(event const& x) {
-  if (!connected())
-    return make_error(ec::format_error, "not connected to plasma store");
-  // FIXME: For testing purposes, we store the string representation of each
-  // event as separate object.
-  auto str = to_string(x);
-  auto oid = make_random_object_id();
-  if (auto err = create_object(plasma_client_, oid, make_const_byte_span(str)))
-    return err;
-  std::cout << oid.hex() << std::endl; // FIXME: print as JSON
+caf::expected<void> writer::write(const event& x) {
+  auto& layout = caf::get<record_type>(x.type());
+  auto i = builders_.find(layout);
+  if (i == builders_.end()) {
+    std::vector<std::unique_ptr<::arrow::ArrayBuilder>> builders;
+    // TODO: construct builders
+    i = builders_.emplace(layout, std::move(builders)).first;
+  }
+  auto& builders = i->second;
+  VAST_ASSERT(layout.fields.size() == builders.size());
+  for (size_t i = 0; i < builders.size(); ++i) {
+    auto& field_type = layout.fields[i].type;
+    auto builder = builders[i].get();
+    if (auto error = append(field_type, make_view(x.data()), builder))
+      return error;
+  }
   return caf::no_error;
 }
 
+std::shared_ptr<::arrow::Buffer> make_buffer(const ::arrow::RecordBatch& xs) {
+  CAF_IGNORE_UNUSED(xs);
+  std::shared_ptr<::arrow::Buffer> result;
+  //auto result = std::make_shared<arrow::PoolBuffer>(pool);
+  //auto sink = std::make_unique<arrow::io::BufferOutputStream>(result);
+  //std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
+  //auto status = arrow::ipc::RecordBatchStreamWriter::Open(
+  //  sink.get(), batch.schema(), &writer);
+  //if (!status.ok())
+  //  return make_error(ec::format_error, "failed to open arrow stream writer",
+  //                    status.ToString());
+  //status = writer->WriteRecordBatch(batch);
+  //if (!status.ok())
+  //  return make_error(ec::format_error, "failed to write batch",
+  //                    status.ToString());
+  //status = writer->Close();
+  //if (!status.ok())
+  //  return make_error(ec::format_error, "failed to close arrow stream writer",
+  //                    status.ToString());
+  //status = sink->Close();
+  //if (!status.ok())
+  //  return make_error(ec::format_error, "failed to close arrow stream writer",
+  //                    status.ToString());
+  return result;
+};
+
 caf::expected<void> writer::flush() {
-  // TODO: flush builders into record batch and ship to plasma
+  if (!connected())
+    return make_error(ec::format_error, "not connected to plasma store");
+  // Go through all builders and create record batches.
+  for (auto& kvp : builders_) {
+    auto& [layout, builders] = kvp;
+    // FIXME: Construct a record batch from the current state of builders.
+    auto schema = make_schema(layout);
+    std::vector<std::shared_ptr<::arrow::Array>> columns;
+    auto num_rows = 0; // FIXME
+    auto record_batch = ::arrow::RecordBatch::Make(schema, num_rows,
+                                                   std::move(columns));
+    VAST_ASSERT(record_batch != nullptr);
+    // Create buffer from record batch.
+    auto buffer = make_buffer(*record_batch);
+    auto bytes = make_const_byte_span(buffer->data(), buffer->size());
+    // Create Plasma Object ID.
+    auto oid = make_random_object_id();
+    if (auto err = make_object(plasma_client_, oid, bytes))
+      return err;
+    // TODO: print object ID as JSON
+    std::cout << oid.hex() << std::endl;
+  }
   return caf::no_error;
 }
 

--- a/libvast/src/format/arrow.cpp
+++ b/libvast/src/format/arrow.cpp
@@ -13,19 +13,57 @@
 
 #include "vast/format/arrow.hpp"
 
+#include <arrow/buffer.h>
+#include <plasma/common.h>
+
+#include "vast/concept/printable/to_string.hpp"
+#include "vast/concept/printable/vast/event.hpp"
+#include "vast/concept/printable/vast/uuid.hpp"
+#include "vast/detail/assert.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
+#include "vast/span.hpp"
 
 namespace vast::format::arrow {
 
+namespace {
+
+plasma::ObjectID make_random_object_id() {
+  // FIXME: properly generate a random number; eventually one for a record
+  // batch.
+  auto random_uuid = to_string(uuid::random());
+  random_uuid.resize(plasma::kUniqueIDSize);
+  return plasma::ObjectID::from_binary(random_uuid);
+}
+
+caf::error create_object(plasma::PlasmaClient& client, const plasma::ObjectID oid,
+                         span<const byte> bytes) {
+  auto size = static_cast<int64_t>(bytes.size());
+  std::shared_ptr<::arrow::Buffer> buffer;
+  auto status = client.Create(oid, size, nullptr, 0, &buffer);
+  if (!status.ok())
+    return make_error(ec::format_error, "failed to create plasma object",
+                      status.ToString());
+  VAST_ASSERT(buffer != nullptr);
+  VAST_ASSERT(buffer->size() == bytes.size());
+  std::memcpy(buffer->mutable_data(), bytes.data(), bytes.size());
+  status = client.Seal(oid);
+  if (!status.ok())
+    return make_error(ec::format_error, "failed to seal plasma object",
+                      status.ToString());
+  return caf::none;
+}
+
+} // namespace <anonymous>
+
 writer::writer(std::string plasma_socket)
   : plasma_socket_{std::move(plasma_socket)} {
-  VAST_DEBUG(name(), "connects to plasma store at", plasma_socket);
+  VAST_DEBUG(name(), "connects to plasma store at", plasma_socket_);
   constexpr int num_retries = 100;
-  auto status = plasma_client_.Connect(plasma_socket, "", 0, num_retries);
+  auto status = plasma_client_.Connect(plasma_socket_, "", 0, num_retries);
   connected_ = status.ok();
-  if (!connected_)
-    VAST_ERROR(name(), "failed to connect to plasma store");
+  if (!connected())
+    VAST_ERROR(name(), "failed to connect to plasma store", status.ToString());
 }
 
 writer::~writer() {
@@ -36,10 +74,16 @@ writer::~writer() {
     VAST_ERROR(name(), "failed to disconnect from plasma store");
 }
 
-caf::expected<void> writer::write(event const& /* e */) {
+caf::expected<void> writer::write(event const& x) {
   if (!connected())
     return make_error(ec::format_error, "not connected to plasma store");
-  // TODO: write event into record batch builders.
+  // FIXME: For testing purposes, we store the string representation of each
+  // event as separate object.
+  auto str = to_string(x);
+  auto oid = make_random_object_id();
+  if (auto err = create_object(plasma_client_, oid, make_const_byte_span(str)))
+    return err;
+  std::cout << oid.hex() << std::endl; // FIXME: print as JSON
   return caf::no_error;
 }
 

--- a/libvast/src/format/arrow.cpp
+++ b/libvast/src/format/arrow.cpp
@@ -1,0 +1,59 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/format/arrow.hpp"
+
+#include "vast/error.hpp"
+#include "vast/logger.hpp"
+
+namespace vast::format::arrow {
+
+writer::writer(std::string plasma_socket)
+  : plasma_socket_{std::move(plasma_socket)} {
+  VAST_DEBUG(name(), "connects to plasma store at", plasma_socket);
+  constexpr int num_retries = 100;
+  auto status = plasma_client_.Connect(plasma_socket, "", 0, num_retries);
+  connected_ = status.ok();
+  if (!connected_)
+    VAST_ERROR(name(), "failed to connect to plasma store");
+}
+
+writer::~writer() {
+  if (!connected())
+    return;
+  auto status = plasma_client_.Disconnect();
+  if (!status.ok())
+    VAST_ERROR(name(), "failed to disconnect from plasma store");
+}
+
+caf::expected<void> writer::write(event const& /* e */) {
+  if (!connected())
+    return make_error(ec::format_error, "not connected to plasma store");
+  // TODO: write event into record batch builders.
+  return caf::no_error;
+}
+
+caf::expected<void> writer::flush() {
+  // TODO: flush builders into record batch and ship to plasma
+  return caf::no_error;
+}
+
+const char* writer::name() const {
+  return "arrow-writer";
+}
+
+bool writer::connected() const {
+  return connected_;
+}
+
+} // namespace vast::format::arrow

--- a/libvast/test/format/arrow.cpp
+++ b/libvast/test/format/arrow.cpp
@@ -1,0 +1,25 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#define SUITE format
+
+#include "vast/format/arrow.hpp"
+
+#include "vast/test/test.hpp"
+
+using namespace vast;
+
+TEST(arrow writer) {
+  format::arrow::writer writer{"/tmp/plasma"};
+  CHECK(!writer.connected());
+}

--- a/libvast/test/format/arrow.cpp
+++ b/libvast/test/format/arrow.cpp
@@ -16,10 +16,36 @@
 #include "vast/format/arrow.hpp"
 
 #include "vast/test/test.hpp"
+#include "vast/test/fixtures/events.hpp"
+
+//#include <plasma/store.h>
 
 using namespace vast;
 
+struct fixture : fixtures::events {
+  fixture() {
+// FIXME: Cannot use a plasma store fixture because the <plasma/store.h>
+// transitively includes flatbuffers, which we don't have necessarily .
+//    rm(directory);
+//    constexpr int64_t system_memory = 1'000'000;
+//    constexpr bool hugetlbfs_enabled = false;
+//    plasma_store = std::make_unique<plasma::PlasmaStore>(nullptr,
+//                                                         system_memory,
+//                                                         directory,
+//                                                         hugetlbfs_enabled);
+  }
+
+  std::string directory = "/tmp/plasma";
+////  std::unique_ptr<plasma::PlasmaStore> plasma_store;
+};
+
+FIXTURE_SCOPE(plasma_tests, fixture)
+
 TEST(arrow writer) {
-  format::arrow::writer writer{"/tmp/plasma"};
-  CHECK(!writer.connected());
+  format::arrow::writer writer{directory};
+  REQUIRE(writer.connected());
+  for (auto& x : bro_conn_log)
+    CHECK(writer.write(x));
 }
+
+FIXTURE_SCOPE_END()

--- a/libvast/vast/format/arrow.hpp
+++ b/libvast/vast/format/arrow.hpp
@@ -1,0 +1,52 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include <plasma/client.h>
+
+#include "vast/format/writer.hpp"
+
+namespace vast::format::arrow {
+
+/// Converts events into Arrow Record batches and writes them into a Plasma
+/// store.
+class writer : format::writer {
+public:
+  writer() = default;
+
+  /// Constructs an Arrow writer that connects to a (local) plasma store.
+  /// @param plasma_socket The path to the local Plasma listening socket.
+  explicit writer(std::string plasma_socket);
+
+  ~writer();
+
+  caf::expected<void> write(const event& e) override;
+
+  caf::expected<void> flush() override;
+
+  const char* name() const override;
+
+  /// Checks whether the writer is connected to the Plasma store.
+  /// @returns `true` if the connection to the Plasma store is alive.
+  bool connected() const;
+
+private:
+  plasma::PlasmaClient plasma_client_;
+  std::string plasma_socket_;
+  bool connected_ = false;
+};
+
+} // namespace vast::format::arrow

--- a/libvast/vast/format/arrow.hpp
+++ b/libvast/vast/format/arrow.hpp
@@ -13,11 +13,16 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
+#include <arrow/array/builder_base.h>
 #include <plasma/client.h>
 
 #include "vast/format/writer.hpp"
+#include "vast/type.hpp"
 
 namespace vast::format::arrow {
 
@@ -44,9 +49,12 @@ public:
   bool connected() const;
 
 private:
+  using array_builder_ptr = std::unique_ptr<::arrow::ArrayBuilder>;
+
   plasma::PlasmaClient plasma_client_;
   std::string plasma_socket_;
   bool connected_ = false;
+  std::unordered_map<record_type, std::vector<array_builder_ptr>> builders_;
 };
 
 } // namespace vast::format::arrow


### PR DESCRIPTION
This PR bundles the effort of integrating [Apache Arrow](https://arrow.apache.org) with VAST. The corresponding integration branch is `topic/arrow`.

### Converting VAST Events into Arrow

- [x] Find Arrow and Plasma via CMake
- [x] Create a writer scaffold
- [ ] Convert events

### Storing Arrow Data in Plasma

After the results have been converted into record batches, we store them in Plasma to make them available for other tools.

- [x] Store record batches in Plasma
  - [x] Connect to a running Plasma store
  - [x] Copy batches into a Plasma buffer and display object ID on standard output

Printing the object IDs on standard output is be fine for the prototype, but eventually we need a different channel to convey the object IDs to other tools. 

### Write Python PoC Example

- [ ] Write proof-of-concept Python script that takes events via Plasma