### PR TITLE
Replace usage of bitmap with ids where appropiate

### DIFF
--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -115,7 +115,7 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
     }
   );
   return {
-    [=](bitmap& hits) {
+    [=](ids& hits) {
       timespan runtime = steady_clock::now() - self->state.start;
       self->state.stats.runtime = runtime;
       auto count = rank(hits);
@@ -140,11 +140,11 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
       self->send(self->state.sink, self->state.id, self->state.stats);
       if (self->state.stats.received < self->state.stats.expected) {
         VAST_DEBUG(self, "received", self->state.stats.received << '/'
-                                     << self->state.stats.expected, "bitmaps");
+                                     << self->state.stats.expected, "ID sets");
         request_more_hits(self);
       } else {
         VAST_DEBUG(self, "received all", self->state.stats.expected,
-                   "bitmap(s) in", runtime);
+                   "ID set(s) in", runtime);
         if (self->state.accountant)
           self->send(self->state.accountant, "exporter.hits.runtime", runtime);
         shutdown(self);

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -13,7 +13,7 @@
 
 #include <caf/all.hpp>
 
-#include "vast/bitmap.hpp"
+#include "vast/ids.hpp"
 #include "vast/concept/parseable/numeric/integral.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/printable/stream.hpp"
@@ -53,7 +53,7 @@ auto to_digest(const T& x) {
 }
 
 struct collector_state {
-  bitmap hits;
+  ids hits;
   size_t got = 0;
   predicate pred;
   std::string name = "collector";
@@ -67,9 +67,9 @@ behavior collector(stateful_actor<collector_state>* self, predicate pred,
   self->state.name += '[' + to_string(pred) + ']';
   self->state.pred = std::move(pred);
   return {
-    [=](const bitmap& hits) {
+    [=](const ids& hits) {
       VAST_DEBUG(self, "got", rank(hits), "hits,",
-                 (self->state.got + 1) << '/' << expected, "bitmaps");
+                 (self->state.got + 1) << '/' << expected, "ID sets");
       self->state.hits |= hits;
       if (++self->state.got == expected) {
         VAST_DEBUG(self, "relays", rank(self->state.hits), "to evaluator");
@@ -80,55 +80,55 @@ behavior collector(stateful_actor<collector_state>* self, predicate pred,
   };
 }
 
-struct bitmap_evaluator {
-  bitmap_evaluator(const std::unordered_map<predicate, bitmap>& bitmaps)
-    : bitmaps{bitmaps} {
+struct ids_evaluator {
+  ids_evaluator(const std::unordered_map<predicate, ids>& xs)
+    : xs{xs} {
     // nop
   }
 
-  bitmap operator()(none) const {
+  ids operator()(none) const {
     return {};
   }
 
-  bitmap operator()(const conjunction& c) const {
-    auto bm = visit(*this, c[0]);
-    if (bm.empty() || all<0>(bm))
+  ids operator()(const conjunction& c) const {
+    auto result = visit(*this, c[0]);
+    if (result.empty() || all<0>(result))
       return {};
     for (size_t i = 1; i < c.size(); ++i) {
-      bm &= visit(*this, c[i]);
-      if (bm.empty() || all<0>(bm)) // short-circuit
+      result &= visit(*this, c[i]);
+      if (result.empty() || all<0>(result)) // short-circuit
         return {};
     }
-    return bm;
+    return result;
   }
 
-  bitmap operator()(const disjunction& d) const {
-    bitmap bm;
+  ids operator()(const disjunction& d) const {
+    ids result;
     for (auto& op : d) {
-      bm |= visit(*this, op);
-      if (all<1>(bm)) // short-circuit
+      result |= visit(*this, op);
+      if (all<1>(result)) // short-circuit
         break;
     }
-    return bm;
+    return result;
   }
 
-  bitmap operator()(const negation& n) const {
-    auto bm = visit(*this, n.expr());
-    bm.flip();
-    return bm;
+  ids operator()(const negation& n) const {
+    auto result = visit(*this, n.expr());
+    result.flip();
+    return result;
   }
 
-  bitmap operator()(const predicate& pred) const {
-    auto i = bitmaps.find(pred);
-    return i != bitmaps.end() ? i->second : bitmap{};
+  ids operator()(const predicate& pred) const {
+    auto i = xs.find(pred);
+    return i != xs.end() ? i->second : ids{};
   }
 
-  const std::unordered_map<predicate, bitmap>& bitmaps;
+  const std::unordered_map<predicate, ids>& xs;
 };
 
 struct evaluator_state {
-  bitmap hits;
-  std::unordered_map<predicate, bitmap> predicates;
+  ids hits;
+  std::unordered_map<predicate, ids> predicates;
   const char* name = "evaluator";
 };
 
@@ -137,9 +137,9 @@ struct evaluator_state {
 behavior evaluator(stateful_actor<evaluator_state>* self,
                    expression expr, size_t num_predicates, actor sink) {
   return {
-    [=](predicate& pred, bitmap& hits) {
+    [=](predicate& pred, ids& hits) {
       self->state.predicates.emplace(std::move(pred), std::move(hits));
-      auto expr_hits = visit(bitmap_evaluator{self->state.predicates}, expr);
+      auto expr_hits = visit(ids_evaluator{self->state.predicates}, expr);
       auto delta = expr_hits - self->state.hits;
       VAST_DEBUG(self, "evaluated",
                  self->state.predicates.size() << '/' << num_predicates,
@@ -204,7 +204,7 @@ behavior partition(stateful_actor<partition_state>* self, path dir) {
     [=](const expression& expr) {
       VAST_DEBUG(self, "got expression:", expr);
       auto start = steady_clock::now();
-      auto rp = self->make_response_promise<bitmap>();
+      auto rp = self->make_response_promise<ids>();
       // For each known type, check whether the expression could match.
       // If so, locate/load the corresponding indexer.
       std::vector<actor> indexers;
@@ -223,16 +223,16 @@ behavior partition(stateful_actor<partition_state>* self, path dir) {
       if (indexers.empty()) {
         VAST_DEBUG(self, "did not find a matching type in",
                    self->state.indexers.size(), "indexer(s)");
-        rp.deliver(bitmap{});
+        rp.deliver(ids{});
         return;
       }
-      // Spawn a sink that accumulates the stream of bitmaps from the evaluator
+      // Spawn a sink that accumulates the stream of ids from the evaluator
       // and ultimately responds to the user with the result.
       auto accumulator = self->system().spawn(
         [=](event_based_actor* job) mutable -> behavior {
-          auto result = std::make_shared<bitmap>();
+          auto result = std::make_shared<ids>();
           return {
-            [=](const bitmap& hits) mutable {
+            [=](const ids& hits) mutable {
               VAST_ASSERT(any<1>(hits));
               *result |= hits;
             },

--- a/libvast/src/value_index.cpp
+++ b/libvast/src/value_index.cpp
@@ -178,7 +178,7 @@ expected<void> value_index::push_back(const data& x, event_id id) {
   return {};
 }
 
-expected<bitmap>
+expected<ids>
 value_index::lookup(relational_operator op, const data& x) const {
   if (is<none>(x)) {
     if (!(op == equal || op == not_equal))
@@ -226,7 +226,7 @@ bool string_index::push_back_impl(const data& x, size_type skip) {
   return true;
 }
 
-expected<bitmap>
+expected<ids>
 string_index::lookup_impl(relational_operator op, const data& x) const {
   auto str = get_if<std::string>(x);
   if (!str)
@@ -315,7 +315,7 @@ bool address_index::push_back_impl(const data& x, size_type skip) {
   return true;
 }
 
-expected<bitmap>
+expected<ids>
 address_index::lookup_impl(relational_operator op, const data& x) const {
   auto size = v4_.size();
   if (auto addr = get_if<address>(x)) {
@@ -375,7 +375,7 @@ bool subnet_index::push_back_impl(const data& x, size_type skip) {
   return false;
 }
 
-expected<bitmap>
+expected<ids>
 subnet_index::lookup_impl(relational_operator op, const data& x) const {
   auto sn = get_if<subnet>(x);
   if (!sn)
@@ -414,11 +414,11 @@ subnet_index::lookup_impl(relational_operator op, const data& x) const {
       // the lookup returns all subnets in U that include x.
       bitmap result;
       for (auto i = uint8_t{1}; i <= sn->length(); ++i) {
-        auto bm = network_.lookup(in, subnet{sn->network(), i});
-        if (!bm)
-          return bm;
-        *bm &= length_.lookup(equal, i);
-        result |= *bm;
+        auto xs = network_.lookup(in, subnet{sn->network(), i});
+        if (!xs)
+          return xs;
+        *xs &= length_.lookup(equal, i);
+        result |= *xs;
       }
       if (op == not_ni)
         result.flip();
@@ -445,7 +445,7 @@ bool port_index::push_back_impl(const data& x, size_type skip) {
   return false;
 }
 
-expected<bitmap>
+expected<ids>
 port_index::lookup_impl(relational_operator op, const data& x) const {
   if (op == in || op == not_in)
     return make_error(ec::unsupported_operator, op);
@@ -487,7 +487,7 @@ bool sequence_index::push_back_impl(const data& x, size_type skip) {
   return false;
 }
 
-expected<bitmap>
+expected<ids>
 sequence_index::lookup_impl(relational_operator op, const data& x) const {
   if (op == ni)
     op = in;

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -11,7 +11,7 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include "vast/bitmap.hpp"
+#include "vast/ids.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/query_options.hpp"
@@ -57,9 +57,9 @@ TEST(index) {
       CHECK_EQUAL(scheduled, 3u);
       // After the lookup ID has arrived,
       size_t i = 0;
-      bitmap all;
+      ids all;
       self->receive_for(i, scheduled)(
-        [&](const bitmap& hits) { all |= hits; },
+        [&](const ids& hits) { all |= hits; },
         error_handler()
       );
       CHECK_EQUAL(rank(all), total_hits);
@@ -79,15 +79,15 @@ TEST(index) {
       CHECK_EQUAL(total, 3u);
       CHECK_EQUAL(scheduled, 2u); // Only two this time
       size_t i = 0;
-      bitmap all;
+      ids all;
       self->receive_for(i, scheduled)(
-        [&](const bitmap& hits) { all |= hits; },
+        [&](const ids& hits) { all |= hits; },
         error_handler()
       );
       // Evict one partition.
       self->send(index, id, size_t{1});
       self->receive(
-        [&](const bitmap& hits) { all |= hits; },
+        [&](const ids& hits) { all |= hits; },
         error_handler()
       );
       CHECK_EQUAL(rank(all), total_hits); // conn + dns + http

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -11,7 +11,7 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include "vast/bitmap.hpp"
+#include "vast/ids.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
 
@@ -46,13 +46,13 @@ struct partition_fixture : fixtures::actor_system_and_events {
     self->wait_for(partition);
   }
 
-  bitmap query(const std::string& str) {
+  ids query(const std::string& str) {
     MESSAGE("sending query");
     auto expr = to<expression>(str);
     REQUIRE(expr);
-    bitmap result;
+    ids result;
     self->request(partition, infinite, *expr).receive(
-      [&](bitmap& hits) {
+      [&](ids& hits) {
         result = std::move(hits);
       },
       error_handler()
@@ -67,7 +67,7 @@ struct partition_fixture : fixtures::actor_system_and_events {
     MESSAGE("respawning partition and sending query again");
     partition = self->spawn(system::partition, directory);
     self->request(partition, infinite, *expr).receive(
-      [&](const bitmap& hits) {
+      [&](const ids& hits) {
         REQUIRE_EQUAL(hits, result);
       },
       error_handler()

--- a/libvast/vast/ids.hpp
+++ b/libvast/vast/ids.hpp
@@ -11,33 +11,16 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#ifndef VAST_SYSTEM_QUERY_STATISTICS_HPP
-#define VAST_SYSTEM_QUERY_STATISTICS_HPP
+#ifndef VAST_IDS_HPP
+#define VAST_IDS_HPP
 
-#include <cstddef>
-#include <cstdint>
+#include "vast/bitmap.hpp"
 
-#include "vast/time.hpp"
+namespace vast {
 
-namespace vast::system {
+/// A set of IDs.
+using ids = bitmap;
 
-/// Statistics about a query.
-struct query_statistics {
-  timespan runtime;         ///< Current runtime.
-  size_t expected = 0;      ///< Expected ID sets from INDEX.
-  size_t scheduled = 0;     ///< Scheduled partitions (ID sets) at INDEX.
-  size_t received = 0;      ///< Received ID sets from INDEX.
-  uint64_t processed = 0;   ///< Processed candidates from ARCHIVE.
-  uint64_t shipped = 0;     ///< Shipped results to sink.
-  uint64_t requested = 0;   ///< User-requested pending results to extract.
-};
-
-template <class Inspector>
-auto inspect(Inspector& f, query_statistics& qs) {
-  return f(qs.runtime, qs.expected, qs.scheduled, qs.received, qs.processed,
-           qs.shipped, qs.requested);
-}
-
-} // namespace vast::system
+} // namespace vast
 
 #endif

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -20,7 +20,7 @@
 #include <unordered_map>
 
 #include "vast/aliases.hpp"
-#include "vast/bitmap.hpp"
+#include "vast/ids.hpp"
 #include "vast/expression.hpp"
 #include "vast/query_options.hpp"
 #include "vast/uuid.hpp"
@@ -36,8 +36,8 @@ struct exporter_state {
   caf::actor index;
   caf::actor sink;
   accountant_type accountant;
-  bitmap hits;
-  bitmap unprocessed;
+  ids hits;
+  ids unprocessed;
   std::unordered_map<type, expression> checkers;
   std::deque<event> candidates;
   std::vector<event> results;

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -18,7 +18,6 @@
 
 #include <caf/stateful_actor.hpp>
 
-#include "vast/bitmap.hpp"
 #include "vast/expression.hpp"
 #include "vast/filesystem.hpp"
 #include "vast/uuid.hpp"


### PR DESCRIPTION
Here is a list of files (without the unit test files) I have changed or omitted.
Omitted with a question mark means I'm not sure if these files have to refactored as well. 

File | Note
----|-----------
libvast/vast/ids.* |                 added
libvast/vast/bitmap_algorithms.* |   omitted; low level bitmap operations
libvast/src/bitmap.* |               omitted; low level bitmap operations
vast/coder.*: |                      omitted; low level bitmap operations
libvast/src/system/configuration.* | omitted
libvast/vast/batch.* |               omitted; name ids in use
libvast/src/system/archive.* |               omitted
libvast/vast/value_index.* |         changed
libvast/src/system/indexer.* |       changed
libvast/vast/system/index.* |        changed
libvast/vast/system/exporter.* |     changed
libvast/src/system/partition.*  |    changed
vast/system/query_statistics.* |     changed

I omitted the files batch and archive because we want to overhaul them in the near future with mmap and masks etc.
Is this Ok?


