### PR TITLE
Change const notation: T const[&|*] -> const T[&|*] and coding style ! exp -> !expr

### DIFF
--- a/libvast/src/address.cpp
+++ b/libvast/src/address.cpp
@@ -103,19 +103,19 @@ bool address::mask(unsigned top_bits_to_keep) {
   return true;
 }
 
-address& address::operator&=(address const& other) {
+address& address::operator&=(const address& other) {
   for (auto i = 0u; i < 16u; ++i)
     bytes_[i] &= other.bytes_[i];
   return *this;
 }
 
-address& address::operator|=(address const& other) {
+address& address::operator|=(const address& other) {
   for (auto i = 0u; i < 16u; ++i)
     bytes_[i] |= other.bytes_[i];
   return *this;
 }
 
-address& address::operator^=(address const& other) {
+address& address::operator^=(const address& other) {
   if (is_v4() || other.is_v4())
     for (auto i = 12u; i < 16u; ++i)
       bytes_[i] ^= other.bytes_[i];
@@ -125,7 +125,7 @@ address& address::operator^=(address const& other) {
   return *this;
 }
 
-std::array<uint8_t, 16> const& address::data() const {
+const std::array<uint8_t, 16>& address::data() const {
   return bytes_;
 }
 
@@ -140,15 +140,15 @@ bool address::compare(const address& other, size_t k) const {
   return (*x & mask) == (*y & mask);
 }
 
-bool operator==(address const& x, address const& y) {
+bool operator==(const address& x, const address& y) {
   return x.bytes_ == y.bytes_;
 }
 
-bool operator<(address const& x, address const& y) {
+bool operator<(const address& x, const address& y) {
   return x.bytes_ < y.bytes_;
 }
 
-bool convert(address const& a, json& j) {
+bool convert(const address& a, json& j) {
   j = to_string(a);
   return true;
 }

--- a/libvast/src/attribute.cpp
+++ b/libvast/src/attribute.cpp
@@ -25,11 +25,11 @@ attribute::attribute(std::string key, optional<std::string> value)
     value{std::move(value)} {
 }
 
-bool operator==(attribute const& x, attribute const& y) {
+bool operator==(const attribute& x, const attribute& y) {
   return x.key == y.key && x.value == y.value;
 };
 
-bool operator<(attribute const& x, attribute const& y) {
+bool operator<(const attribute& x, const attribute& y) {
   return std::tie(x.key, x.value) < std::tie(y.key, y.value);
 }
 

--- a/libvast/src/batch.cpp
+++ b/libvast/src/batch.cpp
@@ -45,7 +45,7 @@ batch::size_type batch::events() const {
   return events_;
 }
 
-uint64_t bytes(batch const& b) {
+uint64_t bytes(const batch& b) {
   return sizeof(b.method_) + sizeof(b.first_) + sizeof(b.last_) +
     sizeof(b.events_) + sizeof(b.ids_) + sizeof(b.data_) + b.data_.size();
 }
@@ -57,7 +57,7 @@ batch::writer::writer(compression method)
   batch_.method_ = method;
 }
 
-bool batch::writer::write(event const& e) {
+bool batch::writer::write(const event& e) {
   // Write meta data.
   if (e.timestamp() < batch_.first_)
     batch_.first_ = e.timestamp();
@@ -88,7 +88,7 @@ batch batch::writer::seal() {
   return result;
 }
 
-batch::reader::reader(batch const& b)
+batch::reader::reader(const batch& b)
   : data_{b.data_},
     id_range_{bit_range(b.ids_)},
     available_{b.events()},
@@ -190,7 +190,7 @@ expected<event> batch::reader::materialize() {
     }
     e.timestamp(ts);
     return e;
-  } catch (std::runtime_error const& e) {
+  } catch (const std::runtime_error& e) {
     return make_error(ec::unspecified, e.what());
   }
 }

--- a/libvast/src/bitmap.cpp
+++ b/libvast/src/bitmap.cpp
@@ -46,11 +46,11 @@ void bitmap::flip() {
   visit([](auto& bm) { bm.flip(); }, bitmap_);
 }
 
-bool operator==(bitmap const& x, bitmap const& y) {
+bool operator==(const bitmap& x, const bitmap& y) {
   return x.bitmap_ == y.bitmap_;
 }
 
-bitmap_bit_range::bitmap_bit_range(bitmap const& bm) {
+bitmap_bit_range::bitmap_bit_range(const bitmap& bm) {
   auto visitor = [&](auto& b) {
     auto r = bit_range(b);
     if (!r.done())
@@ -72,7 +72,7 @@ bool bitmap_bit_range::done() const {
   return visit([](auto& rng) { return rng.done(); }, range_);
 }
 
-bitmap_bit_range bit_range(bitmap const& bm) {
+bitmap_bit_range bit_range(const bitmap& bm) {
   return bitmap_bit_range{bm};
 }
 

--- a/libvast/src/bitstream_polymorphic.cpp
+++ b/libvast/src/bitstream_polymorphic.cpp
@@ -16,7 +16,7 @@
 
 namespace vast {
 
-detail::bitstream_concept::iterator::iterator(iterator const& other)
+detail::bitstream_concept::iterator::iterator(const iterator& other)
   : concept_{other.concept_ ? other.concept_->copy() : nullptr} {
 }
 
@@ -25,7 +25,7 @@ detail::bitstream_concept::iterator::iterator(iterator&& other)
 }
 
 detail::bitstream_concept::iterator& detail::bitstream_concept::iterator::
-operator=(iterator const& other) {
+operator=(const iterator& other) {
   concept_ = other.concept_ ? other.concept_->copy() : nullptr;
   return *this;
 }
@@ -36,7 +36,7 @@ operator=(iterator&& other) {
   return *this;
 }
 
-bool detail::bitstream_concept::iterator::equals(iterator const& other) const {
+bool detail::bitstream_concept::iterator::equals(const iterator& other) const {
   VAST_ASSERT(concept_);
   VAST_ASSERT(other.concept_);
   return concept_->equals(*other.concept_);
@@ -53,14 +53,14 @@ detail::bitstream_concept::iterator::dereference() const {
   return concept_->dereference();
 }
 
-bitstream::bitstream(bitstream const& other)
+bitstream::bitstream(const bitstream& other)
   : concept_{other.concept_ ? other.concept_->copy() : nullptr} {
 }
 
 bitstream::bitstream(bitstream&& other) : concept_{std::move(other.concept_)} {
 }
 
-bitstream& bitstream::operator=(bitstream const& other) {
+bitstream& bitstream::operator=(const bitstream& other) {
   concept_ = other.concept_ ? other.concept_->copy() : nullptr;
   return *this;
 }
@@ -74,7 +74,7 @@ bitstream::operator bool() const {
   return concept_ != nullptr;
 }
 
-bool bitstream::equals(bitstream const& other) const {
+bool bitstream::equals(const bitstream& other) const {
   VAST_ASSERT(concept_);
   VAST_ASSERT(other.concept_);
   return concept_->equals(*other.concept_);
@@ -85,14 +85,14 @@ void bitstream::bitwise_not() {
     concept_->bitwise_not();
 }
 
-void bitstream::bitwise_and(bitstream const& other) {
+void bitstream::bitwise_and(const bitstream& other) {
   if (concept_ && other.concept_)
     concept_->bitwise_and(*other.concept_);
   else
     concept_.reset();
 }
 
-void bitstream::bitwise_or(bitstream const& other) {
+void bitstream::bitwise_or(const bitstream& other) {
   if (!other.concept_)
     return;
 
@@ -102,19 +102,19 @@ void bitstream::bitwise_or(bitstream const& other) {
     concept_ = other.concept_->copy();
 }
 
-void bitstream::bitwise_xor(bitstream const& other) {
+void bitstream::bitwise_xor(const bitstream& other) {
   if (concept_ && other.concept_)
     concept_->bitwise_xor(*other.concept_);
   else
     concept_.reset();
 }
 
-void bitstream::bitwise_subtract(bitstream const& other) {
+void bitstream::bitwise_subtract(const bitstream& other) {
   if (concept_ && other.concept_)
     concept_->bitwise_subtract(*other.concept_);
 }
 
-void bitstream::append_impl(bitstream const& other) {
+void bitstream::append_impl(const bitstream& other) {
   VAST_ASSERT(concept_);
   VAST_ASSERT(other.concept_);
   concept_->append_impl(*other.concept_);
@@ -200,12 +200,12 @@ bitstream::size_type bitstream::find_prev_impl(size_type i) const {
   return concept_->find_prev_impl(i);
 }
 
-bitvector const& bitstream::bits_impl() const {
+const bitvector& bitstream::bits_impl() const {
   VAST_ASSERT(concept_);
   return concept_->bits_impl();
 }
 
-bool operator==(bitstream const& x, bitstream const& y) {
+bool operator==(const bitstream& x, const bitstream& y) {
   return x.equals(y);
 }
 

--- a/libvast/src/compression.cpp
+++ b/libvast/src/compression.cpp
@@ -49,7 +49,7 @@ size_t compress_bound(size_t size) {
 
 size_t uncompress_bound(const char* data, size_t size) {
   size_t n;
-  if (! ::snappy::GetUncompressedLength(data, size, &n))
+  if (!::snappy::GetUncompressedLength(data, size, &n))
     return 0;
   return n;
 }

--- a/libvast/src/compression.cpp
+++ b/libvast/src/compression.cpp
@@ -29,11 +29,11 @@ size_t compress_bound(size_t size) {
   return LZ4_compressBound(size);
 }
 
-size_t compress(char const* in, size_t in_size, char* out, size_t out_size) {
+size_t compress(const char* in, size_t in_size, char* out, size_t out_size) {
   return LZ4_compress_default(in, out, in_size, out_size);
 }
 
-size_t uncompress(char const* in, size_t in_size, char* out, size_t out_size) {
+size_t uncompress(const char* in, size_t in_size, char* out, size_t out_size) {
   return LZ4_decompress_safe(in, out, static_cast<int>(in_size),
                              static_cast<int>(out_size));
 }
@@ -47,20 +47,20 @@ size_t compress_bound(size_t size) {
   return ::snappy::MaxCompressedLength(size);
 }
 
-size_t uncompress_bound(char const* data, size_t size) {
+size_t uncompress_bound(const char* data, size_t size) {
   size_t n;
   if (! ::snappy::GetUncompressedLength(data, size, &n))
     return 0;
   return n;
 }
 
-size_t compress(char const* in, size_t in_size, char* out) {
+size_t compress(const char* in, size_t in_size, char* out) {
   size_t n;
   ::snappy::RawCompress(in, in_size, out, &n);
   return n;
 }
 
-bool uncompress(char const* in, size_t in_size, char* out) {
+bool uncompress(const char* in, size_t in_size, char* out) {
   return ::snappy::RawUncompress(in, in_size, out);
 }
 

--- a/libvast/src/concept/hashable/crc.cpp
+++ b/libvast/src/concept/hashable/crc.cpp
@@ -123,7 +123,7 @@ void crc(const void * key, int len, uint32_t seed, void * out) {
 
 crc32::crc32(uint32_t seed) : digest_{seed} { }
 
-void crc32::operator()(void const* x, size_t n) {
+void crc32::operator()(const void* x, size_t n) {
   VAST_ASSERT(n <= (1u << 31) - 1);
   crc(x, static_cast<int>(n), digest_, &digest_);
 }

--- a/libvast/src/concept/hashable/xxhash.cpp
+++ b/libvast/src/concept/hashable/xxhash.cpp
@@ -29,7 +29,7 @@ xxhash32::xxhash32(result_type seed) noexcept {
   ::XXH32_reset(state, seed);
 }
 
-void xxhash32::operator()(void const* x, size_t n) noexcept {
+void xxhash32::operator()(const void* x, size_t n) noexcept {
   VAST_ASSERT(n <= (1u << 31) - 1);
   auto state = reinterpret_cast<XXH32_state_t*>(&state_);
   auto result = ::XXH32_update(state, x, n);
@@ -50,7 +50,7 @@ xxhash64::xxhash64(result_type seed) noexcept {
   ::XXH64_reset(state, seed);
 }
 
-void xxhash64::operator()(void const* x, size_t n) noexcept {
+void xxhash64::operator()(const void* x, size_t n) noexcept {
   auto state = reinterpret_cast<XXH64_state_t*>(&state_);
   auto result = ::XXH64_update(state, x, n);
   VAST_ASSERT(result == XXH_OK);

--- a/libvast/src/concept/serializable/vast/vector_event.cpp
+++ b/libvast/src/concept/serializable/vast/vector_event.cpp
@@ -20,7 +20,7 @@
 
 namespace vast {
 
-void serialize(caf::serializer& sink, std::vector<event> const& events) {
+void serialize(caf::serializer& sink, const std::vector<event>& events) {
   util::flat_set<type::hash_type::digest_type> digests;
   auto size = events.size();
   sink.begin_sequence(size);

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -144,45 +144,45 @@ struct adder {
 };
 
 struct match_visitor {
-  bool operator()(std::string const& lhs, pattern const& rhs) const {
+  bool operator()(const std::string& lhs, const pattern& rhs) const {
     return rhs.match(lhs);
   }
 
   template <class T, class U>
-  bool operator()(T const&, U const&) const {
+  bool operator()(const T&, const U&) const {
     return false;
   }
 };
 
 struct in_visitor {
-  bool operator()(std::string const& lhs, std::string const& rhs) const {
+  bool operator()(const std::string& lhs, const std::string& rhs) const {
     return rhs.find(lhs) != std::string::npos;
   }
 
-  bool operator()(std::string const& lhs, pattern const& rhs) const {
+  bool operator()(const std::string& lhs, const pattern& rhs) const {
     return rhs.search(lhs);
   }
 
-  bool operator()(address const& lhs, subnet const& rhs) const {
+  bool operator()(const address& lhs, const subnet& rhs) const {
     return rhs.contains(lhs);
   }
 
-  bool operator()(subnet const& lhs, subnet const& rhs) const {
+  bool operator()(const subnet& lhs, const subnet& rhs) const {
     return rhs.contains(lhs);
   }
 
   template <class T>
-  bool operator()(T const& lhs, set const& rhs) const {
+  bool operator()(const T& lhs, const set& rhs) const {
     return std::find(rhs.begin(), rhs.end(), lhs) != rhs.end();
   }
 
   template <class T>
-  bool operator()(T const& lhs, vector const& rhs) const {
+  bool operator()(const T& lhs, const vector& rhs) const {
     return std::find(rhs.begin(), rhs.end(), lhs) != rhs.end();
   }
 
   template <class T, class U>
-  bool operator()(T const&, U const&) const {
+  bool operator()(const T&, const U&) const {
     return false;
   }
 };
@@ -192,7 +192,7 @@ struct in_visitor {
 data::data(none) {
 }
 
-data& data::operator+=(data const& rhs) {
+data& data::operator+=(const data& rhs) {
   visit(adder{*this}, *this, rhs);
   return *this;
 }
@@ -201,15 +201,15 @@ detail::data_variant& expose(data& d) {
   return d.data_;
 }
 
-bool operator==(data const& lhs, data const& rhs) {
+bool operator==(const data& lhs, const data& rhs) {
   return lhs.data_ == rhs.data_;
 }
 
-bool operator<(data const& lhs, data const& rhs) {
+bool operator<(const data& lhs, const data& rhs) {
   return lhs.data_ < rhs.data_;
 }
 
-bool evaluate(data const& lhs, relational_operator op, data const& rhs) {
+bool evaluate(const data& lhs, relational_operator op, const data& rhs) {
   switch (op) {
     default:
       VAST_ASSERT(!"missing case");
@@ -241,7 +241,7 @@ bool evaluate(data const& lhs, relational_operator op, data const& rhs) {
   }
 }
 
-data const* get(vector const& v, offset const& o) {
+data const* get(const vector& v, const offset& o) {
   vector const* x = &v;
   for (size_t i = 0; i < o.size(); ++i) {
     auto& idx = o[i];
@@ -257,7 +257,7 @@ data const* get(vector const& v, offset const& o) {
   return nullptr;
 }
 
-data const* get(data const& d, offset const& o) {
+data const* get(const data& d, const offset& o) {
   if (auto v = get_if<vector>(d))
     return get(*v, o);
   return nullptr;
@@ -303,7 +303,7 @@ optional<vector> unflatten(Iterator& f, Iterator l, const record_type& rec) {
 
 } // namespace <anonymous>
 
-vector flatten(vector const& xs) {
+vector flatten(const vector& xs) {
   auto f = xs.begin();
   auto l = xs.end();
   return flatten(f, l);
@@ -315,7 +315,7 @@ vector flatten(vector&& xs) {
   return flatten(f, l);
 }
 
-data flatten(data const& x) {
+data flatten(const data& x) {
   auto xs = get_if<vector>(x);
   return xs ? flatten(*xs) : x;
 }
@@ -325,25 +325,25 @@ data flatten(data&& x) {
   return xs ? flatten(std::move(*xs)) : x;
 }
 
-optional<vector> unflatten(vector const& xs, record_type const& rt) {
+optional<vector> unflatten(const vector& xs, const record_type& rt) {
   auto first = xs.begin();
   auto last = xs.end();
   return unflatten(first, last, rt);
 }
 
-optional<vector> unflatten(vector&& xs, record_type const& rt) {
+optional<vector> unflatten(vector&& xs, const record_type& rt) {
   auto first = std::make_move_iterator(xs.begin());
   auto last = std::make_move_iterator(xs.end());
   return unflatten(first, last, rt);
 }
 
-optional<vector> unflatten(data const& x, type const& t) {
+optional<vector> unflatten(const data& x, const type& t) {
   auto xs = get_if<vector>(x);
   auto rt = get_if<record_type>(t);
   return xs && rt ? unflatten(*xs, *rt) : optional<vector>{};
 }
 
-optional<vector> unflatten(data&& x, type const& t) {
+optional<vector> unflatten(data&& x, const type& t) {
   auto xs = get_if<vector>(x);
   auto rt = get_if<record_type>(t);
   return xs && rt ? unflatten(std::move(*xs), *rt) : optional<vector>{};
@@ -358,13 +358,13 @@ struct jsonizer {
     return true;
   }
 
-  bool operator()(std::string const& str) const {
+  bool operator()(const std::string& str) const {
     j_ = str;
     return true;
   }
 
   template <class T>
-  bool operator()(T const& x) const {
+  bool operator()(const T& x) const {
     return convert(x, j_);
   }
 
@@ -373,7 +373,7 @@ struct jsonizer {
 
 } // namespace <anonymous>
 
-bool convert(vector const& v, json& j) {
+bool convert(const vector& v, json& j) {
   json::array a(v.size());
   for (auto i = 0u; i < v.size(); ++i)
     if (!visit(jsonizer{a[i]}, v[i]))
@@ -382,7 +382,7 @@ bool convert(vector const& v, json& j) {
   return true;
 }
 
-bool convert(set const& s, json& j) {
+bool convert(const set& s, json& j) {
   json::array a(s.size());
   auto i = 0u;
   for (auto& x : s)
@@ -392,7 +392,7 @@ bool convert(set const& s, json& j) {
   return true;
 }
 
-bool convert(table const& t, json& j) {
+bool convert(const table& t, json& j) {
   json::array values;
   for (auto& p : t) {
     json::array a;
@@ -409,11 +409,11 @@ bool convert(table const& t, json& j) {
   return true;
 }
 
-bool convert(data const& d, json& j) {
+bool convert(const data& d, json& j) {
   return visit(jsonizer{j}, d);
 }
 
-bool convert(data const& d, json& j, type const& t) {
+bool convert(const data& d, json& j, const type& t) {
   auto v = get_if<vector>(d);
   auto rt = get_if<record_type>(t);
   if (v && rt) {

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -422,7 +422,7 @@ bool convert(const data& d, json& j, const type& t) {
     json::object o;
     for (auto i = 0u; i < v->size(); ++i) {
       auto& f = rt->fields[i];
-      if (! convert((*v)[i], o[f.name], f.type))
+      if (!convert((*v)[i], o[f.name], f.type))
         return false;
     }
     j = std::move(o);

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -241,8 +241,8 @@ bool evaluate(const data& lhs, relational_operator op, const data& rhs) {
   }
 }
 
-data const* get(const vector& v, const offset& o) {
-  vector const* x = &v;
+const data* get(const vector& v, const offset& o) {
+  const vector* x = &v;
   for (size_t i = 0; i < o.size(); ++i) {
     auto& idx = o[i];
     if (idx >= x->size())
@@ -257,7 +257,7 @@ data const* get(const vector& v, const offset& o) {
   return nullptr;
 }
 
-data const* get(const data& d, const offset& o) {
+const data* get(const data& d, const offset& o) {
   if (auto v = get_if<vector>(d))
     return get(*v, o);
   return nullptr;

--- a/libvast/src/detail/compressedbuf.cpp
+++ b/libvast/src/detail/compressedbuf.cpp
@@ -75,7 +75,7 @@ compressedbuf::int_type compressedbuf::overflow(int_type c) {
   return c;
 }
 
-std::streamsize compressedbuf::xsputn(char_type const* s, std::streamsize n) {
+std::streamsize compressedbuf::xsputn(const char_type* s, std::streamsize n) {
   auto put = std::streamsize{0};
   while (put < n) {
     while (epptr() == pptr()) {

--- a/libvast/src/detail/fdoutbuf.cpp
+++ b/libvast/src/detail/fdoutbuf.cpp
@@ -32,7 +32,7 @@ fdoutbuf::int_type fdoutbuf::overflow(int_type c) {
   return c;
 }
 
-std::streamsize fdoutbuf::xsputn(char const* s, std::streamsize n) {
+std::streamsize fdoutbuf::xsputn(const char* s, std::streamsize n) {
   return ::write(fd_, s, n);
 }
 

--- a/libvast/src/detail/line_range.cpp
+++ b/libvast/src/detail/line_range.cpp
@@ -21,7 +21,7 @@ line_range::line_range(std::istream& input) : input_{input} {
   next(); // prime the pump
 }
 
-std::string const& line_range::get() const {
+const std::string& line_range::get() const {
   return line_;
 }
 

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -29,7 +29,7 @@
 namespace vast {
 namespace detail {
 
-int uds_listen(std::string const& path) {
+int uds_listen(const std::string& path) {
   int fd;
   if ((fd = ::socket(AF_UNIX, SOCK_STREAM, 0)) < 0)
     return fd;
@@ -57,7 +57,7 @@ int uds_accept(int socket) {
   return fd;
 }
 
-int uds_connect(std::string const& path) {
+int uds_connect(const std::string& path) {
   int fd;
   if ((fd = ::socket(AF_UNIX, SOCK_STREAM, 0)) < 0)
     return fd;
@@ -131,18 +131,18 @@ int uds_recv_fd(int socket) {
 }
 
 VAST_DIAGNOSTIC_POP
-int unix_domain_socket::listen(std::string const& path) {
+int unix_domain_socket::listen(const std::string& path) {
   return detail::uds_listen(path);
 }
 
-unix_domain_socket unix_domain_socket::accept(std::string const& path) {
+unix_domain_socket unix_domain_socket::accept(const std::string& path) {
   auto server = detail::uds_listen(path);
   if (server != -1)
     return unix_domain_socket{detail::uds_accept(server)};
   return unix_domain_socket{};
 }
 
-unix_domain_socket unix_domain_socket::connect(std::string const& path) {
+unix_domain_socket unix_domain_socket::connect(const std::string& path) {
   return unix_domain_socket{detail::uds_connect(path)};
 }
 

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -225,9 +225,9 @@ bool read(int fd, void* buffer, size_t bytes, size_t* got) {
   return true;
 }
 
-bool write(int fd, void const* buffer, size_t bytes, size_t* put) {
+bool write(int fd, const void* buffer, size_t bytes, size_t* put) {
   auto total = size_t{0};
-  auto buf = reinterpret_cast<uint8_t const*>(buffer);
+  auto buf = reinterpret_cast<const uint8_t*>(buffer);
   while (total < bytes) {
     ssize_t written;
     do {

--- a/libvast/src/detail/string.cpp
+++ b/libvast/src/detail/string.cpp
@@ -19,11 +19,11 @@
 namespace vast {
 namespace detail {
 
-std::string byte_escape(std::string const& str) {
+std::string byte_escape(const std::string& str) {
   return escape(str, print_escaper);
 }
 
-std::string byte_escape(std::string const& str, std::string const& extra) {
+std::string byte_escape(const std::string& str, const std::string& extra) {
   auto print_extra_escaper = [&](auto& f, auto l, auto out) {
     if (extra.find(*f) != std::string::npos) {
       *out++ = '\\';
@@ -35,15 +35,15 @@ std::string byte_escape(std::string const& str, std::string const& extra) {
   return escape(str, print_extra_escaper);
 }
 
-std::string byte_escape_all(std::string const& str) {
+std::string byte_escape_all(const std::string& str) {
   return escape(str, hex_escaper);
 }
 
-std::string byte_unescape(std::string const& str) {
+std::string byte_unescape(const std::string& str) {
   return unescape(str, byte_unescaper);
 }
 
-std::string json_escape(std::string const& str) {
+std::string json_escape(const std::string& str) {
   if (str.empty())
     return "\"\"";
   std::string result;
@@ -58,7 +58,7 @@ std::string json_escape(std::string const& str) {
   return result;
 }
 
-std::string json_unescape(std::string const& str) {
+std::string json_unescape(const std::string& str) {
   // Unescape everything until the closing double quote.
   auto f = str.begin();
   auto l = str.end();
@@ -77,19 +77,19 @@ std::string json_unescape(std::string const& str) {
   return result;
 }
 
-std::string percent_escape(std::string const& str) {
+std::string percent_escape(const std::string& str) {
   return escape(str, percent_escaper);
 }
 
-std::string percent_unescape(std::string const& str) {
+std::string percent_unescape(const std::string& str) {
   return unescape(str, percent_unescaper);
 }
 
-std::string double_escape(std::string const& str, std::string const& esc) {
+std::string double_escape(const std::string& str, const std::string& esc) {
   return escape(str, double_escaper(esc));
 }
 
-std::string double_unescape(std::string const& str, std::string const& esc) {
+std::string double_unescape(const std::string& str, const std::string& esc) {
   return unescape(str, double_unescaper(esc));
 }
 

--- a/libvast/src/die.cpp
+++ b/libvast/src/die.cpp
@@ -18,7 +18,7 @@
 
 namespace vast {
 
-[[noreturn]] void die(std::string const& msg) {
+[[noreturn]] void die(const std::string& msg) {
   if (!msg.empty())
     std::cerr << "\nERROR: " << msg << std::endl;
   std::abort();

--- a/libvast/src/event.cpp
+++ b/libvast/src/event.cpp
@@ -44,29 +44,29 @@ vast::timestamp event::timestamp() const {
   return timestamp_;
 }
 
-event flatten(event const& e) {
-  event result = flatten(static_cast<value const&>(e));
+event flatten(const event& e) {
+  event result = flatten(static_cast<const value&>(e));
   result.id(e.id());
   result.timestamp(e.timestamp());
   return result;
 }
 
-bool operator==(event const& x, event const& y) {
+bool operator==(const event& x, const event& y) {
   return x.id() == y.id() &&
     x.timestamp() == y.timestamp() &&
-    static_cast<value const&>(x) == static_cast<value const&>(y);
+    static_cast<const value&>(x) == static_cast<const value&>(y);
 }
 
-bool operator<(event const& x, event const& y) {
-  return std::tie(x.id_, x.timestamp_, static_cast<value const&>(x)) <
-    std::tie(y.id_, y.timestamp_, static_cast<value const&>(y));
+bool operator<(const event& x, const event& y) {
+  return std::tie(x.id_, x.timestamp_, static_cast<const value&>(x)) <
+    std::tie(y.id_, y.timestamp_, static_cast<const value&>(y));
 }
 
-bool convert(event const& e, json& j) {
+bool convert(const event& e, json& j) {
   json::object o;
   o["id"] = e.id();
   o["timestamp"] = e.timestamp().time_since_epoch().count();
-  if (!convert(static_cast<value const&>(e), o["value"]))
+  if (!convert(static_cast<const value&>(e), o["value"]))
     return false;
   j = std::move(o);
   return true;

--- a/libvast/src/ewah_bitmap.cpp
+++ b/libvast/src/ewah_bitmap.cpp
@@ -27,7 +27,7 @@ ewah_bitmap::size_type ewah_bitmap::size() const {
   return num_bits_;
 }
 
-ewah_bitmap::block_vector const& ewah_bitmap::blocks() const {
+const ewah_bitmap::block_vector& ewah_bitmap::blocks() const {
   return blocks_;
 }
 
@@ -227,13 +227,13 @@ void ewah_bitmap::bump_dirty_count() {
   }
 }
 
-bool operator==(ewah_bitmap const& x, ewah_bitmap const& y) {
+bool operator==(const ewah_bitmap& x, const ewah_bitmap& y) {
   // If the block vector and the number of bits are equal, so must be the
   // marker by construction.
   return x.blocks_ == y.blocks_ && x.num_bits_ == y.num_bits_;
 }
 
-ewah_bitmap_range::ewah_bitmap_range(ewah_bitmap const& bm)
+ewah_bitmap_range::ewah_bitmap_range(const ewah_bitmap& bm)
   : bm_{&bm} {
   if (!bm_->empty())
     scan();
@@ -289,7 +289,7 @@ void ewah_bitmap_range::scan() {
   }
 }
 
-ewah_bitmap_range bit_range(ewah_bitmap const& bm) {
+ewah_bitmap_range bit_range(const ewah_bitmap& bm) {
   return ewah_bitmap_range{bm};
 }
 

--- a/libvast/src/expression.cpp
+++ b/libvast/src/expression.cpp
@@ -21,33 +21,33 @@ attribute_extractor::attribute_extractor(std::string str)
   : attr{std::move(str)} {
 }
 
-bool operator==(attribute_extractor const& x, attribute_extractor const& y) {
+bool operator==(const attribute_extractor& x, const attribute_extractor& y) {
   return x.attr == y.attr;
 }
 
-bool operator<(attribute_extractor const& x, attribute_extractor const& y) {
+bool operator<(const attribute_extractor& x, const attribute_extractor& y) {
   return x.attr < y.attr;
 }
 
 key_extractor::key_extractor(vast::key k) : key{std::move(k)} {
 }
 
-bool operator==(key_extractor const& lhs, key_extractor const& rhs) {
+bool operator==(const key_extractor& lhs, const key_extractor& rhs) {
   return lhs.key == rhs.key;
 }
 
-bool operator<(key_extractor const& lhs, key_extractor const& rhs) {
+bool operator<(const key_extractor& lhs, const key_extractor& rhs) {
   return lhs.key < rhs.key;
 }
 
 type_extractor::type_extractor(vast::type t) : type{std::move(t)} {
 }
 
-bool operator==(type_extractor const& lhs, type_extractor const& rhs) {
+bool operator==(const type_extractor& lhs, const type_extractor& rhs) {
   return lhs.type == rhs.type;
 }
 
-bool operator<(type_extractor const& lhs, type_extractor const& rhs) {
+bool operator<(const type_extractor& lhs, const type_extractor& rhs) {
   return lhs.type < rhs.type;
 }
 
@@ -55,11 +55,11 @@ data_extractor::data_extractor(vast::type t, vast::offset o)
   : type{std::move(t)}, offset{std::move(o)} {
 }
 
-bool operator==(data_extractor const& lhs, data_extractor const& rhs) {
+bool operator==(const data_extractor& lhs, const data_extractor& rhs) {
   return lhs.type == rhs.type && lhs.offset == rhs.offset;
 }
 
-bool operator<(data_extractor const& lhs, data_extractor const& rhs) {
+bool operator<(const data_extractor& lhs, const data_extractor& rhs) {
   return std::tie(lhs.type, lhs.offset) < std::tie(rhs.type, rhs.offset);
 }
 
@@ -67,11 +67,11 @@ predicate::predicate(operand l, relational_operator o, operand r)
   : lhs{std::move(l)}, op{o}, rhs{std::move(r)} {
 }
 
-bool operator==(predicate const& lhs, predicate const& rhs) {
+bool operator==(const predicate& lhs, const predicate& rhs) {
   return lhs.lhs == rhs.lhs && lhs.op == rhs.op && lhs.rhs == rhs.rhs;
 }
 
-bool operator<(predicate const& lhs, predicate const& rhs) {
+bool operator<(const predicate& lhs, const predicate& rhs) {
   return std::tie(lhs.lhs, lhs.op, lhs.rhs)
          < std::tie(rhs.lhs, rhs.op, rhs.rhs);
 }
@@ -84,7 +84,7 @@ negation::negation(expression expr)
   : expr_{std::make_unique<expression>(std::move(expr))} {
 }
 
-negation::negation(negation const& other)
+negation::negation(const negation& other)
   : expr_{std::make_unique<expression>(*other.expr_)} {
 }
 
@@ -92,7 +92,7 @@ negation::negation(negation&& other) noexcept
   : expr_{std::move(other.expr_)} {
 }
 
-negation& negation::operator=(negation const& other) {
+negation& negation::operator=(const negation& other) {
   *expr_ = *other.expr_;
   return *this;
 }
@@ -102,7 +102,7 @@ negation& negation::operator=(negation&& other) noexcept {
   return *this;
 }
 
-expression const& negation::expr() const {
+const expression& negation::expr() const {
   return *expr_;
 }
 
@@ -111,19 +111,19 @@ expression& negation::expr() {
 }
 
 
-bool operator==(negation const& lhs, negation const& rhs) {
+bool operator==(const negation& lhs, const negation& rhs) {
   return *lhs.expr_ == *rhs.expr_;
 }
 
-bool operator<(negation const& lhs, negation const& rhs) {
+bool operator<(const negation& lhs, const negation& rhs) {
   return *lhs.expr_ < *rhs.expr_;
 }
 
-bool operator==(expression const& lhs, expression const& rhs) {
+bool operator==(const expression& lhs, const expression& rhs) {
   return lhs.node_ == rhs.node_;
 }
 
-bool operator<(expression const& lhs, expression const& rhs) {
+bool operator<(const expression& lhs, const expression& rhs) {
   return lhs.node_ < rhs.node_;
 }
 
@@ -131,7 +131,7 @@ expression::node& expose(expression& e) {
   return e.node_;
 }
 
-expression normalize(expression const& expr) {
+expression normalize(const expression& expr) {
   expression r;
   r = visit(hoister{}, expr);
   r = visit(aligner{}, r);

--- a/libvast/src/filesystem.cpp
+++ b/libvast/src/filesystem.cpp
@@ -53,7 +53,7 @@
 
 namespace vast {
 
-constexpr char const* path::separator;
+constexpr const char* path::separator;
 
 path path::current() {
 #ifdef VAST_POSIX
@@ -64,7 +64,7 @@ path path::current() {
 #endif
 }
 
-path::path(char const* str) : str_{str} {
+path::path(const char* str) : str_{str} {
 }
 
 path::path(std::string str) : str_{std::move(str)} {
@@ -308,7 +308,7 @@ bool file::read(void* sink, size_t bytes, size_t* got) {
   return is_open_ && detail::read(handle_, sink, bytes, got);
 }
 
-bool file::write(void const* source, size_t bytes, size_t* put) {
+bool file::write(const void* source, size_t bytes, size_t* put) {
   return is_open_ && detail::write(handle_, source, bytes, put);
 }
 

--- a/libvast/src/filesystem.cpp
+++ b/libvast/src/filesystem.cpp
@@ -423,7 +423,7 @@ bool rm(const path& p) {
   auto t = p.kind();
   if (t == path::type::directory) {
     for (auto& entry : directory{p})
-      if (! rm(entry))
+      if (!rm(entry))
         return false;
     return VAST_DELETE_DIRECTORY(p.str().data());
   }

--- a/libvast/src/filesystem.cpp
+++ b/libvast/src/filesystem.cpp
@@ -70,7 +70,7 @@ path::path(char const* str) : str_{str} {
 path::path(std::string str) : str_{std::move(str)} {
 }
 
-path& path::operator/=(path const& p) {
+path& path::operator/=(const path& p) {
   if (p.empty() || (detail::ends_with(str_, separator) && p == separator))
     return *this;
   if (str_.empty())
@@ -82,7 +82,7 @@ path& path::operator/=(path const& p) {
   return *this;
 }
 
-path& path::operator+=(path const& p) {
+path& path::operator+=(const path& p) {
   str_ = str_ + p.str_;
   return *this;
 }
@@ -180,7 +180,7 @@ path path::chop(int n) const {
   return r;
 }
 
-std::string const& path::str() const {
+const std::string& path::str() const {
   return str_;
 }
 
@@ -219,11 +219,11 @@ bool path::is_symlink() const {
   return kind() == symlink;
 }
 
-bool operator==(path const& x, path const& y) {
+bool operator==(const path& x, const path& y) {
   return x.str_ == y.str_;
 }
 
-bool operator<(path const& x, path const& y) {
+bool operator<(const path& x, const path& y) {
   return x.str_ < y.str_;
 }
 
@@ -322,7 +322,7 @@ bool file::seek(size_t bytes) {
   return true;
 }
 
-path const& file::path() const {
+const path& file::path() const {
   return path_;
 }
 
@@ -355,11 +355,11 @@ void directory::iterator::increment() {
 #endif
 }
 
-path const& directory::iterator::dereference() const {
+const path& directory::iterator::dereference() const {
   return current_;
 }
 
-bool directory::iterator::equals(iterator const& other) const {
+bool directory::iterator::equals(const iterator& other) const {
   return dir_ == other.dir_;
 }
 
@@ -382,11 +382,11 @@ directory::iterator directory::end() const {
   return {};
 }
 
-path const& directory::path() const {
+const path& directory::path() const {
   return path_;
 }
 
-std::vector<path> split(path const& p) {
+std::vector<path> split(const path& p) {
   if (p.empty())
     return {};
   auto components = detail::to_strings(
@@ -404,7 +404,7 @@ std::vector<path> split(path const& p) {
   return result;
 }
 
-bool exists(path const& p) {
+bool exists(const path& p) {
 #ifdef VAST_POSIX
   struct stat st;
   return ::lstat(p.str().data(), &st) == 0;
@@ -413,7 +413,7 @@ bool exists(path const& p) {
 #endif // VAST_POSIX
 }
 
-void create_symlink(path const& target, path const& link) {
+void create_symlink(const path& target, const path& link) {
   ::symlink(target.str().c_str(), link.str().c_str());
 }
 
@@ -432,7 +432,7 @@ bool rm(const path& p) {
   return false;
 }
 
-expected<void> mkdir(path const& p) {
+expected<void> mkdir(const path& p) {
   auto components = split(p);
   if (components.empty())
     return make_error(ec::filesystem_error, "cannot mkdir empty path");
@@ -461,7 +461,7 @@ expected<void> mkdir(path const& p) {
   return {};
 }
 
-expected<std::string> load_contents(path const& p) {
+expected<std::string> load_contents(const path& p) {
   std::string contents;
   caf::containerbuf<std::string> obuf{contents};
   std::ostream out{&obuf};

--- a/libvast/src/format/bgpdump.cpp
+++ b/libvast/src/format/bgpdump.cpp
@@ -85,7 +85,7 @@ expected<schema> reader::schema() const {
   return sch;
 }
 
-char const* reader::name() const {
+const char* reader::name() const {
   return "bgpdump-reader";
 }
 

--- a/libvast/src/format/bgpdump.cpp
+++ b/libvast/src/format/bgpdump.cpp
@@ -59,7 +59,7 @@ bgpdump_parser::bgpdump_parser() {
   state_change_type.name("bgpdump::state_change");
 }
 
-expected<void> reader::schema(vast::schema const& sch) {
+expected<void> reader::schema(const vast::schema& sch) {
   auto types = {
     &parser_.announce_type,
     &parser_.route_type,

--- a/libvast/src/format/bro.cpp
+++ b/libvast/src/format/bro.cpp
@@ -34,7 +34,7 @@ namespace bro {
 namespace {
 
 // Creates a VAST type from an ASCII Bro type in a log header.
-expected<type> parse_type(std::string const& bro_type) {
+expected<type> parse_type(const std::string& bro_type) {
   type t;
   if (bro_type == "enum" || bro_type == "string" || bro_type == "file")
     t = string_type{};
@@ -87,36 +87,36 @@ expected<type> parse_type(std::string const& bro_type) {
 
 struct bro_type_printer {
   template <class T>
-  std::string operator()(T const& x) const {
+  std::string operator()(const T& x) const {
     return to_string(x);
   }
 
-  std::string operator()(real_type const&) {
+  std::string operator()(const real_type&) {
     return "double";
   }
 
-  std::string operator()(timestamp_type const&) {
+  std::string operator()(const timestamp_type&) {
     return "time";
   }
 
-  std::string operator()(timespan_type const&) {
+  std::string operator()(const timespan_type&) {
     return "interval";
   }
 
-  std::string operator()(vector_type const& t) const {
+  std::string operator()(const vector_type& t) const {
     return "vector[" + visit(*this, t.value_type) + ']';
   }
 
-  std::string operator()(set_type const& t) const {
+  std::string operator()(const set_type& t) const {
     return "set[" + visit(*this, t.value_type) + ']';
   }
 
-  std::string operator()(alias_type const& t) const {
+  std::string operator()(const alias_type& t) const {
     return visit(*this, t.value_type);
   }
 };
 
-expected<std::string> to_bro_string(type const& t) {
+expected<std::string> to_bro_string(const type& t) {
   return visit(bro_type_printer{}, t);
 }
 
@@ -130,14 +130,14 @@ struct time_factory {
 };
 
 template <class Stream>
-Stream& operator<<(Stream& out, time_factory const& t) {
+Stream& operator<<(Stream& out, const time_factory& t) {
   auto now = std::time(nullptr);
   auto tm = *std::localtime(&now);
   out << std::put_time(&tm, t.fmt);
   return out;
 }
 
-void stream_header(type const& t, std::ostream& out) {
+void stream_header(const type& t, std::ostream& out) {
   auto i = t.name().find("bro::");
   auto path = i == std::string::npos ? t.name() : t.name().substr(5);
   out << "#separator " << separator << '\n'
@@ -161,31 +161,31 @@ struct streamer {
   }
 
   template <class T>
-  void operator()(T const&, none) const {
+  void operator()(const T&, none) const {
     out_ << unset_field;
   }
 
   template <class T, class U>
-  auto operator()(T const&, U const& x) const
+  auto operator()(const T&, const U& x) const
   -> std::enable_if_t<!std::is_same<U, none>::value> {
     out_ << to_string(x);
   }
 
-  void operator()(integer_type const&, integer i) const {
+  void operator()(const integer_type&, integer i) const {
     out_ << i;
   }
 
-  void operator()(count_type const&, count c) const {
+  void operator()(const count_type&, count c) const {
     out_ << c;
   }
 
-  void operator()(real_type const&, real r) const {
+  void operator()(const real_type&, real r) const {
     auto p = real_printer<real, 6>{};
     auto out = std::ostreambuf_iterator<char>(out_);
     p.print(out, r);
   }
 
-  void operator()(timestamp_type const&, timestamp ts) const {
+  void operator()(const timestamp_type&, timestamp ts) const {
     double d;
     convert(ts.time_since_epoch(), d);
     auto p = real_printer<real, 6>{};
@@ -193,7 +193,7 @@ struct streamer {
     p.print(out, d);
   }
 
-  void operator()(timespan_type const&, timespan span) const {
+  void operator()(const timespan_type&, timespan span) const {
     double d;
     convert(span, d);
     auto p = real_printer<real, 6>{};
@@ -201,7 +201,7 @@ struct streamer {
     p.print(out, d);
   }
 
-  void operator()(string_type const&, std::string const& str) const {
+  void operator()(const string_type&, const std::string& str) const {
     auto out = std::ostreambuf_iterator<char>{out_};
     auto f = str.begin();
     auto l = str.end();
@@ -212,11 +212,11 @@ struct streamer {
         out_ << *f;
   }
 
-  void operator()(port_type const&, port const& p) const {
+  void operator()(const port_type&, const port& p) const {
     out_ << p.number();
   }
 
-  void operator()(record_type const& r, vector const& v) const {
+  void operator()(const record_type& r, const vector& v) const {
     VAST_ASSERT(!v.empty());
     VAST_ASSERT(r.fields.size() == v.size());
     visit(*this, r.fields[0].type, v[0]);
@@ -226,20 +226,20 @@ struct streamer {
     }
   }
 
-  void operator()(vector_type const& t, vector const& v) const {
+  void operator()(const vector_type& t, const vector& v) const {
     stream(v, t.value_type, set_separator);
   }
 
-  void operator()(set_type const& t, set const& s) const {
+  void operator()(const set_type& t, const set& s) const {
     stream(s, t.value_type, set_separator);
   }
 
-  void operator()(table_type const&, table const&) const {
+  void operator()(const table_type&, const table&) const {
     VAST_ASSERT(!"not supported by Bro's log format.");
   }
 
   template <class Container, class Sep>
-  void stream(Container& c, type const& value_type, Sep const& sep) const {
+  void stream(Container& c, const type& value_type, const Sep& sep) const {
     if (c.empty()) {
       // Cannot occur if we have a record
       out_ << empty_field;
@@ -332,7 +332,7 @@ expected<event> reader::read() {
   return e;
 }
 
-expected<void> reader::schema(vast::schema const& sch) {
+expected<void> reader::schema(const vast::schema& sch) {
   schema_ = sch;
   return no_error;
 }
@@ -351,9 +351,9 @@ const char* reader::name() const {
 
 // Parses a single header line a Bro log. (Since parsing headers is not on the
 // critical path, we are "lazy" and return strings instead of string views.)
-expected<std::string> parse_header_line(std::string const& line,
-                                        std::string const& sep,
-                                        std::string const& prefix) {
+expected<std::string> parse_header_line(const std::string& line,
+                                        const std::string& sep,
+                                        const std::string& prefix) {
   auto s = detail::split(line, sep, "", 1);
   if (!(s.size() == 2
         && std::equal(prefix.begin(), prefix.end(), s[0].first, s[0].second)))
@@ -460,7 +460,7 @@ expected<void> reader::parse_header() {
     }
   }
   // Create Bro parsers.
-  auto make_parser = [](auto const& type, auto const& set_sep) {
+  auto make_parser = [](const auto& type, const auto& set_sep) {
     using iterator_type = std::string::const_iterator;
     return make_bro_parser<iterator_type>(type, set_sep);
   };
@@ -484,7 +484,7 @@ writer::~writer() {
       *pair.second << footer;
 }
 
-expected<void> writer::write(event const& e) {
+expected<void> writer::write(const event& e) {
   if (!is<record_type>(e.type()))
     return make_error(ec::format_error, "cannot process non-record events");
   std::ostream* os = nullptr;

--- a/libvast/src/format/bro.cpp
+++ b/libvast/src/format/bro.cpp
@@ -126,7 +126,7 @@ constexpr auto empty_field = "(empty)";
 constexpr auto unset_field = "-";
 
 struct time_factory {
-  char const* fmt = "%Y-%m-%d-%H-%M-%S";
+  const char* fmt = "%Y-%m-%d-%H-%M-%S";
 };
 
 template <class Stream>
@@ -380,7 +380,7 @@ expected<void> reader::parse_header() {
     }
   }
   // Retrieve remaining header lines.
-  char const* prefixes[] = {
+  const char* prefixes[] = {
     "#set_separator",
     "#empty_field",
     "#unset_field",
@@ -389,7 +389,7 @@ expected<void> reader::parse_header() {
     "#fields",
     "#types",
   };
-  std::vector<std::string> header(sizeof(prefixes) / sizeof(char const*));
+  std::vector<std::string> header(sizeof(prefixes) / sizeof(const char*));
   for (auto i = 0u; i < header.size(); ++i) {
     lines_->next();
     if (lines_->done())

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -275,7 +275,7 @@ expected<event> reader::read() {
   return e;
 }
 
-expected<void> reader::schema(vast::schema const& sch) {
+expected<void> reader::schema(const vast::schema& sch) {
   auto t = sch.find(pcap_packet_type.name());
   if (!t)
     return make_error(ec::format_error, "did not find packet type in schema");
@@ -307,7 +307,7 @@ writer::~writer() {
     ::pcap_close(pcap_);
 }
 
-expected<void> writer::write(event const& e) {
+expected<void> writer::write(const event& e) {
   if (!pcap_) {
 #ifdef PCAP_TSTAMP_PRECISION_NANO
     pcap_ = ::pcap_open_dead_with_tstamp_precision(DLT_RAW, 65535,

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -113,7 +113,7 @@ expected<event> reader::read() {
     VAST_INFO(name(), "evicts flows after", max_age_ << "s of inactivity");
     VAST_INFO(name(), "expires flow table every", expire_interval_ << "s");
   }
-  uint8_t const* data;
+  const uint8_t* data;
   pcap_pkthdr* header;
   auto r = ::pcap_next_ex(pcap_, &header, &data);
   if (r == 0)
@@ -131,9 +131,9 @@ expected<event> reader::read() {
   connection conn;
   auto packet_size = header->len - 14;
   auto layer3 = data + 14;
-  uint8_t const* layer4 = nullptr;
+  const uint8_t* layer4 = nullptr;
   uint8_t layer4_proto = 0;
-  auto layer2_type = *reinterpret_cast<uint16_t const*>(data + 12);
+  auto layer2_type = *reinterpret_cast<const uint16_t*>(data + 12);
   uint64_t payload_size = packet_size;
   switch (detail::to_host_order(layer2_type)) {
     default:
@@ -145,8 +145,8 @@ expected<event> reader::read() {
       if (header_size < 20)
         return make_error(ec::format_error, "IPv4 header too short: ",
                           header_size, " bytes");
-      auto orig_h = reinterpret_cast<uint32_t const*>(layer3 + 12);
-      auto resp_h = reinterpret_cast<uint32_t const*>(layer3 + 16);
+      auto orig_h = reinterpret_cast<const uint32_t*>(layer3 + 12);
+      auto resp_h = reinterpret_cast<const uint32_t*>(layer3 + 16);
       conn.src = {orig_h, address::ipv4, address::network};
       conn.dst = {resp_h, address::ipv4, address::network};
       layer4_proto = *(layer3 + 9);
@@ -156,8 +156,8 @@ expected<event> reader::read() {
     case 0x86dd: {
       if (header->len < 14 + 40)
         return make_error(ec::format_error, "IPv6 header too short");
-      auto orig_h = reinterpret_cast<uint32_t const*>(layer3 + 8);
-      auto resp_h = reinterpret_cast<uint32_t const*>(layer3 + 24);
+      auto orig_h = reinterpret_cast<const uint32_t*>(layer3 + 8);
+      auto resp_h = reinterpret_cast<const uint32_t*>(layer3 + 24);
       conn.src = {orig_h, address::ipv4, address::network};
       conn.dst = {resp_h, address::ipv4, address::network};
       layer4_proto = *(layer3 + 6);
@@ -167,18 +167,18 @@ expected<event> reader::read() {
   }
   if (layer4_proto == IPPROTO_TCP) {
     VAST_ASSERT(layer4);
-    auto orig_p = *reinterpret_cast<uint16_t const*>(layer4);
-    auto resp_p = *reinterpret_cast<uint16_t const*>(layer4 + 2);
+    auto orig_p = *reinterpret_cast<const uint16_t*>(layer4);
+    auto resp_p = *reinterpret_cast<const uint16_t*>(layer4 + 2);
     orig_p = detail::to_host_order(orig_p);
     resp_p = detail::to_host_order(resp_p);
     conn.sport = {orig_p, port::tcp};
     conn.dport = {resp_p, port::tcp};
-    auto data_offset = *reinterpret_cast<uint8_t const*>(layer4 + 12) >> 4;
+    auto data_offset = *reinterpret_cast<const uint8_t*>(layer4 + 12) >> 4;
     payload_size -= data_offset * 4;
   } else if (layer4_proto == IPPROTO_UDP) {
     VAST_ASSERT(layer4);
-    auto orig_p = *reinterpret_cast<uint16_t const*>(layer4);
-    auto resp_p = *reinterpret_cast<uint16_t const*>(layer4 + 2);
+    auto orig_p = *reinterpret_cast<const uint16_t*>(layer4);
+    auto resp_p = *reinterpret_cast<const uint16_t*>(layer4 + 2);
     orig_p = detail::to_host_order(orig_p);
     resp_p = detail::to_host_order(resp_p);
     conn.sport = {orig_p, port::udp};
@@ -186,8 +186,8 @@ expected<event> reader::read() {
     payload_size -= 8;
   } else if (layer4_proto == IPPROTO_ICMP) {
     VAST_ASSERT(layer4);
-    auto message_type = *reinterpret_cast<uint8_t const*>(layer4);
-    auto message_code = *reinterpret_cast<uint8_t const*>(layer4 + 1);
+    auto message_type = *reinterpret_cast<const uint8_t*>(layer4);
+    auto message_code = *reinterpret_cast<const uint8_t*>(layer4 + 1);
     conn.sport = {message_type, port::icmp};
     conn.dport = {message_code, port::icmp};
     payload_size -= 8; // TODO: account for variable-size data.
@@ -248,7 +248,7 @@ expected<event> reader::read() {
   meta.emplace_back(std::move(conn.dport));
   packet.emplace_back(std::move(meta));
   // We start with the network layer and skip the link layer.
-  auto str = reinterpret_cast<char const*>(data + 14);
+  auto str = reinterpret_cast<const char*>(data + 14);
   packet.emplace_back(std::string{str, packet_size});
   using namespace std::chrono;
   auto secs = seconds(header->ts.tv_sec);
@@ -342,7 +342,7 @@ expected<void> writer::write(const event& e) {
   header.len = payload->size();
   // Dump packet.
   ::pcap_dump(reinterpret_cast<uint8_t*>(dumper_), &header,
-              reinterpret_cast<uint8_t const*>(payload->c_str()));
+              reinterpret_cast<const uint8_t*>(payload->c_str()));
   if (++total_packets_ % flush_interval_ == 0) {
     auto r = flush();
     if (!r)

--- a/libvast/src/http.cpp
+++ b/libvast/src/http.cpp
@@ -19,7 +19,7 @@
 namespace vast {
 namespace http {
 
-header const* message::header(std::string const& name) const {
+header const* message::header(const std::string& name) const {
   auto pred = [&](auto& x) -> bool {
     if (x.name.size() != name.size())
       return false;

--- a/libvast/src/http.cpp
+++ b/libvast/src/http.cpp
@@ -19,7 +19,7 @@
 namespace vast {
 namespace http {
 
-header const* message::header(const std::string& name) const {
+const header* message::header(const std::string& name) const {
   auto pred = [&](auto& x) -> bool {
     if (x.name.size() != name.size())
       return false;

--- a/libvast/src/null_bitmap.cpp
+++ b/libvast/src/null_bitmap.cpp
@@ -43,12 +43,12 @@ void null_bitmap::flip() {
   bitvector_.flip();
 }
 
-bool operator==(null_bitmap const& x, null_bitmap const& y) {
+bool operator==(const null_bitmap& x, const null_bitmap& y) {
   return x.bitvector_ == y.bitvector_;
 }
 
 
-null_bitmap_range::null_bitmap_range(null_bitmap const& bm)
+null_bitmap_range::null_bitmap_range(const null_bitmap& bm)
   : bitvector_{&bm.bitvector_},
     block_{bm.bitvector_.blocks().begin()},
     end_{bm.bitvector_.blocks().end()} {
@@ -98,7 +98,7 @@ void null_bitmap_range::scan() {
   }
 }
 
-null_bitmap_range bit_range(null_bitmap const& bm) {
+null_bitmap_range bit_range(const null_bitmap& bm) {
   return null_bitmap_range{bm};
 }
 

--- a/libvast/src/pattern.cpp
+++ b/libvast/src/pattern.cpp
@@ -20,7 +20,7 @@
 
 namespace vast {
 
-pattern pattern::glob(std::string const& str) {
+pattern pattern::glob(const std::string& str) {
   auto rx = std::regex_replace(str, std::regex("\\."), "\\.");
   rx = std::regex_replace(rx, std::regex("\\*"), ".*");
   return pattern{std::regex_replace(rx, std::regex("\\?"), ".")};
@@ -29,11 +29,11 @@ pattern pattern::glob(std::string const& str) {
 pattern::pattern(std::string str) : str_(std::move(str)) {
 }
 
-bool pattern::match(std::string const& str) const {
+bool pattern::match(const std::string& str) const {
   return std::regex_match(str.begin(), str.end(), std::regex{str_});
 }
 
-bool pattern::search(std::string const& str) const {
+bool pattern::search(const std::string& str) const {
   return std::regex_search(str.begin(), str.end(), std::regex{str_});
 }
 
@@ -41,15 +41,15 @@ const std::string& pattern::string() const {
   return str_;
 }
 
-bool operator==(pattern const& lhs, pattern const& rhs) {
+bool operator==(const pattern& lhs, const pattern& rhs) {
   return lhs.str_ == rhs.str_;
 }
 
-bool operator<(pattern const& lhs, pattern const& rhs) {
+bool operator<(const pattern& lhs, const pattern& rhs) {
   return lhs.str_ < rhs.str_;
 }
 
-bool convert(pattern const& p, json& j) {
+bool convert(const pattern& p, json& j) {
   j = to_string(p);
   return true;
 }

--- a/libvast/src/port.cpp
+++ b/libvast/src/port.cpp
@@ -39,17 +39,17 @@ void port::type(port_type t) {
   type_ = t;
 }
 
-bool operator==(port const& x, port const& y) {
+bool operator==(const port& x, const port& y) {
   return x.number_ == y.number_
          && (x.type_ == y.type_ || x.type_ == port::unknown
              || y.type_ == port::unknown);
 }
 
-bool operator<(port const& x, port const& y) {
+bool operator<(const port& x, const port& y) {
   return std::tie(x.number_, x.type_) < std::tie(y.number_, y.type_);
 }
 
-bool convert(port const& p, json& j) {
+bool convert(const port& p, json& j) {
   j = to_string(p);
   return true;
 }

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -43,7 +43,7 @@ bool schema::add(const type& t) {
   return true;
 }
 
-type const* schema::find(const std::string& name) const {
+const type* schema::find(const std::string& name) const {
   for (auto& t : types_)
     if (t.name() == name)
       return &t;

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -22,7 +22,7 @@
 
 namespace vast {
 
-optional<schema> schema::merge(schema const& s1, schema const& s2) {
+optional<schema> schema::merge(const schema& s1, const schema& s2) {
   auto result = s2;
   for (auto& t : s1) {
     if (auto u = s2.find(t.name())) {
@@ -36,14 +36,14 @@ optional<schema> schema::merge(schema const& s1, schema const& s2) {
   return result;
 }
 
-bool schema::add(type const& t) {
+bool schema::add(const type& t) {
   if (is<none_type>(t) || t.name().empty() || find(t.name()))
     return false;
   types_.push_back(std::move(t));
   return true;
 }
 
-type const* schema::find(std::string const& name) const {
+type const* schema::find(const std::string& name) const {
   for (auto& t : types_)
     if (t.name() == name)
       return &t;
@@ -70,7 +70,7 @@ void schema::clear() {
   types_.clear();
 }
 
-bool operator==(schema const& x, schema const& y) {
+bool operator==(const schema& x, const schema& y) {
   return x.types_ == y.types_;
 }
 
@@ -80,7 +80,7 @@ bool operator==(schema const& x, schema const& y) {
 //namespace {
 //
 //struct pointer_hash {
-//  size_t operator()(type const& t) const noexcept {
+//  size_t operator()(const type& t) const noexcept {
 //    return reinterpret_cast<size_t>(t.ptr_.get());
 //  }
 //};
@@ -108,24 +108,24 @@ bool operator==(schema const& x, schema const& y) {
 //  }
 //
 //  template <class T>
-//  void operator()(T const& x) const {
+//  void operator()(const T& x) const {
 //    sink_ << x;
 //  };
 //
-//  void operator()(vector_type const& t) const {
+//  void operator()(const vector_type& t) const {
 //    save_type(t.value_type);
 //  }
 //
-//  void operator()(set_type const& t) const {
+//  void operator()(const set_type& t) const {
 //    save_type(t.value_type);
 //  }
 //
-//  void operator()(table_type const& t) const {
+//  void operator()(const table_type& t) const {
 //    save_type(t.key_type);
 //    save_type(t.value_type);
 //  }
 //
-//  void operator()(record_type const& t) const {
+//  void operator()(const record_type& t) const {
 //    auto size = t.fields.size();
 //    sink_.begin_sequence(size);
 //    for (auto& f : t.fields) {
@@ -141,7 +141,7 @@ bool operator==(schema const& x, schema const& y) {
 //
 //} // namespace <anonymous>
 
-void serialize(caf::serializer& sink, schema const& sch) {
+void serialize(caf::serializer& sink, const schema& sch) {
   sink << to_string(sch);
 }
 
@@ -155,7 +155,7 @@ void serialize(caf::deserializer& source, schema& sch) {
   parse(i, str.end(), sch);
 }
 
-bool convert(schema const& s, json& j) {
+bool convert(const schema& s, json& j) {
   json::object o;
   json::array a;
   std::transform(s.begin(), s.end(), std::back_inserter(a),

--- a/libvast/src/subnet.cpp
+++ b/libvast/src/subnet.cpp
@@ -31,15 +31,15 @@ subnet::subnet(address addr, uint8_t length)
   }
 }
 
-bool subnet::contains(address const& addr) const {
+bool subnet::contains(const address& addr) const {
   return addr.compare(network_, length_);
 }
 
-bool subnet::contains(subnet const& other) const {
+bool subnet::contains(const subnet& other) const {
   return length_ <= other.length_ && contains(other.network_);
 }
 
-address const& subnet::network() const {
+const address& subnet::network() const {
   return network_;
 }
 
@@ -59,15 +59,15 @@ bool subnet::initialize() {
   return true;
 }
 
-bool operator==(subnet const& x, subnet const& y) {
+bool operator==(const subnet& x, const subnet& y) {
   return x.network_ == y.network_ && x.length_ == y.length_;
 }
 
-bool operator<(subnet const& x, subnet const& y) {
+bool operator<(const subnet& x, const subnet& y) {
   return std::tie(x.network_, x.length_) < std::tie(y.network_, y.length_);
 }
 
-bool convert(subnet const& sn, json& j) {
+bool convert(const subnet& sn, json& j) {
   j = to_string(sn);
   return true;
 }

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -31,7 +31,7 @@ namespace system {
 namespace {
 
 template <class Actor>
-void init(Actor self, path const& filename) {
+void init(Actor self, const path& filename) {
   if (!exists(filename.parent())) {
     auto t = mkdir(filename.parent());
     if (!t) {
@@ -57,7 +57,7 @@ void init(Actor self, path const& filename) {
 }
 
 template <class Actor, class T>
-void record(Actor self, std::string const& key, T x) {
+void record(Actor self, const std::string& key, T x) {
   using namespace std::chrono;
   auto node = self->current_sender()->node();
   auto now = system_clock::now().time_since_epoch();
@@ -78,7 +78,7 @@ void record(Actor self, std::string const& key, T x) {
 
 accountant_type::behavior_type accountant(
   accountant_type::stateful_pointer<accountant_state> self,
-  path const& filename) {
+  const path& filename) {
   using namespace std::chrono;
   init(self, filename);
   return {
@@ -93,25 +93,25 @@ accountant_type::behavior_type accountant(
       if (self->current_sender() == self)
         self->delayed_send(self, seconds(10), flush_atom::value);
     },
-    [=](std::string const& key, std::string const& value) {
+    [=](const std::string& key, const std::string& value) {
       record(self, key, value);
     },
     // Helpers to avoid to_string(..) in sender context.
-    [=](std::string const& key, timespan value) {
+    [=](const std::string& key, timespan value) {
       auto us = duration_cast<microseconds>(value).count();
       record(self, key, us);
     },
-    [=](std::string const& key, timestamp value) {
+    [=](const std::string& key, timestamp value) {
       auto us = duration_cast<microseconds>(value.time_since_epoch()).count();
       record(self, key, us);
     },
-    [=](std::string const& key, int64_t value) {
+    [=](const std::string& key, int64_t value) {
       record(self, key, value);
     },
-    [=](std::string const& key, uint64_t value) {
+    [=](const std::string& key, uint64_t value) {
       record(self, key, value);
     },
-    [=](std::string const& key, double value) {
+    [=](const std::string& key, double value) {
       record(self, key, value);
     }
   };

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -228,7 +228,7 @@ archive(archive_type::stateful_pointer<archive_state> self,
       auto rp = self->make_response_promise<lookup_promise>();
       // Collect candidate segments by seeking through the query bitmap and
       // probing each ID interval.
-      std::vector<uuid const*> candidates;
+      std::vector<const uuid*> candidates;
       auto ones = select(bm);
       auto i = self->state.segments.begin();
       auto end = self->state.segments.end();

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -51,7 +51,7 @@ void segment::add(batch&& b) {
 // M is the number of batches and N the size of the bitmap. Conceptually,
 // there's a straight-forward O(log M * N) or even O(N) algorithm by walking
 // through the query bitmap in lock-step with the batches.
-expected<std::vector<event>> segment::extract(bitmap const& bm) const {
+expected<std::vector<event>> segment::extract(const bitmap& bm) const {
   std::vector<event> result;
   auto min = select(bm, 1);
   auto max = select(bm, -1);
@@ -73,11 +73,11 @@ expected<std::vector<event>> segment::extract(bitmap const& bm) const {
   return result;
 }
 
-uuid const& segment::id() const {
+const uuid& segment::id() const {
   return id_;
 }
 
-uint64_t bytes(segment const& s) {
+uint64_t bytes(const segment& s) {
   return s.bytes_;
 }
 
@@ -159,7 +159,7 @@ archive(archive_type::stateful_pointer<archive_state> self,
     self->state.accountant = actor_cast<accountant_type>(acc);
   }
   return {
-    [=](std::vector<event> const& events) {
+    [=](const std::vector<event>& events) {
       VAST_ASSERT(!events.empty());
       // Ensure that all events have strictly monotonic IDs
       auto non_monotonic = [](auto& x, auto& y) {
@@ -221,7 +221,7 @@ archive(archive_type::stateful_pointer<archive_state> self,
       }
       return rp;
     },
-    [=](bitmap const& bm) -> lookup_promise {
+    [=](const bitmap& bm) -> lookup_promise {
       VAST_ASSERT(rank(bm) > 0);
       VAST_DEBUG(self, "got query for", rank(bm), "events in range ["
                  << select(bm, 1) << ',' << (select(bm, -1) + 1) << ')');

--- a/libvast/src/system/consensus.cpp
+++ b/libvast/src/system/consensus.cpp
@@ -977,7 +977,7 @@ behavior consensus(stateful_actor<server_state>* self, path dir) {
       //                     "not enough commited entries to snapshot");
       return save_snapshot(self, index, snapshot);
     },
-    [=](peer_atom, actor const& peer, server_id peer_id) {
+    [=](peer_atom, const actor& peer, server_id peer_id) {
       VAST_DEBUG(role(self), "re-activates peer", peer_id);
       VAST_ASSERT(peer_id != 0);
       auto i = std::find_if(self->state.peers.begin(),
@@ -1070,7 +1070,7 @@ behavior consensus(stateful_actor<server_state>* self, path dir) {
     [=](seed_atom, uint64_t value) {
       self->state.prng.seed(value);
     },
-    [=](peer_atom, actor const& peer, server_id peer_id) {
+    [=](peer_atom, const actor& peer, server_id peer_id) {
       VAST_ASSERT(peer_id != 0);
       VAST_DEBUG(role(self), "adds new peer", peer_id);
       if (peer_id == self->state.id) {

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -204,15 +204,15 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
       ship_results(self);
       request_more_hits(self);
     },
-    [=](archive_type const& archive) {
+    [=](const archive_type& archive) {
       VAST_DEBUG(self, "registers archive", archive);
       self->state.archive = archive;
     },
-    [=](index_atom, actor const& index) {
+    [=](index_atom, const actor& index) {
       VAST_DEBUG(self, "registers index", index);
       self->state.index = index;
     },
-    [=](sink_atom, actor const& sink) {
+    [=](sink_atom, const actor& sink) {
       VAST_DEBUG(self, "registers index", sink);
       self->send(self->state.sink, sys_atom::value, put_atom::value, sink);
     },

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -73,7 +73,7 @@ expected<void> write_state(stateful_actor<importer_state>* self) {
 // Generates the default EXIT handler that saves states and shuts down internal
 // components.
 auto shutdown(stateful_actor<importer_state>* self) {
-  return [=](exit_msg const& msg) {
+  return [=](const exit_msg& msg) {
     write_state(self);
     self->anon_send(self->state.archive, sys_atom::value, delete_atom::value);
     self->anon_send(self->state.index, sys_atom::value, delete_atom::value);
@@ -164,24 +164,24 @@ behavior importer(stateful_actor<importer_state>* self, path dir,
   self->set_default_handler(skip);
   self->set_exit_handler(shutdown(self));
   self->set_down_handler(
-    [=](down_msg const& msg) {
+    [=](const down_msg& msg) {
       if (msg.source == self->state.meta_store)
         self->state.meta_store = meta_store_type{};
     }
   );
   return {
-    [=](meta_store_type const& ms) {
+    [=](const meta_store_type& ms) {
       VAST_DEBUG(self, "registers meta store");
       VAST_ASSERT(ms != self->state.meta_store);
       self->monitor(ms);
       self->state.meta_store = ms;
     },
-    [=](archive_type const& archive) {
+    [=](const archive_type& archive) {
       VAST_DEBUG(self, "registers archive", archive);
       self->send(self->state.archive, sys_atom::value, put_atom::value,
                  actor_cast<actor>(archive));
     },
-    [=](index_atom, actor const& index) {
+    [=](index_atom, const actor& index) {
       VAST_DEBUG(self, "registers index", index);
       self->send(self->state.index, sys_atom::value, put_atom::value, index);
     },

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -279,7 +279,7 @@ behavior index(stateful_actor<index_state>* self, const path& dir,
       auto msg = self->current_mailbox_element()->move_content_to_message();
       self->send(self->state.active.partition, msg);
     },
-    [=](expression const& expr) -> result<uuid, size_t, size_t> {
+    [=](const expression& expr) -> result<uuid, size_t, size_t> {
       auto sender = actor_cast<actor>(self->current_sender());
       VAST_DEBUG(self, "got lookup:", expr);
       // Identify the relevant partitions.
@@ -307,7 +307,7 @@ behavior index(stateful_actor<index_state>* self, const path& dir,
       ctx.first->second.partitions = std::move(partitions);
       return {id, num_partitions, n};
     },
-    [=](uuid const& id, size_t n) {
+    [=](const uuid& id, size_t n) {
       auto& ctx = self->state.lookups[id];
       VAST_DEBUG(self, "processes lookup", id << ':', ctx.expr);
       if (n == 0) {

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -72,7 +72,7 @@ behavior value_indexer(stateful_actor<value_indexer_state>* self,
       self->quit(make_error(ec::unspecified, "failed to construct index"));
   }
   return {
-    [=](std::vector<event> const& events) {
+    [=](const std::vector<event>& events) {
       VAST_TRACE(self, "got", events.size(), "events");
       for (auto& e : events) {
         VAST_ASSERT(e.id() != invalid_event_id);
@@ -86,7 +86,7 @@ behavior value_indexer(stateful_actor<value_indexer_state>* self,
         }
       }
     },
-    [=](predicate const& pred) -> result<bitmap> {
+    [=](const predicate& pred) -> result<bitmap> {
       VAST_TRACE(self, "got predicate:", pred);
       return self->state.idx->lookup(pred.op, get<data>(pred.rhs));
     },
@@ -127,24 +127,24 @@ behavior value_indexer(stateful_actor<value_indexer_state>* self,
 // only with a specific aspect of an event.
 
 behavior time_indexer(stateful_actor<value_indexer_state>* self,
-                      path const& p) {
+                      const path& p) {
   // TODO: add type attributes to tune index, e.g., for seconds granularity.
   auto t = timestamp_type{};
-  auto extract = [](event const& e) { return optional<data>{e.timestamp()}; };
+  auto extract = [](const event& e) { return optional<data>{e.timestamp()}; };
   return value_indexer(self, p, t, extract);
 }
 
 behavior type_indexer(stateful_actor<value_indexer_state>* self,
-                      path const& p) {
+                      const path& p) {
   auto t = string_type{};
-  auto extract = [](event const& e) { return optional<data>{e.type().name()}; };
+  auto extract = [](const event& e) { return optional<data>{e.type().name()}; };
   return value_indexer(self, p, t, extract);
 }
 
 // Indexes the data from non-record event type.
 behavior flat_data_indexer(stateful_actor<value_indexer_state>* self,
                            path dir, type event_type) {
-  auto extract = [=](event const& e) -> optional<data const&> {
+  auto extract = [=](const event& e) -> optional<const data&> {
     if (e.type() != event_type)
       return {};
     return e.data();
@@ -156,7 +156,7 @@ behavior flat_data_indexer(stateful_actor<value_indexer_state>* self,
 behavior field_data_indexer(stateful_actor<value_indexer_state>* self,
                             path dir, type event_type, type value_type,
                             offset off) {
-  auto extract = [=](event const& e) -> optional<data const&> {
+  auto extract = [=](const event& e) -> optional<const data&> {
     if (e.type() != event_type)
       return {};
     auto v = get_if<vector>(e.data());
@@ -173,7 +173,7 @@ behavior field_data_indexer(stateful_actor<value_indexer_state>* self,
 }
 
 // Tests whether a type has a "skip" attribute.
-bool skip(type const& t) {
+bool skip(const type& t) {
   auto& attrs = t.attributes();
   auto pred = [](auto& x) { return x.key == "skip"; };
   return std::find_if(attrs.begin(), attrs.end(), pred) != attrs.end();
@@ -184,16 +184,16 @@ struct loader {
   using result_type = std::vector<actor>;
 
   template <class T>
-  result_type operator()(T const&) {
+  result_type operator()(const T&) {
     return {};
   }
 
   template <class T, class U>
-  result_type operator()(T const&, U const&) {
+  result_type operator()(const T&, const U&) {
     return {};
   }
 
-  result_type operator()(disjunction const& d) {
+  result_type operator()(const disjunction& d) {
     result_type result;
     for (auto& op : d) {
       auto x = visit(*this, op);
@@ -204,11 +204,11 @@ struct loader {
     return result;
   }
 
-  result_type operator()(predicate const& p) {
+  result_type operator()(const predicate& p) {
     return visit(*this, p.lhs, p.rhs);
   }
 
-  result_type operator()(attribute_extractor const& ex, data const& x) {
+  result_type operator()(const attribute_extractor& ex, const data& x) {
     result_type result;
     auto p = self->state.dir / "meta";
     if (ex.attr == "time") {
@@ -233,7 +233,7 @@ struct loader {
     return result;
   }
 
-  result_type operator()(data_extractor const& dx, data const&) {
+  result_type operator()(const data_extractor& dx, const data&) {
     result_type result;
     if (dx.offset.empty()) {
       auto p = self->state.dir / "data";
@@ -324,15 +324,15 @@ behavior event_indexer(stateful_actor<event_indexer_state>* self,
     self->state.indexers.erase(i);
   };
   self->set_down_handler(
-    [=](down_msg const& msg) { remove_indexer(msg.source); }
+    [=](const down_msg& msg) { remove_indexer(msg.source); }
   );
   return {
-    [=](std::vector<event> const&) {
+    [=](const std::vector<event>&) {
       auto msg = self->current_mailbox_element()->move_content_to_message();
       for (auto& x : self->state.indexers)
         self->send(x.second, msg);
     },
-    [=](predicate const& pred) {
+    [=](const predicate& pred) {
       VAST_DEBUG(self, "got predicate:", pred);
       auto rp = self->make_response_promise<bitmap>();
       // For now, we require that the predicate is part of a normalized
@@ -380,7 +380,7 @@ behavior event_indexer(stateful_actor<event_indexer_state>* self,
         self->send(i.second, shutdown_atom::value);
       // Wait until all indexers have terminated.
       self->set_down_handler(
-        [=](down_msg const& msg) {
+        [=](const down_msg& msg) {
           remove_indexer(msg.source);
           if (self->state.indexers.empty())
             self->quit(exit_reason::user_shutdown);

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -90,7 +90,7 @@ struct bitmap_evaluator {
     return {};
   }
 
-  bitmap operator()(conjunction const& c) const {
+  bitmap operator()(const conjunction& c) const {
     auto bm = visit(*this, c[0]);
     if (bm.empty() || all<0>(bm))
       return {};
@@ -102,7 +102,7 @@ struct bitmap_evaluator {
     return bm;
   }
 
-  bitmap operator()(disjunction const& d) const {
+  bitmap operator()(const disjunction& d) const {
     bitmap bm;
     for (auto& op : d) {
       bm |= visit(*this, op);
@@ -112,13 +112,13 @@ struct bitmap_evaluator {
     return bm;
   }
 
-  bitmap operator()(negation const& n) const {
+  bitmap operator()(const negation& n) const {
     auto bm = visit(*this, n.expr());
     bm.flip();
     return bm;
   }
 
-  bitmap operator()(predicate const& pred) const {
+  bitmap operator()(const predicate& pred) const {
     auto i = bitmaps.find(pred);
     return i != bitmaps.end() ? i->second : bitmap{};
   }
@@ -183,7 +183,7 @@ behavior partition(stateful_actor<partition_state>* self, path dir) {
       self->state.indexers.emplace(x.second, actor{});
   }
   return {
-    [=](std::vector<event> const& events) {
+    [=](const std::vector<event>& events) {
       VAST_ASSERT(!events.empty());
       VAST_DEBUG(self, "got", events.size(), "events");
       // Locate relevant indexers.
@@ -201,7 +201,7 @@ behavior partition(stateful_actor<partition_state>* self, path dir) {
       for (auto& indexer : indexers)
         self->send(indexer, msg);
     },
-    [=](expression const& expr) {
+    [=](const expression& expr) {
       VAST_DEBUG(self, "got expression:", expr);
       auto start = steady_clock::now();
       auto rp = self->make_response_promise<bitmap>();

--- a/libvast/src/system/task.cpp
+++ b/libvast/src/system/task.cpp
@@ -38,7 +38,7 @@ void notify(Actor self) {
 };
 
 template <class Actor>
-void complete(Actor self, actor_addr const& a) {
+void complete(Actor self, const actor_addr& a) {
   auto w = self->state.workers.find(a);
   if (w == self->state.workers.end()) {
     VAST_ERROR(self, "got completion signal from unknown actor:", a);
@@ -57,32 +57,32 @@ namespace detail {
 behavior task(stateful_actor<task_state>* self, message done_msg) {
   self->state.done_msg = std::move(done_msg);
   self->set_exit_handler(
-    [=](exit_msg const& msg) {
+    [=](const exit_msg& msg) {
       self->state.subscribers.clear();
       notify(self);
       self->quit(msg.reason);
     }
   );
   self->set_down_handler(
-    [=](down_msg const& msg) {
+    [=](const down_msg& msg) {
       if (self->state.workers.erase(msg.source) == 1)
         notify(self);
     }
   );
   return {
-    [=](actor const& a) {
+    [=](const actor& a) {
       VAST_TRACE(self, "registers actor", a);
       self->monitor(a);
       if (++self->state.workers[a.address()] == 1)
         ++self->state.total;
     },
-    [=](actor const& a, uint64_t n) {
+    [=](const actor& a, uint64_t n) {
       VAST_TRACE(self, "registers actor", a, "for", n, "sub-tasks");
       self->monitor(a);
       self->state.workers[a.address()] += n;
       ++self->state.total;
     },
-    [=](done_atom, actor_addr const& addr) {
+    [=](done_atom, const actor_addr& addr) {
       VAST_TRACE(self, "manually completed actor with address", addr);
       complete(self, addr);
     },
@@ -90,11 +90,11 @@ behavior task(stateful_actor<task_state>* self, message done_msg) {
       VAST_TRACE(self, "completed actor", self->current_sender());
       complete(self, actor_cast<actor_addr>(self->current_sender()));
     },
-    [=](supervisor_atom, actor const& a) {
+    [=](supervisor_atom, const actor& a) {
       VAST_TRACE(self, "notifies actor", a, "about task completion");
       self->state.supervisors.insert(a);
     },
-    [=](subscriber_atom, actor const& a) {
+    [=](subscriber_atom, const actor& a) {
       VAST_TRACE(self, "notifies actor", a, "on task status change");
       self->state.subscribers.insert(a);
     },

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -33,7 +33,7 @@ type& type::name(std::string str) {
   return *this;
 }
 
-std::string const& type::name() const {
+const std::string& type::name() const {
   return *visit([](auto& x) { return &x.name(); }, *this);
 }
 
@@ -41,7 +41,7 @@ std::vector<attribute>& type::attributes() {
   return *visit([](auto& x) { return &x.attributes(); }, *this);
 }
 
-std::vector<attribute> const& type::attributes() const {
+const std::vector<attribute>& type::attributes() const {
   return *visit([](auto& x) { return &x.attributes(); }, *this);
 }
 
@@ -54,24 +54,24 @@ namespace {
 
 struct equal_to {
   template <class T, class U>
-  bool operator()(T const&, U const&) const noexcept {
+  bool operator()(const T&, const U&) const noexcept {
     return false;
   }
 
   template <class T>
-  bool operator()(T const& x, T const& y) const noexcept {
+  bool operator()(const T& x, const T& y) const noexcept {
     return x == y;
   }
 };
 
 struct less_than {
   template <class T, class U>
-  bool operator()(T const&, U const&) const noexcept {
+  bool operator()(const T&, const U&) const noexcept {
     return false;
   }
 
   template <class T>
-  bool operator()(T const& x, T const& y) const noexcept {
+  bool operator()(const T& x, const T& y) const noexcept {
     return x < y;
   }
 };
@@ -174,7 +174,7 @@ size_t record_type::each::range_state::depth() const {
   return trace.size();
 }
 
-record_type::each::each(record_type const& r) {
+record_type::each::each(const record_type& r) {
   if (r.fields.empty())
     return;
   auto rec = &r;
@@ -207,11 +207,11 @@ bool record_type::each::done() const {
   return records_.empty();
 }
 
-record_type::each::range_state const& record_type::each::get() const {
+const record_type::each::range_state& record_type::each::get() const {
   return state_;
 }
 
-expected<offset> record_type::resolve(key const& k) const {
+expected<offset> record_type::resolve(const key& k) const {
   if (k.empty())
     return make_error(ec::unspecified, "empty symbol sequence");
   offset off;
@@ -238,7 +238,7 @@ expected<offset> record_type::resolve(key const& k) const {
   return off;
 }
 
-expected<key> record_type::resolve(offset const& o) const {
+expected<key> record_type::resolve(const offset& o) const {
   if (o.empty())
     return make_error(ec::unspecified, "empty offset sequence");
   key k;
@@ -262,7 +262,7 @@ namespace {
 struct finder {
   enum mode { prefix, suffix, exact, any };
 
-  finder(key  k, mode m, std::string const& init = "")
+  finder(key  k, mode m, const std::string& init = "")
     : mode_{m}, key_{std::move(k)} {
     VAST_ASSERT(!key_.empty());
     if (!init.empty())
@@ -270,7 +270,7 @@ struct finder {
   }
 
   template <typename T>
-  std::vector<std::pair<offset, key>> operator()(T const&) const {
+  std::vector<std::pair<offset, key>> operator()(const T&) const {
     std::vector<std::pair<offset, key>> r;
     if (off_.empty() || key_.size() > trace_.size())
       return r;
@@ -301,7 +301,7 @@ struct finder {
     return r;
   }
 
-  std::vector<std::pair<offset, key>> operator()(record_type const& r) {
+  std::vector<std::pair<offset, key>> operator()(const record_type& r) {
     std::vector<std::pair<offset, key>> result;
     off_.push_back(0);
     for (auto& f : r.fields) {
@@ -315,7 +315,7 @@ struct finder {
     return result;
   }
 
-  static bool match(std::string const& key, std::string const& trace) {
+  static bool match(const std::string& key, const std::string& trace) {
     return pattern::glob(key).match(trace);
   }
 
@@ -327,21 +327,21 @@ struct finder {
 
 } // namespace <anonymous>
 
-std::vector<std::pair<offset, key>> record_type::find(key const& k) const {
+std::vector<std::pair<offset, key>> record_type::find(const key& k) const {
   return finder{k, finder::exact, name()}(*this);
 }
 
 std::vector<std::pair<offset, key>>
-record_type::find_prefix(key const& k) const {
+record_type::find_prefix(const key& k) const {
   return finder{k, finder::prefix, name()}(*this);
 }
 
 std::vector<std::pair<offset, key>>
-record_type::find_suffix(key const& k) const {
+record_type::find_suffix(const key& k) const {
   return finder{k, finder::suffix, name()}(*this);
 }
 
-type const* record_type::at(key const& k) const {
+type const* record_type::at(const key& k) const {
   auto r = this;
   for (size_t i = 0; i < k.size(); ++i) {
     auto& id = k[i];
@@ -362,7 +362,7 @@ type const* record_type::at(key const& k) const {
   return nullptr;
 }
 
-type const* record_type::at(offset const& o) const {
+type const* record_type::at(const offset& o) const {
   auto r = this;
   for (size_t i = 0; i < o.size(); ++i) {
     auto& idx = o[i];
@@ -378,7 +378,7 @@ type const* record_type::at(offset const& o) const {
   return nullptr;
 }
 
-record_type flatten(record_type const& rec) {
+record_type flatten(const record_type& rec) {
   record_type result;
   for (auto& outer : rec.fields)
     if (auto r = get_if<record_type>(outer.type)) {
@@ -391,12 +391,12 @@ record_type flatten(record_type const& rec) {
   return result;
 }
 
-type flatten(type const& t) {
+type flatten(const type& t) {
   auto r = get_if<record_type>(t);
   return r ? flatten(*r) : t;
 }
 
-record_type unflatten(record_type const& rec) {
+record_type unflatten(const record_type& rec) {
   record_type result;
   for (auto& f : rec.fields) {
     auto names = detail::to_strings(detail::split(f.name, "."));
@@ -426,7 +426,7 @@ record_type unflatten(record_type const& rec) {
   return result;
 }
 
-type unflatten(type const& t) {
+type unflatten(const type& t) {
   auto r = get_if<record_type>(t);
   return r ? unflatten(*r) : t;
 }
@@ -471,48 +471,48 @@ namespace {
 
 struct type_congruence_checker {
   template <typename T>
-  bool operator()(T const&, T const&) const {
+  bool operator()(const T&, const T&) const {
     return true;
   }
 
   template <typename T, typename U>
-  bool operator()(T const&, U const&) const {
+  bool operator()(const T&, const U&) const {
     return false;
   }
 
   template <typename T>
-  bool operator()(T const& x, alias_type const& a) const {
+  bool operator()(const T& x, const alias_type& a) const {
     using namespace std::placeholders;
     return visit(std::bind(std::cref(*this), std::cref(x), _1), a.value_type);
   }
 
   template <typename T>
-  bool operator()(alias_type const& a, T const& x) const {
+  bool operator()(const alias_type& a, const T& x) const {
     return (*this)(x, a);
   }
 
-  bool operator()(alias_type const& x, alias_type const& y) const {
+  bool operator()(const alias_type& x, const alias_type& y) const {
     return visit(*this, x.value_type, y.value_type);
   }
 
-  bool operator()(enumeration_type const& x, enumeration_type const& y) const {
+  bool operator()(const enumeration_type& x, const enumeration_type& y) const {
     return x.fields.size() == y.fields.size();
   }
 
-  bool operator()(vector_type const& x, vector_type const& y) const {
+  bool operator()(const vector_type& x, const vector_type& y) const {
     return visit(*this, x.value_type, y.value_type);
   }
 
-  bool operator()(set_type const& x, set_type const& y) const {
+  bool operator()(const set_type& x, const set_type& y) const {
     return visit(*this, x.value_type, y.value_type);
   }
 
-  bool operator()(table_type const& x, table_type const& y) const {
+  bool operator()(const table_type& x, const table_type& y) const {
     return visit(*this, x.key_type, y.key_type) &&
         visit(*this, x.value_type, y.value_type);
   }
 
-  bool operator()(record_type const& x, record_type const& y) const {
+  bool operator()(const record_type& x, const record_type& y) const {
     if (x.fields.size() != y.fields.size())
       return false;
     for (size_t i = 0; i < x.fields.size(); ++i)
@@ -524,75 +524,75 @@ struct type_congruence_checker {
 
 struct data_congruence_checker {
   template <typename T, typename U>
-  bool operator()(T const&, U const&) const {
+  bool operator()(const T&, const U&) const {
     return false;
   }
 
-  bool operator()(none_type const&, none) const {
+  bool operator()(const none_type&, none) const {
     return true;
   }
 
-  bool operator()(boolean_type const&, boolean) const {
+  bool operator()(const boolean_type&, boolean) const {
     return true;
   }
 
-  bool operator()(integer_type const&, integer) const {
+  bool operator()(const integer_type&, integer) const {
     return true;
   }
 
-  bool operator()(count_type const&, count) const {
+  bool operator()(const count_type&, count) const {
     return true;
   }
 
-  bool operator()(real_type const&, real) const {
+  bool operator()(const real_type&, real) const {
     return true;
   }
 
-  bool operator()(timespan_type const&, timespan) const {
+  bool operator()(const timespan_type&, timespan) const {
     return true;
   }
 
-  bool operator()(timestamp_type const&, timestamp) const {
+  bool operator()(const timestamp_type&, timestamp) const {
     return true;
   }
 
-  bool operator()(string_type const&, std::string const&) const {
+  bool operator()(const string_type&, const std::string&) const {
     return true;
   }
 
-  bool operator()(pattern_type const&, pattern const&) const {
+  bool operator()(const pattern_type&, const pattern&) const {
     return true;
   }
 
-  bool operator()(address_type const&, address const&) const {
+  bool operator()(const address_type&, const address&) const {
     return true;
   }
 
-  bool operator()(subnet_type const&, subnet const&) const {
+  bool operator()(const subnet_type&, const subnet&) const {
     return true;
   }
 
-  bool operator()(port_type const&, port const&) const {
+  bool operator()(const port_type&, const port&) const {
     return true;
   }
 
-  bool operator()(enumeration_type const& x, std::string const& y) const {
+  bool operator()(const enumeration_type& x, const std::string& y) const {
     return std::find(x.fields.begin(), x.fields.end(), y) != x.fields.end();
   }
 
-  bool operator()(vector_type const&, vector const&) const {
+  bool operator()(const vector_type&, const vector&) const {
     return true;
   }
 
-  bool operator()(set_type const&, set const&) const {
+  bool operator()(const set_type&, const set&) const {
     return true;
   }
 
-  bool operator()(table_type const&, table const&) const {
+  bool operator()(const table_type&, const table&) const {
     return true;
   }
 
-  bool operator()(record_type const& x, vector const& y) const {
+  bool operator()(const record_type& x, const vector& y) const {
     if (x.fields.size() != y.size())
       return false;
     for (size_t i = 0; i < x.fields.size(); ++i)
@@ -602,7 +602,7 @@ struct data_congruence_checker {
   }
 
   template <typename T>
-  bool operator()(alias_type const& t, T const& x) const {
+  bool operator()(const alias_type& t, const T& x) const {
     using namespace std::placeholders;
     return visit(std::bind(std::cref(*this), _1, std::cref(x)), t.value_type);
   }
@@ -610,19 +610,19 @@ struct data_congruence_checker {
 
 } // namespace <anonymous>
 
-bool congruent(type const& x, type const& y) {
+bool congruent(const type& x, const type& y) {
   return visit(type_congruence_checker{}, x, y);
 }
 
-bool congruent(type const& x, data const& y) {
+bool congruent(const type& x, const data& y) {
   return visit(data_congruence_checker{}, x, y);
 }
 
-bool congruent(data const& x, type const& y) {
+bool congruent(const data& x, const type& y) {
   return visit(data_congruence_checker{}, y, x);
 }
 
-bool compatible(type const& lhs, relational_operator op, type const& rhs) {
+bool compatible(const type& lhs, relational_operator op, const type& rhs) {
   switch (op) {
     default:
       return false;
@@ -652,7 +652,7 @@ bool compatible(type const& lhs, relational_operator op, type const& rhs) {
   }
 }
 
-bool compatible(type const& lhs, relational_operator op, data const& rhs) {
+bool compatible(const type& lhs, relational_operator op, const data& rhs) {
   switch (op) {
     default:
       return false;
@@ -686,7 +686,7 @@ bool compatible(type const& lhs, relational_operator op, data const& rhs) {
   }
 }
 
-bool compatible(data const& lhs, relational_operator op, type const& rhs) {
+bool compatible(const data& lhs, relational_operator op, const type& rhs) {
   return compatible(rhs, flip(op), lhs);
 }
 
@@ -717,19 +717,19 @@ VAST_SPECIALIZE_DATA_TO_TYPE(port, port_type)
 #undef VAST_SPECIALIZE_DATA_TO_TYPE
 
 struct data_checker {
-  data_checker(type const& t) : type_{t} { }
+  data_checker(const type& t) : type_{t} { }
 
   template <typename T>
-  bool operator()(T const&) const {
+  bool operator()(const T&) const {
     return is<typename data_to_type<T>::type>(type_);
   }
 
-  bool operator()(enumeration const& e) const {
+  bool operator()(const enumeration& e) const {
     auto t = get_if<enumeration_type>(type_);
     return t && e < t->fields.size();
   }
 
-  bool operator()(vector const& v) const {
+  bool operator()(const vector& v) const {
     auto r = get_if<record_type>(type_);
     if (r) {
       if (r->fields.size() != v.size())
@@ -745,14 +745,14 @@ struct data_checker {
     return t && type_check(t->value_type, v[0]);
   }
 
-  bool operator()(set const& s) const {
+  bool operator()(const set& s) const {
     if (s.empty())
       return true;
     auto t = get_if<set_type>(type_);
     return t && type_check(t->value_type, *s.begin());
   }
 
-  bool operator()(table const& x) const {
+  bool operator()(const table& x) const {
     if (x.empty())
       return true;
     auto t = get_if<table_type>(type_);
@@ -762,12 +762,12 @@ struct data_checker {
       type_check(t->value_type, x.begin()->second);
   }
 
-  type const& type_;
+  const type& type_;
 };
 
 } // namespace <anonymous>
 
-bool type_check(type const& t, data const& d) {
+bool type_check(const type& t, const data& d) {
   return is<none>(d) || visit(data_checker{t}, d);
 }
 
@@ -779,25 +779,25 @@ struct default_constructor {
   }
 
   template <typename T>
-  data operator()(T const&) const {
+  data operator()(const T&) const {
     return type_to_data<T>{};
   }
 
-  data operator()(record_type const& r) const {
+  data operator()(const record_type& r) const {
     vector v;
     for (auto& f : r.fields)
       v.push_back(visit(*this, f.type));
     return v;
   }
 
-  data operator()(alias_type const& a) const {
+  data operator()(const alias_type& a) const {
     return construct(a.value_type);
   }
 };
 
 } // namespace <anonymous>
 
-data construct(type const& t) {
+data construct(const type& t) {
   return visit(default_constructor{}, t);
 }
 
@@ -806,75 +806,75 @@ namespace {
 struct kind_printer {
   using result_type = std::string;
 
-  result_type operator()(none_type const&) const {
+  result_type operator()(const none_type&) const {
     return "none";
   }
 
-  result_type operator()(boolean_type const&) const {
+  result_type operator()(const boolean_type&) const {
     return "bool";
   }
 
-  result_type operator()(integer_type const&) const {
+  result_type operator()(const integer_type&) const {
     return "integer";
   }
 
-  result_type operator()(count_type const&) const {
+  result_type operator()(const count_type&) const {
     return "count";
   }
 
-  result_type operator()(real_type const&) const {
+  result_type operator()(const real_type&) const {
     return "real";
   }
 
-  result_type operator()(timespan_type const&) const {
+  result_type operator()(const timespan_type&) const {
     return "timespan";
   }
 
-  result_type operator()(timestamp_type const&) const {
+  result_type operator()(const timestamp_type&) const {
     return "timestamp";
   }
 
-  result_type operator()(string_type const&) const {
+  result_type operator()(const string_type&) const {
     return "string";
   }
 
-  result_type operator()(pattern_type const&) const {
+  result_type operator()(const pattern_type&) const {
     return "pattern";
   }
 
-  result_type operator()(address_type const&) const {
+  result_type operator()(const address_type&) const {
     return "address";
   }
 
-  result_type operator()(subnet_type const&) const {
+  result_type operator()(const subnet_type&) const {
     return "subnet";
   }
 
-  result_type operator()(port_type const&) const {
+  result_type operator()(const port_type&) const {
     return "port";
   }
 
-  result_type operator()(enumeration_type const&) const {
+  result_type operator()(const enumeration_type&) const {
     return "enumeration";
   }
 
-  result_type operator()(vector_type const&) const {
+  result_type operator()(const vector_type&) const {
     return "vector";
   }
 
-  result_type operator()(set_type const&) const {
+  result_type operator()(const set_type&) const {
     return "set";
   }
 
-  result_type operator()(table_type const&) const {
+  result_type operator()(const table_type&) const {
     return "table";
   }
 
-  result_type operator()(record_type const&) const {
+  result_type operator()(const record_type&) const {
     return "record";
   }
 
-  result_type operator()(alias_type const&) const {
+  result_type operator()(const alias_type&) const {
     return "alias";
   }
 };
@@ -883,12 +883,12 @@ struct jsonizer {
   jsonizer(json& j) : json_{j} { }
 
   template <typename T>
-  bool operator()(T const&) {
+  bool operator()(const T&) {
     json_ = {};
     return true;
   }
 
-  bool operator()(enumeration_type const& e) {
+  bool operator()(const enumeration_type& e) {
     json::array a;
     std::transform(e.fields.begin(),
                    e.fields.end(),
@@ -898,7 +898,7 @@ struct jsonizer {
     return true;
   }
 
-  bool operator()(vector_type const& v) {
+  bool operator()(const vector_type& v) {
     json::object o;
     if (!convert(v.value_type, o["value_type"]))
       return false;
@@ -906,7 +906,7 @@ struct jsonizer {
     return true;
   }
 
-  bool operator()(set_type const& s) {
+  bool operator()(const set_type& s) {
     json::object o;
     if (!convert(s.value_type, o["value_type"]))
       return false;
@@ -914,7 +914,7 @@ struct jsonizer {
     return true;
   }
 
-  bool operator()(table_type const& t) {
+  bool operator()(const table_type& t) {
     json::object o;
     if (!convert(t.key_type, o["key"]))
       return false;
@@ -924,7 +924,7 @@ struct jsonizer {
     return true;
   }
 
-  bool operator()(record_type const& r) {
+  bool operator()(const record_type& r) {
     json::object o;
     for (auto& field : r.fields)
       if (!convert(field.type, o[to_string(field.name)]))
@@ -933,7 +933,7 @@ struct jsonizer {
     return true;
   }
 
-  bool operator()(alias_type const& a) {
+  bool operator()(const alias_type& a) {
     return convert(a.value_type, json_);
   }
 
@@ -942,7 +942,7 @@ struct jsonizer {
 
 } // namespace <anonymous>
 
-bool convert(type const& t, json& j) {
+bool convert(const type& t, json& j) {
   json::object o;
   o["name"] = t.name();
   o["kind"] = visit(kind_printer{}, t);

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -341,11 +341,11 @@ record_type::find_suffix(const key& k) const {
   return finder{k, finder::suffix, name()}(*this);
 }
 
-type const* record_type::at(const key& k) const {
+const type* record_type::at(const key& k) const {
   auto r = this;
   for (size_t i = 0; i < k.size(); ++i) {
     auto& id = k[i];
-    record_field const* f = nullptr;
+    const record_field* f = nullptr;
     for (auto& a : r->fields)
       if (a.name == id) {
         f = &a;
@@ -362,7 +362,7 @@ type const* record_type::at(const key& k) const {
   return nullptr;
 }
 
-type const* record_type::at(const offset& o) const {
+const type* record_type::at(const offset& o) const {
   auto r = this;
   for (size_t i = 0; i < o.size(); ++i) {
     auto& idx = o[i];

--- a/libvast/src/uuid.cpp
+++ b/libvast/src/uuid.cpp
@@ -98,11 +98,11 @@ void uuid::swap(uuid& other) {
   std::swap_ranges(begin(), end(), other.begin());
 }
 
-bool operator==(uuid const& x, uuid const& y) {
+bool operator==(const uuid& x, const uuid& y) {
   return std::equal(x.begin(), x.end(), y.begin());
 }
 
-bool operator<(uuid const& x, uuid const& y) {
+bool operator<(const uuid& x, const uuid& y) {
   return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
 }
 

--- a/libvast/src/value.cpp
+++ b/libvast/src/value.cpp
@@ -16,46 +16,46 @@
 
 namespace vast {
 
-bool value::type(vast::type const& t) {
+bool value::type(const vast::type& t) {
   if (!type_check(t, data_))
     return false;
   type_ = t;
   return true;
 }
 
-type const& value::type() const {
+const type& value::type() const {
   return type_;
 }
 
-vast::data const& value::data() const {
+const vast::data& value::data() const {
   return data_;
 }
 
-value flatten(value const& v) {
+value flatten(const value& v) {
   return {flatten(v.data()), flatten(v.type())};
 }
 
-bool operator==(value const& lhs, value const& rhs) {
+bool operator==(const value& lhs, const value& rhs) {
   return lhs.data_ == rhs.data_;
 }
 
-bool operator!=(value const& lhs, value const& rhs) {
+bool operator!=(const value& lhs, const value& rhs) {
   return lhs.data_ != rhs.data_;
 }
 
-bool operator<(value const& lhs, value const& rhs) {
+bool operator<(const value& lhs, const value& rhs) {
   return lhs.data_ < rhs.data_;
 }
 
-bool operator<=(value const& lhs, value const& rhs) {
+bool operator<=(const value& lhs, const value& rhs) {
   return lhs.data_ <= rhs.data_;
 }
 
-bool operator>=(value const& lhs, value const& rhs) {
+bool operator>=(const value& lhs, const value& rhs) {
   return lhs.data_ >= rhs.data_;
 }
 
-bool operator>(value const& lhs, value const& rhs) {
+bool operator>(const value& lhs, const value& rhs) {
   return lhs.data_ > rhs.data_;
 }
 
@@ -63,7 +63,7 @@ detail::data_variant& expose(value& v) {
   return expose(v.data_);
 }
 
-bool convert(value const& v, json& j) {
+bool convert(const value& v, json& j) {
   json::object o;
   if (!convert(v.type(), o["type"]))
     return false;

--- a/libvast/src/wah_bitmap.cpp
+++ b/libvast/src/wah_bitmap.cpp
@@ -30,7 +30,7 @@ wah_bitmap::size_type wah_bitmap::size() const {
   return num_bits_;
 }
 
-wah_bitmap::block_vector const& wah_bitmap::blocks() const {
+const wah_bitmap::block_vector& wah_bitmap::blocks() const {
   return blocks_;
 }
 
@@ -167,11 +167,11 @@ void wah_bitmap::merge_active_word() {
   }
 }
 
-bool operator==(wah_bitmap const& x, wah_bitmap const& y) {
+bool operator==(const wah_bitmap& x, const wah_bitmap& y) {
   return x.blocks_ == y.blocks_ && x.num_bits_ == y.num_bits_;
 }
 
-wah_bitmap_range::wah_bitmap_range(wah_bitmap const& bm)
+wah_bitmap_range::wah_bitmap_range(const wah_bitmap& bm)
   : bm_{&bm},
     begin_{bm.blocks_.begin()},
     end_{bm.blocks_.end()} {
@@ -204,7 +204,7 @@ void wah_bitmap_range::scan() {
   }
 }
 
-wah_bitmap_range bit_range(wah_bitmap const& bm) {
+wah_bitmap_range bit_range(const wah_bitmap& bm) {
   return wah_bitmap_range{bm};
 }
 

--- a/libvast/test/address.cpp
+++ b/libvast/test/address.cpp
@@ -97,12 +97,12 @@ TEST(IPv6) {
 
   uint8_t raw8[16] = {0xdf, 0x00, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
                       0x02, 0x02, 0xb3, 0xff, 0xfe, 0x1e, 0x83, 0x28};
-  auto p = reinterpret_cast<uint32_t const*>(raw8);
+  auto p = reinterpret_cast<const uint32_t*>(raw8);
   address e(p, address::ipv6, address::network);
   CHECK(e == (a ^ d));
 
   uint32_t raw32[4] = {0xdf000db8, 0x00000000, 0x0202b3ff, 0xfe1e8328};
-  p = reinterpret_cast<uint32_t const*>(raw32);
+  p = reinterpret_cast<const uint32_t*>(raw32);
   address f(p, address::ipv6, address::host);
   CHECK(f == (a ^ d));
   CHECK(f == e);

--- a/libvast/test/bitmap.cpp
+++ b/libvast/test/bitmap.cpp
@@ -436,7 +436,7 @@ ewah_bitmap make_ewah3() {
   return bm;
 }
 
-std::string to_block_string(ewah_bitmap const& bm) {
+std::string to_block_string(const ewah_bitmap& bm) {
   using word_type = ewah_bitmap::word_type;
   std::string str;
   if (bm.blocks().empty())

--- a/libvast/test/expression_evaluation.cpp
+++ b/libvast/test/expression_evaluation.cpp
@@ -58,8 +58,8 @@ struct fixture {
   }
 
   schema sch;
-  type const* foo;
-  type const* bar;
+  const type* foo;
+  const type* bar;
   event e;
   event e0;
   event e1;

--- a/libvast/test/fixtures/actor_system.hpp
+++ b/libvast/test/fixtures/actor_system.hpp
@@ -70,7 +70,7 @@ struct actor_system : filesystem {
   }
 
   auto error_handler() {
-    return [&](caf::error const& e) { FAIL(system.render(e)); };
+    return [&](const caf::error& e) { FAIL(system.render(e)); };
   }
 
   configuration config;

--- a/libvast/test/fixtures/events.hpp
+++ b/libvast/test/fixtures/events.hpp
@@ -37,7 +37,7 @@ struct events {
 
 private:
   template <class Reader>
-  static std::vector<event> inhale(char const* filename) {
+  static std::vector<event> inhale(const char* filename) {
     auto input = std::make_unique<std::ifstream>(filename);
     Reader reader{std::move(input)};
     return extract(reader);

--- a/libvast/test/format/bro.cpp
+++ b/libvast/test/format/bro.cpp
@@ -26,7 +26,7 @@ using namespace std::string_literals;
 namespace {
 
 template <class Attribute>
-bool bro_parse(type const& t, std::string const& s, Attribute& attr) {
+bool bro_parse(const type& t, const std::string& s, Attribute& attr) {
   return format::bro::make_bro_parser<std::string::const_iterator>(t)(s, attr);
 }
 

--- a/libvast/test/format/writer.cpp
+++ b/libvast/test/format/writer.cpp
@@ -39,7 +39,7 @@ auto first_ascii_bgpdump_txt_line = R"__(bgpdump::state_change [19482|2014-08-21
 auto first_json_bgpdump_txt_line = R"__({"id": 19482, "timestamp": 1408579214000000000, "value": {"type": {"name": "bgpdump::state_change", "kind": "record", "structure": {"timestamp": {"name": "", "kind": "timestamp", "structure": null, "attributes": {}}, "source_ip": {"name": "", "kind": "address", "structure": null, "attributes": {}}, "source_as": {"name": "", "kind": "count", "structure": null, "attributes": {}}, "old_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}, "new_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}}, "attributes": {}}, "data": {"timestamp": 1408579214000000000, "source_ip": "2a02:20c8:1f:1::4", "source_as": 50304, "old_state": "3", "new_state": "2"}}})__";
 
 template <class Writer>
-std::vector<std::string> generate(std::vector<event> const& xs) {
+std::vector<std::string> generate(const std::vector<event>& xs) {
   std::string str;
   auto sb = new caf::containerbuf<std::string>{str};
   auto out = std::make_unique<std::ostream>(sb);

--- a/libvast/test/iterator.cpp
+++ b/libvast/test/iterator.cpp
@@ -44,7 +44,7 @@ private:
     i_ += n;
   }
 
-  auto distance_to(iterator const& other) const {
+  auto distance_to(const iterator& other) const {
     using distance = std::ptrdiff_t;
     return static_cast<distance>(other.i_) - static_cast<distance>(i_);
   }
@@ -53,7 +53,7 @@ private:
     return *(array_ + i_);
   }
 
-  bool equals(iterator const& other) const {
+  bool equals(const iterator& other) const {
     return i_ == other.i_;
   }
 

--- a/libvast/test/system/indexer.cpp
+++ b/libvast/test/system/indexer.cpp
@@ -49,7 +49,7 @@ TEST(indexer) {
     error_handler()
   );
   CHECK_EQUAL(rank(result), 53u);
-  auto check_uid = [](event const& e, std::string const& uid) {
+  auto check_uid = [](const event& e, const std::string& uid) {
     auto& v = get<vector>(e.data());
     return v[1] == uid;
   };

--- a/libvast/test/system/source.cpp
+++ b/libvast/test/system/source.cpp
@@ -34,12 +34,12 @@ TEST(Bro source) {
   self->monitor(src);
   self->send(src, sink_atom::value, self);
   self->send(src, run_atom::value);
-  self->receive([&](std::vector<event> const& events) {
+  self->receive([&](const std::vector<event>& events) {
     CHECK_EQUAL(events.size(), 8462u);
     CHECK_EQUAL(events[0].type().name(), "bro::conn");
   });
   // A source terminates normally after having consumed the entire input.
-  self->receive([&](caf::down_msg const& msg) {
+  self->receive([&](const caf::down_msg& msg) {
     CHECK(msg.reason == caf::exit_reason::normal);
   });
 }

--- a/libvast/test/system/task.cpp
+++ b/libvast/test/system/task.cpp
@@ -27,7 +27,7 @@ FIXTURE_SCOPE(task_tests, fixtures::actor_system)
 
 namespace {
 
-behavior worker(event_based_actor* self, actor const& task) {
+behavior worker(event_based_actor* self, const actor& task) {
   return [=](std::string) {
     self->send(task, done_atom::value);
     self->quit();

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -288,7 +288,7 @@ TEST(congruence) {
   CHECK(s0 != s1);
   CHECK(s0 != s2);
   CHECK(congruent(s0, s1));
-  CHECK(! congruent(s1, s2));
+  CHECK(!congruent(s1, s2));
   MESSAGE("records");
   auto r0 = record_type{
     {"a", address_type{}},

--- a/libvast/test/variant.cpp
+++ b/libvast/test/variant.cpp
@@ -50,24 +50,24 @@ struct referencer {
 
 struct binary {
   template <typename T>
-  bool operator()(T const&, T const&) const {
+  bool operator()(const T&, const T&) const {
     return true;
   }
 
   template <typename T, typename U>
-  bool operator()(T const&, U const&) const {
+  bool operator()(const T&, const U&) const {
     return false;
   }
 };
 
 struct ternary {
   template <typename T, typename U>
-  double operator()(bool c, T const& t, U const& f) const {
+  double operator()(bool c, const T& t, const U& f) const {
     return c ? t : f;
   }
 
   template <typename T, typename U, typename V>
-  double operator()(T const&, U const&, V const&) const {
+  double operator()(const T&, const U&, const V&) const {
     return 42;
   }
 };

--- a/libvast/vast/address.hpp
+++ b/libvast/vast/address.hpp
@@ -87,21 +87,21 @@ public:
   /// AND's another address to this instance.
   /// @param other The other address.
   /// @returns A reference to `*this`.
-  address& operator&=(address const& other);
+  address& operator&=(const address& other);
 
   /// OR's another address to this instance.
   /// @param other The other address.
   /// @returns A reference to `*this`.
-  address& operator|=(address const& other);
+  address& operator|=(const address& other);
 
   /// XOR's another address to this instance.
   /// @param other The other address.
   /// @returns A reference to `*this`.
-  address& operator^=(address const& other);
+  address& operator^=(const address& other);
 
   /// Retrieves the underlying byte array.
   /// @returns A reference to an array of 16 bytes.
-  std::array<uint8_t, 16> const& data() const;
+  const std::array<uint8_t, 16>& data() const;
 
   /// Compares the top-k bits of this address with another one.
   /// @param other The other address.
@@ -110,15 +110,15 @@ public:
   /// @pre `k > 0 && k <= 128`
   bool compare(const address& other, size_t k) const;
 
-  friend bool operator==(address const& x, address const& y);
-  friend bool operator<(address const& x, address const& y);
+  friend bool operator==(const address& x, const address& y);
+  friend bool operator<(const address& x, const address& y);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, address& a) {
     return f(a.bytes_);
   }
 
-  friend bool convert(address const& a, json& j);
+  friend bool convert(const address& a, json& j);
 
 private:
   std::array<uint8_t, 16> bytes_;

--- a/libvast/vast/attribute.hpp
+++ b/libvast/vast/attribute.hpp
@@ -29,8 +29,8 @@ struct attribute : detail::totally_ordered<attribute> {
   std::string key;
   optional<std::string> value;
 
-  friend bool operator==(attribute const& x, attribute const& y);
-  friend bool operator<(attribute const& x, attribute const& y);
+  friend bool operator==(const attribute& x, const attribute& y);
+  friend bool operator<(const attribute& x, const attribute& y);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, attribute& a) {

--- a/libvast/vast/batch.hpp
+++ b/libvast/vast/batch.hpp
@@ -75,7 +75,7 @@ public:
   }
 
   // TODO: make this a generic concept that leverages the inspection API.
-  friend uint64_t bytes(batch const&);
+  friend uint64_t bytes(const batch&);
 
 private:
   compression method_;
@@ -94,7 +94,7 @@ public:
 
   /// Writes an event into the batch.
   /// @param e The event to serialize.
-  bool write(event const& e);
+  bool write(const event& e);
 
   /// Constructs a batch from the accumulated events.
   batch seal();
@@ -111,7 +111,7 @@ class batch::reader {
 public:
   /// Constructs a reader from a batch.
   /// @param b The batch to extract objects from.
-  reader(batch const& b);
+  reader(const batch& b);
 
   /// Extracts all events.
   /// @returns The set events in the corresponding batch.
@@ -125,7 +125,7 @@ public:
 private:
   expected<event> materialize();
 
-  buffer_type const& data_;
+  const buffer_type& data_;
   std::unordered_map<uint32_t, type> type_cache_;
   select_range<bitmap_bit_range> id_range_;
   size_type available_;

--- a/libvast/vast/bitmap.hpp
+++ b/libvast/vast/bitmap.hpp
@@ -74,7 +74,7 @@ public:
 
   // -- concepts -------------------------------------------------------------
 
-  friend bool operator==(bitmap const& x, bitmap const& y);
+  friend bool operator==(const bitmap& x, const bitmap& y);
 
   template <class Inspector>
   friend auto inspect(Inspector&f, bitmap& bm) {
@@ -92,7 +92,7 @@ private:
 class bitmap_bit_range
   : public bit_range_base<bitmap_bit_range, bitmap::block_type> {
 public:
-  explicit bitmap_bit_range(bitmap const& bm);
+  explicit bitmap_bit_range(const bitmap& bm);
 
   void next();
   bool done() const;
@@ -107,7 +107,7 @@ private:
   range_variant range_;
 };
 
-bitmap_bit_range bit_range(bitmap const& bm);
+bitmap_bit_range bit_range(const bitmap& bm);
 
 } // namespace vast
 

--- a/libvast/vast/bitmap_algorithms.hpp
+++ b/libvast/vast/bitmap_algorithms.hpp
@@ -61,7 +61,7 @@ using eval_result_type_t = typename eval_result_type<T, U>::type;
 /// according to *op*.
 template <bool FillLHS, bool FillRHS, class LHS, class RHS, class Operation>
 detail::eval_result_type_t<LHS, RHS>
-binary_eval(LHS const& lhs, RHS const& rhs, Operation op) {
+binary_eval(const LHS& lhs, const RHS& rhs, Operation op) {
   using result_type = detail::eval_result_type_t<LHS, RHS>;
   using word_type = typename result_type::word_type;
   static_assert(
@@ -201,31 +201,31 @@ auto nary_eval(Iterator begin, Iterator end, Operation op) {
 }
 
 template <class LHS, class RHS>
-auto binary_and(LHS const& lhs, RHS const& rhs) {
+auto binary_and(const LHS& lhs, const RHS& rhs) {
   auto op = [](auto x, auto y) { return x & y; };
   return binary_eval<false, false>(lhs, rhs, op);
 }
 
 template <class LHS, class RHS>
-auto binary_or(LHS const& lhs, RHS const& rhs) {
+auto binary_or(const LHS& lhs, const RHS& rhs) {
   auto op = [](auto x, auto y) { return x | y; };
   return binary_eval<true, true>(lhs, rhs, op);
 }
 
 template <class LHS, class RHS>
-auto binary_xor(LHS const& lhs, RHS const& rhs) {
+auto binary_xor(const LHS& lhs, const RHS& rhs) {
   auto op = [](auto x, auto y) { return x ^ y; };
   return binary_eval<true, true>(lhs, rhs, op);
 }
 
 template <class LHS, class RHS>
-auto binary_nand(LHS const& lhs, RHS const& rhs) {
+auto binary_nand(const LHS& lhs, const RHS& rhs) {
   auto op = [](auto x, auto y) { return x & ~y; };
   return binary_eval<true, false>(lhs, rhs, op);
 }
 
 template <class LHS, class RHS>
-auto binary_nor(LHS const& lhs, RHS const& rhs) {
+auto binary_nor(const LHS& lhs, const RHS& rhs) {
   auto op = [](auto x, auto y) { return x | ~y; };
   return binary_eval<true, true>(lhs, rhs, op);
 }
@@ -257,7 +257,7 @@ auto nary_xor(Iterator begin, Iterator end) {
 /// @pre `i > 0 && i < bm.size()`
 template <bool Bit = true, class Bitmap>
 typename Bitmap::size_type
-rank(Bitmap const& bm, typename Bitmap::size_type i) {
+rank(const Bitmap& bm, typename Bitmap::size_type i) {
   VAST_ASSERT(i > 0);
   VAST_ASSERT(i < bm.size());
   auto result = typename Bitmap::size_type{0};
@@ -276,7 +276,7 @@ rank(Bitmap const& bm, typename Bitmap::size_type i) {
 /// @param bm The bitmap whose rank to compute.
 /// @returns The population count of *bm*.
 template <bool Bit = true, class Bitmap>
-typename Bitmap::size_type rank(Bitmap const& bm) {
+typename Bitmap::size_type rank(const Bitmap& bm) {
   return bm.empty() ? 0 : rank<Bit>(bm, bm.size() - 1);
 }
 
@@ -289,7 +289,7 @@ typename Bitmap::size_type rank(Bitmap const& bm) {
 /// @relates select_range span
 template <bool Bit = true, class Bitmap>
 typename Bitmap::size_type
-select(Bitmap const& bm, typename Bitmap::size_type i) {
+select(const Bitmap& bm, typename Bitmap::size_type i) {
   VAST_ASSERT(i > 0);
   auto rnk = typename Bitmap::size_type{0};
   auto n = typename Bitmap::size_type{0};
@@ -430,7 +430,7 @@ auto select(const Bitmap& bm) {
 /// @returns The span of *bm*.
 /// @relates select
 template <bool Bit = true, class Bitmap>
-auto span(Bitmap const& bm) {
+auto span(const Bitmap& bm) {
   auto result = std::make_pair(Bitmap::word_type::npos,
                                Bitmap::word_type::npos);
   auto n = typename Bitmap::size_type{0};
@@ -458,7 +458,7 @@ auto span(Bitmap const& bm) {
 /// @param bm The bitmap to test.
 /// @relates all
 template <bool Bit = true, class Bitmap>
-bool any(Bitmap const& bm) {
+bool any(const Bitmap& bm) {
   if constexpr (Bit) {
     for (auto b : bit_range(bm))
       if (b.data())
@@ -483,7 +483,7 @@ bool any(Bitmap const& bm) {
 /// @returns `true` iff all bits in *bm* have value *Bit*.
 /// @relates any
 template <bool Bit = true, class Bitmap>
-auto all(Bitmap const& bm) {
+auto all(const Bitmap& bm) {
   if (bm.empty())
     return false;
   return !any<!Bit>(bm);

--- a/libvast/vast/bitmap_algorithms.hpp
+++ b/libvast/vast/bitmap_algorithms.hpp
@@ -167,14 +167,14 @@ auto nary_eval(Iterator begin, Iterator end, Operation op) {
   // Exposes a pointer to represent either a non-owned bitmap from the input
   // sequence or an intermediary result.
   struct element {
-    explicit element(bitmap_type const* bm) : bitmap{bm} {
+    explicit element(const bitmap_type* bm) : bitmap{bm} {
     }
     explicit element(bitmap_type&& bm)
       : data{std::make_shared<bitmap_type>(std::move(bm))},
         bitmap{data.get()} {
     }
     std::shared_ptr<bitmap_type> data;
-    bitmap_type const* bitmap;
+    const bitmap_type* bitmap;
   };
   auto cmp = [](auto& lhs, auto& rhs) {
     // TODO: instead of using the bitmap size, we should consider whether

--- a/libvast/vast/bitmap_base.hpp
+++ b/libvast/vast/bitmap_base.hpp
@@ -208,7 +208,7 @@ private:
   }
 
   const Derived& derived() const {
-    return *static_cast<Derived const*>(this);
+    return *static_cast<const Derived*>(this);
   }
 };
 

--- a/libvast/vast/bitmap_base.hpp
+++ b/libvast/vast/bitmap_base.hpp
@@ -46,7 +46,7 @@ namespace vast {
 ///
 ///    // Provides a range instance with .begin() and .end() member functions
 ///    // to iterate over the bitmap in terms of sequences of bits.
-///    auto bit_range(bitmap const& bm);
+///    auto bit_range(const bitmap& bm);
 ///
 /// If possible, derived types shall provide an optimized version of the
 /// following operators:
@@ -76,7 +76,7 @@ public:
   /// @param other The other bitmap.
   /// @pre `size() + other.size()` <= max_size`
   template <class Bitmap>
-  void append(Bitmap const& other) {
+  void append(const Bitmap& other) {
     VAST_ASSERT(derived().size() + other.size() <= max_size);
     for (auto bits : bit_range(other))
       if (bits.size() > word_type::width)
@@ -145,31 +145,31 @@ public:
 
   /// Computes the bitwise AND of two bitmaps.
   template <class Rhs = Derived>
-  friend auto operator&(Derived const& lhs, Rhs const& rhs) {
+  friend auto operator&(const Derived& lhs, const Rhs& rhs) {
     return binary_and(lhs, rhs);
   }
 
   /// Computes the bitwise OR of two bitmaps.
   template <class Rhs = Derived>
-  friend auto operator|(Derived const& lhs, Rhs const& rhs) {
+  friend auto operator|(const Derived& lhs, const Rhs& rhs) {
     return binary_or(lhs, rhs);
   }
 
   /// Computes the bitwise XOR of two bitmaps.
   template <class Rhs = Derived>
-  friend auto operator^(Derived const& lhs, Rhs const& rhs) {
+  friend auto operator^(const Derived& lhs, const Rhs& rhs) {
     return binary_xor(lhs, rhs);
   }
 
   /// Computes the bitwise NAND of two bitmaps.
   template <class Rhs = Derived>
-  friend auto operator-(Derived const& lhs, Rhs const& rhs) {
+  friend auto operator-(const Derived& lhs, const Rhs& rhs) {
     return binary_nand(lhs, rhs);
   }
 
   /// Computes the bitwise NOR of two bitmaps.
   template <class Rhs = Derived>
-  friend auto operator/(Derived const& lhs, Rhs const& rhs) {
+  friend auto operator/(const Derived& lhs, const Rhs& rhs) {
     return binary_nor(lhs, rhs);
   }
 
@@ -207,7 +207,7 @@ private:
     return *static_cast<Derived*>(this);
   }
 
-  Derived const& derived() const {
+  const Derived& derived() const {
     return *static_cast<Derived const*>(this);
   }
 };
@@ -216,7 +216,7 @@ private:
 template <class Derived, class Block>
 class bit_range_base : public detail::range_facade<Derived> {
 public:
-  bits<Block> const& get() const {
+  const bits<Block>& get() const {
     return bits_;
   }
 

--- a/libvast/vast/bitmap_index.hpp
+++ b/libvast/vast/bitmap_index.hpp
@@ -75,7 +75,7 @@ public:
 
   /// Appends the contents of another bitmap index to this one.
   /// @param other The other bitmap index.
-  void append(bitmap_index const& other) {
+  void append(const bitmap_index& other) {
     coder_.append(other.coder_);
   }
 
@@ -101,11 +101,11 @@ public:
 
   /// Accesses the underlying coder of the bitmap index.
   /// @returns The coder of this bitmap index.
-  coder_type const& coder() const {
+  const coder_type& coder() const {
     return coder_;
   }
 
-  friend bool operator==(bitmap_index const& x, bitmap_index const& y) {
+  friend bool operator==(const bitmap_index& x, const bitmap_index& y) {
     return x.coder_ == y.coder_;
   }
 

--- a/libvast/vast/bitstream_polymorphic.hpp
+++ b/libvast/vast/bitstream_polymorphic.hpp
@@ -40,7 +40,7 @@ private:
     virtual ~iterator_concept() = default;
     virtual std::unique_ptr<iterator_concept> copy() const = 0;
 
-    virtual bool equals(iterator_concept const& other) const = 0;
+    virtual bool equals(const iterator_concept& other) const = 0;
     virtual void increment() = 0;
     virtual size_type dereference() const = 0;
   };
@@ -59,7 +59,7 @@ private:
       return std::make_unique<iterator_model>(*this);
     }
 
-    virtual bool equals(iterator_concept const& other) const final {
+    virtual bool equals(const iterator_concept& other) const final {
       auto x = dynamic_cast<iterator_model const*>(&other);
       if (x == nullptr)
         die("bad iterator cast");
@@ -94,15 +94,15 @@ public:
           std::forward<Iterator>(i)}} {
     }
 
-    iterator(iterator const& other);
+    iterator(const iterator& other);
     iterator(iterator&& other);
-    iterator& operator=(iterator const& other);
+    iterator& operator=(const iterator& other);
     iterator& operator=(iterator&& other);
 
   private:
     friend util::iterator_access;
 
-    bool equals(iterator const& other) const;
+    bool equals(const iterator& other) const;
     void increment();
     size_type dereference() const;
 
@@ -113,13 +113,13 @@ public:
   virtual std::unique_ptr<bitstream_concept> copy() const = 0;
 
   // Interface as required by bitstream_base<T>.
-  virtual bool equals(bitstream_concept const& other) const = 0;
+  virtual bool equals(const bitstream_concept& other) const = 0;
   virtual void bitwise_not() = 0;
-  virtual void bitwise_and(bitstream_concept const& other) = 0;
-  virtual void bitwise_or(bitstream_concept const& other) = 0;
-  virtual void bitwise_xor(bitstream_concept const& other) = 0;
-  virtual void bitwise_subtract(bitstream_concept const& other) = 0;
-  virtual void append_impl(bitstream_concept const& other) = 0;
+  virtual void bitwise_and(const bitstream_concept& other) = 0;
+  virtual void bitwise_or(const bitstream_concept& other) = 0;
+  virtual void bitwise_xor(const bitstream_concept& other) = 0;
+  virtual void bitwise_subtract(const bitstream_concept& other) = 0;
+  virtual void append_impl(const bitstream_concept& other) = 0;
   virtual void append_impl(size_type n, bool bit) = 0;
   virtual void append_block_impl(block_type block, size_type bits) = 0;
   virtual void push_back_impl(bool bit) = 0;
@@ -136,7 +136,7 @@ public:
   virtual size_type find_next_impl(size_type i) const = 0;
   virtual size_type find_last_impl() const = 0;
   virtual size_type find_prev_impl(size_type i) const = 0;
-  virtual bitvector const& bits_impl() const = 0;
+  virtual const bitvector& bits_impl() const = 0;
 
 protected:
   bitstream_concept() = default;
@@ -148,7 +148,7 @@ class bitstream_model : public bitstream_concept,
                         util::equality_comparable<bitstream_model<Bitstream>> {
   friend access;
 
-  Bitstream const& cast(bitstream_concept const& c) const {
+  const Bitstream& cast(const bitstream_concept& c) const {
     auto x = dynamic_cast<bitstream_model const*>(&c);
     if (x == nullptr)
       die("bad bitstream cast");
@@ -162,7 +162,7 @@ class bitstream_model : public bitstream_concept,
     return x->bitstream_;
   }
 
-  friend bool operator==(bitstream_model const& x, bitstream_model const& y) {
+  friend bool operator==(const bitstream_model& x, const bitstream_model& y) {
     return x.bitstream_ == y.bitstream_;
   }
 
@@ -181,7 +181,7 @@ public:
     return std::make_unique<bitstream_model>(*this);
   }
 
-  virtual bool equals(bitstream_concept const& other) const final {
+  virtual bool equals(const bitstream_concept& other) const final {
     return bitstream_.equals(cast(other));
   }
 
@@ -189,23 +189,23 @@ public:
     bitstream_.bitwise_not();
   }
 
-  virtual void bitwise_and(bitstream_concept const& other) final {
+  virtual void bitwise_and(const bitstream_concept& other) final {
     bitstream_.bitwise_and(cast(other));
   }
 
-  virtual void bitwise_or(bitstream_concept const& other) final {
+  virtual void bitwise_or(const bitstream_concept& other) final {
     bitstream_.bitwise_or(cast(other));
   }
 
-  virtual void bitwise_xor(bitstream_concept const& other) final {
+  virtual void bitwise_xor(const bitstream_concept& other) final {
     bitstream_.bitwise_xor(cast(other));
   }
 
-  virtual void bitwise_subtract(bitstream_concept const& other) final {
+  virtual void bitwise_subtract(const bitstream_concept& other) final {
     bitstream_.bitwise_subtract(cast(other));
   }
 
-  virtual void append_impl(bitstream_concept const& other) final {
+  virtual void append_impl(const bitstream_concept& other) final {
     bitstream_.append_impl(cast(other));
   }
 
@@ -273,7 +273,7 @@ public:
     return bitstream_.find_prev_impl(i);
   }
 
-  virtual bitvector const& bits_impl() const final {
+  virtual const bitvector& bits_impl() const final {
     return bitstream_.bits_impl();
   }
 
@@ -287,14 +287,14 @@ private:
 class bitstream : public bitstream_base<bitstream>,
                   util::equality_comparable<bitstream> {
   friend access;
-  friend bool operator==(bitstream const& x, bitstream const& y);
+  friend bool operator==(const bitstream& x, const bitstream& y);
 
 public:
   using iterator = detail::bitstream_concept::iterator;
   using const_iterator = detail::bitstream_concept::const_iterator;
 
   bitstream() = default;
-  bitstream(bitstream const& other);
+  bitstream(const bitstream& other);
   bitstream(bitstream&& other);
 
   template <
@@ -306,7 +306,7 @@ public:
         std::forward<Bitstream>(bs)}} {
   }
 
-  bitstream& operator=(bitstream const& other);
+  bitstream& operator=(const bitstream& other);
   bitstream& operator=(bitstream&& other);
 
   explicit operator bool() const;
@@ -319,13 +319,13 @@ public:
 private:
   friend bitstream_base<bitstream>;
 
-  bool equals(bitstream const& other) const;
+  bool equals(const bitstream& other) const;
   void bitwise_not();
-  void bitwise_and(bitstream const& other);
-  void bitwise_or(bitstream const& other);
-  void bitwise_xor(bitstream const& other);
-  void bitwise_subtract(bitstream const& other);
-  void append_impl(bitstream const& other);
+  void bitwise_and(const bitstream& other);
+  void bitwise_or(const bitstream& other);
+  void bitwise_xor(const bitstream& other);
+  void bitwise_subtract(const bitstream& other);
+  void append_impl(const bitstream& other);
   void append_impl(size_type n, bool bit);
   void append_block_impl(block_type block, size_type bits);
   void push_back_impl(bool bit);
@@ -342,7 +342,7 @@ private:
   size_type find_next_impl(size_type i) const;
   size_type find_last_impl() const;
   size_type find_prev_impl(size_type i) const;
-  bitvector const& bits_impl() const;
+  const bitvector& bits_impl() const;
 
   std::unique_ptr<detail::bitstream_concept> concept_;
 };

--- a/libvast/vast/bitstream_polymorphic.hpp
+++ b/libvast/vast/bitstream_polymorphic.hpp
@@ -60,7 +60,7 @@ private:
     }
 
     virtual bool equals(const iterator_concept& other) const final {
-      auto x = dynamic_cast<iterator_model const*>(&other);
+      auto x = dynamic_cast<const iterator_model*>(&other);
       if (x == nullptr)
         die("bad iterator cast");
       return iterator_ == x->iterator_;
@@ -149,7 +149,7 @@ class bitstream_model : public bitstream_concept,
   friend access;
 
   const Bitstream& cast(const bitstream_concept& c) const {
-    auto x = dynamic_cast<bitstream_model const*>(&c);
+    auto x = dynamic_cast<const bitstream_model*>(&c);
     if (x == nullptr)
       die("bad bitstream cast");
     return x->bitstream_;

--- a/libvast/vast/bitvector.hpp
+++ b/libvast/vast/bitvector.hpp
@@ -52,7 +52,7 @@ public:
   class reference;
   using const_reference = bool;
   using pointer = reference*;
-  using const_pointer = bool const*;
+  using const_pointer = const bool*;
   using iterator = detail::bitvector_iterator<bitvector>;
   using const_iterator = detail::bitvector_iterator<bitvector const>;
   using reverse_iterator = std::reverse_iterator<iterator>;

--- a/libvast/vast/bitvector.hpp
+++ b/libvast/vast/bitvector.hpp
@@ -79,7 +79,7 @@ public:
 
   ~bitvector() = default;
 
-  bitvector& operator=(bitvector const&) = default;
+  bitvector& operator=(const bitvector&) = default;
   bitvector& operator=(bitvector&&) = default;
   bitvector& operator=(std::initializer_list<value_type>);
 
@@ -156,10 +156,10 @@ public:
   // -- relational operators --------------------------------------------------
 
   template <class B, class A>
-  friend bool operator==(bitvector<B, A> const& x, bitvector<B, A> const& y);
+  friend bool operator==(const bitvector<B, A>& x, const bitvector<B, A>& y);
 
   template <class B, class A>
-  friend bool operator<(bitvector<B, A> const& x, bitvector<B, A> const& y);
+  friend bool operator<(const bitvector<B, A>& x, const bitvector<B, A>& y);
 
   // -------------------------------------------------------------------------
   // -- non-standard extensions ----------------------------------------------
@@ -173,7 +173,7 @@ public:
   static constexpr auto npos = word_type::npos;
 
   /// Retrieves the underlying sequence of blocks.
-  block_vector const& blocks() const noexcept;
+  const block_vector& blocks() const noexcept;
 
   /// Appends a single block or a prefix of a block.
   /// @param x The block value.
@@ -233,7 +233,7 @@ public:
     return *this;
   }
 
-  reference& operator=(reference const& other) noexcept {
+  reference& operator=(const reference& other) noexcept {
     other ? *block_ |= mask_ : *block_ &= ~mask_;
   }
 
@@ -353,7 +353,7 @@ private:
     : bitvector_{&bv}, i_{off} {
   }
 
-  bool equals(bitvector_iterator const& other) const {
+  bool equals(const bitvector_iterator& other) const {
     return i_ == other.i_;
   }
 
@@ -371,7 +371,7 @@ private:
     i_ += n;
   }
 
-  auto distance_to(bitvector_iterator const& other) const {
+  auto distance_to(const bitvector_iterator& other) const {
     return other.i_ - i_;
   }
 
@@ -631,8 +631,8 @@ void bitvector<Block, Allocator>::clear() noexcept {
 }
 
 template <class Block, class Allocator>
-bool operator==(bitvector<Block, Allocator> const& x,
-                bitvector<Block, Allocator> const& y) {
+bool operator==(const bitvector<Block, Allocator>& x,
+                const bitvector<Block, Allocator>& y) {
   if (x.size_ != y.size_)
     return false;
   // Compare all but last block.
@@ -654,7 +654,7 @@ bool operator==(bitvector<Block, Allocator> const& x,
 }
 
 template <class Block, class Allocator>
-typename bitvector<Block, Allocator>::block_vector const&
+const typename bitvector<Block, Allocator>::block_vector&
 bitvector<Block, Allocator>::blocks() const noexcept{
   return blocks_;
 }
@@ -698,7 +698,7 @@ void bitvector<Block, Allocator>::append_blocks(InputIterator first,
 
 template <bool Bit = true, class Block, class Allocator>
 typename bitvector<Block, Allocator>::size_type
-rank(bitvector<Block, Allocator> const& bv) {
+rank(const bitvector<Block, Allocator>& bv) {
   using word_type = typename bitvector<Block, Allocator>::word_type;
   using size_type = typename bitvector<Block, Allocator>::size_type;
   auto result = size_type{0};

--- a/libvast/vast/coder.hpp
+++ b/libvast/vast/coder.hpp
@@ -60,7 +60,7 @@ struct coder {
   /// Appends another coder to this instance.
   /// @param other The coder to append.
   /// @pre `size() + other.size() < Bitmap::max_size`
-  void append(coder const& other);
+  void append(const coder& other);
 
   /// Retrieves the number entries in the coder, i.e., the number of rows.
   /// @returns The size of the coder measured in number of entries.
@@ -92,7 +92,7 @@ public:
     return result;
   }
 
-  void append(singleton_coder const& other) {
+  void append(const singleton_coder& other) {
     bitmap_.append(other.bitmap_);
   }
 
@@ -100,11 +100,11 @@ public:
     return bitmap_.size();
   }
 
-  Bitmap const& storage() const {
+  const Bitmap& storage() const {
     return bitmap_;
   }
 
-  friend bool operator==(singleton_coder const& x, singleton_coder const& y) {
+  friend bool operator==(const singleton_coder& x, const singleton_coder& y) {
     return x.bitmap_ == y.bitmap_;
   }
 
@@ -130,7 +130,7 @@ public:
   vector_coder(size_t n) : size_{0}, bitmaps_(n) {
   }
 
-  void append(vector_coder const& other) {
+  void append(const vector_coder& other) {
     append(other, false);
   }
 
@@ -142,7 +142,7 @@ public:
     return bitmaps_;
   }
 
-  friend bool operator==(vector_coder const& x, vector_coder const& y) {
+  friend bool operator==(const vector_coder& x, const vector_coder& y) {
     return x.size_ == y.size_ && x.bitmaps_ == y.bitmaps_;
   }
 
@@ -152,7 +152,7 @@ public:
   }
 
 protected:
-  void append(vector_coder const& other, bool bit) {
+  void append(const vector_coder& other, bool bit) {
     VAST_ASSERT(bitmaps_.size() == other.bitmaps_.size());
     for (auto i = 0u; i < bitmaps_.size(); ++i) {
       bitmaps_[i].append_bits(bit, this->size() - bitmaps_[i].size());
@@ -303,7 +303,7 @@ public:
     }
   }
 
-  void append(range_coder const& other) {
+  void append(const range_coder& other) {
     vector_coder<Bitmap>::append(other, true);
   }
 };
@@ -440,7 +440,7 @@ public:
     return coders_.empty() ? bitmap_type{} : decode(coders_, op, x);
   }
 
-  void append(multi_level_coder const& other) {
+  void append(const multi_level_coder& other) {
     VAST_ASSERT(coders_.size() == other.coders_.size());
     for (auto i = 0u; i < coders_.size(); ++i)
       coders_[i].append(other.coders_[i]);
@@ -454,8 +454,8 @@ public:
     return coders_;
   }
 
-  friend bool operator==(multi_level_coder const& x,
-                         multi_level_coder const& y) {
+  friend bool operator==(const multi_level_coder& x,
+                         const multi_level_coder& y) {
     return x.base_ == y.base_ && x.coders_ == y.coders_;
   }
 
@@ -498,7 +498,7 @@ private:
   }
 
   // Range-Eval-Opt
-  auto decode(std::vector<range_coder<bitmap_type>> const& coders,
+  auto decode(const std::vector<range_coder<bitmap_type>>& coders,
               relational_operator op, value_type x) const {
     VAST_ASSERT(!(op == in || op == not_in));
     // All coders must have the same number of elements.
@@ -552,7 +552,7 @@ private:
   // If we don't have a range_coder, we only support simple equality queries at
   // this point.
   template <class C>
-  auto decode(std::vector<C> const& coders, relational_operator op,
+  auto decode(const std::vector<C>& coders, relational_operator op,
               value_type x) const
   -> std::enable_if_t<
     is_equality_coder<C>{} || is_bitslice_coder<C>{},

--- a/libvast/vast/compression.hpp
+++ b/libvast/vast/compression.hpp
@@ -38,10 +38,10 @@ namespace lz4 {
 size_t compress_bound(size_t size);
 
 /// Compresses a contiguous byte sequence.
-size_t compress(char const* in, size_t in_size, char* out, size_t out_size);
+size_t compress(const char* in, size_t in_size, char* out, size_t out_size);
 
 /// Uncompresses a contiguous byte sequence.
-size_t uncompress(char const* in, size_t in_size, char* out, size_t out_size);
+size_t uncompress(const char* in, size_t in_size, char* out, size_t out_size);
 
 } // namespace lz4
 
@@ -55,13 +55,13 @@ size_t compress_bound(size_t size);
 
 /// Returns the size of the uncompressed output.
 /// @param size The size of the uncompressed input.
-size_t uncompress_bound(char const* data, size_t size);
+size_t uncompress_bound(const char* data, size_t size);
 
 /// Compresses a contiguous byte sequence.
-size_t compress(char const* in, size_t in_size, char* out);
+size_t compress(const char* in, size_t in_size, char* out);
 
 /// Uncompresses a contiguous byte sequence.
-bool uncompress(char const* in, size_t in_size, char* out);
+bool uncompress(const char* in, size_t in_size, char* out);
 
 } // namespace snappy
 #endif // VAST_SNAPPY

--- a/libvast/vast/concept/convertible/is_convertible.hpp
+++ b/libvast/vast/concept/convertible/is_convertible.hpp
@@ -21,7 +21,7 @@ namespace detail {
 
 struct is_convertible {
   template <typename From, typename To>
-  static auto test(From const* from, To* to)
+  static auto test(const From* from, To* to)
     -> decltype(convert(*from, *to), std::true_type());
 
   template <typename, typename>

--- a/libvast/vast/concept/hashable/crc.hpp
+++ b/libvast/vast/concept/hashable/crc.hpp
@@ -29,7 +29,7 @@ public:
 
   crc32(uint32_t seed = 0);
 
-  void operator()(void const* x, size_t n);
+  void operator()(const void* x, size_t n);
 
   operator result_type() const;
 

--- a/libvast/vast/concept/hashable/hash_append.hpp
+++ b/libvast/vast/concept/hashable/hash_append.hpp
@@ -43,7 +43,7 @@
 //     1. There exists an overload with the following signature:
 //
 //         template <class Hasher, class T>
-//         void hash_append(Hasher& h, T const& x);
+//         void hash_append(Hasher& h, const T& x);
 //
 //     2. T is contiguously hashable under. That is, for all combinations of
 //        two instances of T, say `x` and `y`, if `x == y`, then it must also
@@ -136,7 +136,7 @@ inline constexpr bool is_contiguously_hashable_v
 
 template <class Hasher, class T>
 std::enable_if_t<detail::is_contiguously_hashable<T, Hasher>{}>
-hash_append(Hasher& h, T const& x) noexcept {
+hash_append(Hasher& h, const T& x) noexcept {
   h(std::addressof(x), sizeof(x));
 }
 
@@ -196,55 +196,55 @@ hash_append(Hasher& h, T (&a)[N]) noexcept;
 
 template <class Hasher, class CharT, class Traits, class Alloc>
 std::enable_if_t<!detail::is_contiguously_hashable<CharT, Hasher>{}>
-hash_append(Hasher& h, std::basic_string<CharT, Traits, Alloc> const& s) noexcept;
+hash_append(Hasher& h, const std::basic_string<CharT, Traits, Alloc>& s) noexcept;
 
 template <class Hasher, class CharT, class Traits, class Alloc>
 std::enable_if_t<detail::is_contiguously_hashable<CharT, Hasher>{}>
-hash_append(Hasher& h, std::basic_string<CharT, Traits, Alloc> const& s) noexcept;
+hash_append(Hasher& h, const std::basic_string<CharT, Traits, Alloc>& s) noexcept;
 
 template <class Hasher, class T, class U>
 std::enable_if_t<!detail::is_contiguously_hashable<std::pair<T, U>, Hasher>{}>
-hash_append (Hasher& h, std::pair<T, U> const& p) noexcept;
+hash_append (Hasher& h, const std::pair<T, U>& p) noexcept;
 
 template <class Hasher, class T, size_t N>
 std::enable_if_t<!detail::is_contiguously_hashable<std::array<T, N>, Hasher>{}>
-hash_append(Hasher& h, std::array<T, N> const& a) noexcept;
+hash_append(Hasher& h, const std::array<T, N>& a) noexcept;
 
 template <class Hasher, class T, class Alloc>
 std::enable_if_t<!detail::is_contiguously_hashable<T, Hasher>{}>
-hash_append(Hasher& h, std::vector<T, Alloc> const& v) noexcept;
+hash_append(Hasher& h, const std::vector<T, Alloc>& v) noexcept;
 
 template <class Hasher, class T, class Alloc>
 std::enable_if_t<detail::is_contiguously_hashable<T, Hasher>{}>
-hash_append(Hasher& h, std::vector<T, Alloc> const& v) noexcept;
+hash_append(Hasher& h, const std::vector<T, Alloc>& v) noexcept;
 
 template <class Hasher, class Key, class Comp, class Alloc>
-void hash_append(Hasher& h, std::set<Key, Comp, Alloc> const& s) noexcept;
+void hash_append(Hasher& h, const std::set<Key, Comp, Alloc>& s) noexcept;
 
 template <class Hasher, class Key, class T, class Comp, class Alloc>
-void hash_append(Hasher& h, std::map<Key, T, Comp, Alloc> const& m) noexcept;
+void hash_append(Hasher& h, const std::map<Key, T, Comp, Alloc>& m) noexcept;
 
 template <class Hasher, class Key, class Hash, class Eq, class Alloc>
 void hash_append(Hasher& h,
-                 std::unordered_set<Key, Hash, Eq, Alloc> const& s) noexcept;
+                 const std::unordered_set<Key, Hash, Eq, Alloc>& s) noexcept;
 
 template <class Hasher, class K, class T, class Hash, class Eq, class Alloc>
 void hash_append(Hasher& h,
-                 std::unordered_map<K, T, Hash, Eq, Alloc> const& m) noexcept;
+                 const std::unordered_map<K, T, Hash, Eq, Alloc>& m) noexcept;
 
 template <class Hasher, class ...T>
 std::enable_if_t<!detail::is_contiguously_hashable<std::tuple<T...>, Hasher>{}>
-hash_append(Hasher& h, std::tuple<T...> const& t) noexcept;
+hash_append(Hasher& h, const std::tuple<T...>& t) noexcept;
 
 template <class Hasher, class T0, class T1, class ...T>
-void hash_append(Hasher& h, T0 const& t0, T1 const& t1, T const& ...t) noexcept;
+void hash_append(Hasher& h, const T0& t0, const T1& t1, const T& ...t) noexcept;
 
 // -- C array -----------------------------------------------------------------
 
 template <class Hasher, class T, size_t N>
 std::enable_if_t<!detail::is_contiguously_hashable<T, Hasher>{}>
 hash_append(Hasher& h, T (&a)[N]) noexcept {
-  for (auto const& x : a)
+  for (const auto& x : a)
     hash_append(h, x);
 }
 
@@ -253,7 +253,7 @@ hash_append(Hasher& h, T (&a)[N]) noexcept {
 template <class Hasher, class CharT, class Traits, class Alloc>
 std::enable_if_t<!detail::is_contiguously_hashable<CharT, Hasher>{} >
 hash_append(Hasher& h,
-            std::basic_string<CharT, Traits, Alloc> const& s) noexcept {
+            const std::basic_string<CharT, Traits, Alloc>& s) noexcept {
   for (auto c : s)
     hash_append(h, c);
   hash_append(h, s.size());
@@ -262,7 +262,7 @@ hash_append(Hasher& h,
 template <class Hasher, class CharT, class Traits, class Alloc>
 std::enable_if_t<detail::is_contiguously_hashable<CharT, Hasher>{}>
 hash_append(Hasher& h,
-            std::basic_string<CharT, Traits, Alloc> const& s) noexcept {
+            const std::basic_string<CharT, Traits, Alloc>& s) noexcept {
   h(s.data(), s.size() * sizeof(CharT));
   hash_append(h, s.size());
 }
@@ -271,7 +271,7 @@ hash_append(Hasher& h,
 
 template <class Hasher, class T, class U>
 std::enable_if_t<!detail::is_contiguously_hashable<std::pair<T, U>, Hasher>{}>
-hash_append(Hasher& h, std::pair<T, U> const& p) noexcept {
+hash_append(Hasher& h, const std::pair<T, U>& p) noexcept {
   hash_append(h, p.first, p.second);
 }
 
@@ -279,8 +279,8 @@ hash_append(Hasher& h, std::pair<T, U> const& p) noexcept {
 
 template <class Hasher, class T, size_t N>
 std::enable_if_t<!detail::is_contiguously_hashable<std::array<T, N>, Hasher>{}>
-hash_append(Hasher& h, std::array<T, N> const& a) noexcept {
-  for (auto const& t : a)
+hash_append(Hasher& h, const std::array<T, N>& a) noexcept {
+  for (const auto& t : a)
     hash_append(h, t);
 }
 
@@ -288,15 +288,15 @@ hash_append(Hasher& h, std::array<T, N> const& a) noexcept {
 
 template <class Hasher, class T, class Alloc>
 std::enable_if_t<detail::is_contiguously_hashable<T, Hasher>{}>
-hash_append(Hasher& h, std::vector<T, Alloc> const& v) noexcept {
+hash_append(Hasher& h, const std::vector<T, Alloc>& v) noexcept {
   h(v.data(), v.size() * sizeof(T));
   hash_append(h, v.size());
 }
 
 template <class Hasher, class T, class Alloc>
 std::enable_if_t<!detail::is_contiguously_hashable<T, Hasher>{}>
-hash_append(Hasher& h, std::vector<T, Alloc> const& v) noexcept {
-  for (auto const& t : v)
+hash_append(Hasher& h, const std::vector<T, Alloc>& v) noexcept {
+  for (const auto& t : v)
     hash_append(h, t);
   hash_append(h, v.size());
 }
@@ -304,8 +304,8 @@ hash_append(Hasher& h, std::vector<T, Alloc> const& v) noexcept {
 // -- set ---------------------------------------------------------------------
 
 template <class Hasher, class Key, class Comp, class Alloc>
-void hash_append(Hasher& h, std::set<Key, Comp, Alloc> const& s) noexcept {
-  for (auto const& x : s)
+void hash_append(Hasher& h, const std::set<Key, Comp, Alloc>& s) noexcept {
+  for (const auto& x : s)
     hash_append(h, x);
   hash_append(h, s.size());
 }
@@ -313,8 +313,8 @@ void hash_append(Hasher& h, std::set<Key, Comp, Alloc> const& s) noexcept {
 // -- map ---------------------------------------------------------------------
 
 template <class Hasher, class Key, class T, class Comp, class Alloc>
-void hash_append(Hasher& h, std::map<Key, T, Comp, Alloc> const& m) noexcept {
-  for (auto const& x : m)
+void hash_append(Hasher& h, const std::map<Key, T, Comp, Alloc>& m) noexcept {
+  for (const auto& x : m)
     hash_append(h, x);
   hash_append(h, m.size());
 }
@@ -323,8 +323,8 @@ void hash_append(Hasher& h, std::map<Key, T, Comp, Alloc> const& m) noexcept {
 
 template <class Hasher, class Key, class Hash, class Eq, class Alloc>
 void hash_append(Hasher& h,
-                 std::unordered_set<Key, Hash, Eq, Alloc> const& s) noexcept {
-  for (auto const& x : s)
+                 const std::unordered_set<Key, Hash, Eq, Alloc>& s) noexcept {
+  for (const auto& x : s)
     hash_append(h, x);
   hash_append(h, s.size());
 }
@@ -333,8 +333,8 @@ void hash_append(Hasher& h,
 
 template <class Hasher, class K, class T, class Hash, class Eq, class Alloc>
 void hash_append(Hasher& h,
-                 std::unordered_map<K, T, Hash, Eq, Alloc> const& m) noexcept {
-  for (auto const& x : m)
+                 const std::unordered_map<K, T, Hash, Eq, Alloc>& m) noexcept {
+  for (const auto& x : m)
     hash_append(h, x);
   hash_append(h, m.size());
 }
@@ -347,13 +347,13 @@ inline void for_each_item(...) noexcept {
 }
 
 template <class Hasher, class T>
-int hash_one(Hasher& h, T const& t) noexcept {
+int hash_one(Hasher& h, const T& t) noexcept {
   hash_append(h, t);
   return 0;
 }
 
 template <class Hasher, class ...T, size_t ...I>
-void tuple_hash(Hasher& h, std::tuple<T...> const& t,
+void tuple_hash(Hasher& h, const std::tuple<T...>& t,
                 std::index_sequence<I...>) noexcept {
   for_each_item(hash_one(h, std::get<I>(t))...);
 }
@@ -362,15 +362,15 @@ void tuple_hash(Hasher& h, std::tuple<T...> const& t,
 
 template <class Hasher, class ...T>
 std::enable_if_t<!detail::is_contiguously_hashable<std::tuple<T...>, Hasher>{}>
-hash_append(Hasher& h, std::tuple<T...> const& t) noexcept {
+hash_append(Hasher& h, const std::tuple<T...>& t) noexcept {
   detail::tuple_hash(h, t, std::index_sequence_for<T...>{});
 }
 
 // -- variadic ----------------------------------------------------------------
 
 template <class Hasher, class T0, class T1, class... Ts>
-void hash_append(Hasher& h, T0 const& x0, T1 const& x1,
-                 Ts const& ...xs) noexcept {
+void hash_append(Hasher& h, const T0& x0, const T1& x1,
+                 const Ts& ...xs) noexcept {
   hash_append(h, x0);
   hash_append(h, x1, xs...);
 }
@@ -430,7 +430,7 @@ template <class Hasher, class T>
 std::enable_if_t<
   caf::detail::is_inspectable<detail::hash_inspector<Hasher>, T>::value
 >
-hash_append(Hasher& h, T const& x) noexcept {
+hash_append(Hasher& h, const T& x) noexcept {
   detail::hash_inspector<Hasher> f{h};
   inspect(f, const_cast<T&>(x));
 }

--- a/libvast/vast/concept/hashable/hash_append.hpp
+++ b/libvast/vast/concept/hashable/hash_append.hpp
@@ -163,7 +163,7 @@ hash_append(Hasher& h, T x) noexcept {
 
 template <class Hasher>
 void hash_append(Hasher& h, std::nullptr_t) noexcept {
-  void const* p = nullptr;
+  const void* p = nullptr;
   detail::maybe_reverse_bytes(p, h);
   h(&p, sizeof(p));
 }

--- a/libvast/vast/concept/hashable/uhash.hpp
+++ b/libvast/vast/concept/hashable/uhash.hpp
@@ -29,7 +29,7 @@ public:
   }
 
   template <class T>
-  result_type operator()(T const& x) noexcept {
+  result_type operator()(const T& x) noexcept {
     hash_append(h_, x);
     return static_cast<result_type>(h_);
   }

--- a/libvast/vast/concept/hashable/xxhash.hpp
+++ b/libvast/vast/concept/hashable/xxhash.hpp
@@ -33,7 +33,7 @@ class xxhash32 : public xxhash_base {
 public:
   explicit xxhash32(result_type seed = 0) noexcept;
 
-  void operator()(void const* x, size_t n) noexcept;
+  void operator()(const void* x, size_t n) noexcept;
 
   explicit operator result_type() noexcept;
 
@@ -64,7 +64,7 @@ class xxhash64 : public xxhash_base {
 public:
   explicit xxhash64(result_type seed = 0) noexcept;
 
-  void operator()(void const* x, size_t n) noexcept;
+  void operator()(const void* x, size_t n) noexcept;
 
   explicit operator result_type() noexcept;
 

--- a/libvast/vast/concept/parseable/core/and.hpp
+++ b/libvast/vast/concept/parseable/core/and.hpp
@@ -28,7 +28,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute&) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute&) const {
     auto i = f; // Do not consume input.
     return parser_(i, l, unused);
   }

--- a/libvast/vast/concept/parseable/core/as.hpp
+++ b/libvast/vast/concept/parseable/core/as.hpp
@@ -28,7 +28,7 @@ public:
   }
 
   template <typename Iterator, typename Attr>
-  bool parse(Iterator& f, Iterator const& l, Attr& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attr& a) const {
     attribute x;
     if (!parser_(f, l, x))
       return false;

--- a/libvast/vast/concept/parseable/core/choice.hpp
+++ b/libvast/vast/concept/parseable/core/choice.hpp
@@ -68,7 +68,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     auto save = f;
     if (parse_left<Lhs>(f, l, a))
       return true;
@@ -81,19 +81,19 @@ public:
 
 private:
   template <typename Left, typename Iterator, typename Attribute>
-  auto parse_left(Iterator& f, Iterator const& l, Attribute& a) const
+  auto parse_left(Iterator& f, const Iterator& l, Attribute& a) const
   -> std::enable_if_t<is_choice_parser<Left>{}, bool> {
     return lhs_(f, l, a); // recurse
   }
 
   template <typename Left, typename Iterator>
-  auto parse_left(Iterator& f, Iterator const& l, unused_type) const
+  auto parse_left(Iterator& f, const Iterator& l, unused_type) const
   -> std::enable_if_t<!is_choice_parser<Left>::value, bool> {
     return lhs_(f, l, unused);
   }
 
   template <typename Left, typename Iterator, typename Attribute>
-  auto parse_left(Iterator& f, Iterator const& l, Attribute& a) const
+  auto parse_left(Iterator& f, const Iterator& l, Attribute& a) const
   -> std::enable_if_t<!is_choice_parser<Left>::value, bool> {
     lhs_attribute al;
     if (!lhs_(f, l, al))
@@ -103,12 +103,12 @@ private:
   }
 
   template <typename Iterator>
-  bool parse_right(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse_right(Iterator& f, const Iterator& l, unused_type) const {
     return rhs_(f, l, unused);
   }
 
   template <typename Iterator, typename Attribute>
-  auto parse_right(Iterator& f, Iterator const& l, Attribute& a) const {
+  auto parse_right(Iterator& f, const Iterator& l, Attribute& a) const {
     rhs_attribute ar;
     if (!rhs_(f, l, ar))
       return false;

--- a/libvast/vast/concept/parseable/core/difference.hpp
+++ b/libvast/vast/concept/parseable/core/difference.hpp
@@ -30,7 +30,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     auto save = f;
     if (!rhs_(f, l, unused))
       return lhs_(f, l, a); // Invoke LHS only if RHS doesn't fail.

--- a/libvast/vast/concept/parseable/core/guard.hpp
+++ b/libvast/vast/concept/parseable/core/guard.hpp
@@ -32,12 +32,12 @@ public:
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     return parser_(f, l, unused);
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     attribute attr;
     if (!(parser_(f, l, attr) && guard_(attr)))
       return false;

--- a/libvast/vast/concept/parseable/core/ignore.hpp
+++ b/libvast/vast/concept/parseable/core/ignore.hpp
@@ -30,7 +30,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute&) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute&) const {
     return parser_(f, l, unused);
   }
 

--- a/libvast/vast/concept/parseable/core/kleene.hpp
+++ b/libvast/vast/concept/parseable/core/kleene.hpp
@@ -31,7 +31,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     while (container::parse(parser_, f, l, a))
       ;
     return true;

--- a/libvast/vast/concept/parseable/core/list.hpp
+++ b/libvast/vast/concept/parseable/core/list.hpp
@@ -33,7 +33,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     if (!container::parse(lhs_, f, l, a))
       return false;
     auto save = f;

--- a/libvast/vast/concept/parseable/core/literal.hpp
+++ b/libvast/vast/concept/parseable/core/literal.hpp
@@ -28,11 +28,11 @@ inline auto operator"" _p(char c) {
   return ignore(char_parser{c});
 }
 
-inline auto operator"" _p(char const* str) {
+inline auto operator"" _p(const char* str) {
   return ignore(string_parser{str});
 }
 
-inline auto operator"" _p(char const* str, size_t size) {
+inline auto operator"" _p(const char* str, size_t size) {
   return ignore(string_parser{{str, size}});
 }
 

--- a/libvast/vast/concept/parseable/core/maybe.hpp
+++ b/libvast/vast/concept/parseable/core/maybe.hpp
@@ -30,7 +30,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     parser_(f, l, a);
     return true;
   }

--- a/libvast/vast/concept/parseable/core/not.hpp
+++ b/libvast/vast/concept/parseable/core/not.hpp
@@ -27,7 +27,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute&) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute&) const {
     auto i = f; // Do not consume input.
     return !parser_(i, l, unused);
   }

--- a/libvast/vast/concept/parseable/core/optional.hpp
+++ b/libvast/vast/concept/parseable/core/optional.hpp
@@ -38,13 +38,13 @@ public:
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     parser_(f, l, unused);
     return true;
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     inner_attribute attr;
     if (parser_(f, l, attr))
       a = std::move(attr);

--- a/libvast/vast/concept/parseable/core/parser.hpp
+++ b/libvast/vast/concept/parseable/core/parser.hpp
@@ -65,13 +65,13 @@ struct parser {
   }
 
   template <typename Iterator, typename Attribute>
-  auto operator()(Iterator& f, Iterator const& l, Attribute& a) const
+  auto operator()(Iterator& f, const Iterator& l, Attribute& a) const
   -> decltype(*f, ++f, f == l, bool()) {
     return derived().parse(f, l, a);
   }
 
   template <typename Iterator, typename A0, typename A1, typename... As>
-  auto operator()(Iterator& f, Iterator const& l, A0& a0, A1& a1,
+  auto operator()(Iterator& f, const Iterator& l, A0& a0, A1& a1,
                   As&... as) const
   -> decltype(*f, ++f, f == l, bool()) {
     auto t = std::tie(a0, a1, as...);
@@ -79,8 +79,8 @@ struct parser {
   }
 
 private:
-  Derived const& derived() const {
-    return static_cast<Derived const&>(*this);
+  const Derived& derived() const {
+    return static_cast<const Derived&>(*this);
   }
 };
 

--- a/libvast/vast/concept/parseable/core/plus.hpp
+++ b/libvast/vast/concept/parseable/core/plus.hpp
@@ -31,7 +31,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     if (!container::parse(parser_, f, l, a))
       return false;
     while (container::parse(parser_, f, l, a))

--- a/libvast/vast/concept/parseable/core/repeat.hpp
+++ b/libvast/vast/concept/parseable/core/repeat.hpp
@@ -33,7 +33,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     if (Max == 0)
       return true; // If we have nothing todo, we're succeeding.
     auto save = f;
@@ -54,14 +54,14 @@ private:
 };
 
 template <int Min, int Max = Min, typename Parser>
-auto repeat(Parser const& p) {
+auto repeat(const Parser& p) {
   return repeat_parser<Parser, Min, Max>{p};
 }
 
 namespace parsers {
 
 template <int Min, int Max = Min, typename Parser>
-auto rep(Parser const& p) {
+auto rep(const Parser& p) {
   return repeat<Min, Max, Parser>(p);
 }
 

--- a/libvast/vast/concept/parseable/core/rule.hpp
+++ b/libvast/vast/concept/parseable/core/rule.hpp
@@ -75,7 +75,7 @@ public:
   template <
     typename RHS,
     typename = std::enable_if_t<
-      is_parser<std::decay_t<RHS>>{} && ! detail::is_same_or_derived<rule, RHS>::value
+      is_parser<std::decay_t<RHS>>{} && !detail::is_same_or_derived<rule, RHS>::value
     >
   >
   rule(RHS&& rhs)

--- a/libvast/vast/concept/parseable/core/rule.hpp
+++ b/libvast/vast/concept/parseable/core/rule.hpp
@@ -27,8 +27,8 @@ namespace detail {
 template <typename Iterator, typename Attribute>
 struct abstract_rule {
   ~abstract_rule() = default;
-  virtual bool parse(Iterator& f, Iterator const& l, unused_type) const = 0;
-  virtual bool parse(Iterator& f, Iterator const& l, Attribute& a) const = 0;
+  virtual bool parse(Iterator& f, const Iterator& l, unused_type) const = 0;
+  virtual bool parse(Iterator& f, const Iterator& l, Attribute& a) const = 0;
 };
 
 template <typename Parser, typename Iterator, typename Attribute>
@@ -37,11 +37,11 @@ public:
   explicit rule_definition(Parser p) : parser_(std::move(p)) {
   }
 
-  bool parse(Iterator& f, Iterator const& l, unused_type) const override {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const override {
     return parser_(f, l, unused);
   }
 
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const override {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const override {
     return parser_(f, l, a);
   }
 
@@ -90,12 +90,12 @@ public:
     make_parser<RHS>(std::forward<RHS>(rhs));
   }
 
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     VAST_ASSERT(*parser_ != nullptr);
     return (*parser_)->parse(f, l, unused);
   }
 
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     VAST_ASSERT(*parser_ != nullptr);
     return (*parser_)->parse(f, l, a);
   }

--- a/libvast/vast/concept/parseable/core/sequence.hpp
+++ b/libvast/vast/concept/parseable/core/sequence.hpp
@@ -98,8 +98,8 @@ private:
   static constexpr auto depth_helper()
     -> std::enable_if_t<
          is_sequence_parser<T>::value
-          && ! std::is_same<typename T::lhs_attribute, unused_type>::value
-          && ! std::is_same<typename T::rhs_attribute, unused_type>::value,
+          && !std::is_same<typename T::lhs_attribute, unused_type>::value
+          && !std::is_same<typename T::rhs_attribute, unused_type>::value,
          size_t
        > {
     return 1 + depth_helper<typename T::lhs_type>();
@@ -118,7 +118,7 @@ private:
   template <typename L, typename T>
   static auto get_helper(T& x)
     -> std::enable_if_t<
-         ! is_sequence_parser<L>::value,
+         !is_sequence_parser<L>::value,
          decltype(std::get<0>(x))
        > {
     return std::get<0>(x);

--- a/libvast/vast/concept/parseable/core/sequence.hpp
+++ b/libvast/vast/concept/parseable/core/sequence.hpp
@@ -68,7 +68,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     auto save = f;
     if (parse_left(f, l, a) && parse_right(f, l, a))
       return true;
@@ -125,42 +125,42 @@ private:
   }
 
   template <typename Iterator, typename... Ts>
-  bool parse_left(Iterator& f, Iterator const& l, std::tuple<Ts...>& t) const {
+  bool parse_left(Iterator& f, const Iterator& l, std::tuple<Ts...>& t) const {
     return lhs_(f, l, get_helper<lhs_type>(t));
   }
 
   template <typename Iterator, typename... Ts>
-  bool parse_right(Iterator& f, Iterator const& l, std::tuple<Ts...>& t) const {
+  bool parse_right(Iterator& f, const Iterator& l, std::tuple<Ts...>& t) const {
     return rhs_(f, l, std::get<depth()>(t));
   }
 
   template <typename Iterator>
-  bool parse_left(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse_left(Iterator& f, const Iterator& l, unused_type) const {
     return lhs_(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse_right(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse_right(Iterator& f, const Iterator& l, unused_type) const {
     return rhs_(f, l, unused);
   }
 
   template <typename Iterator, typename T, typename U>
-  bool parse_left(Iterator& f, Iterator const& l, std::pair<T, U>& p) const {
+  bool parse_left(Iterator& f, const Iterator& l, std::pair<T, U>& p) const {
     return lhs_(f, l, p.first);
   }
 
   template <typename Iterator, typename T, typename U>
-  bool parse_right(Iterator& f, Iterator const& l, std::pair<T, U>& p) const {
+  bool parse_right(Iterator& f, const Iterator& l, std::pair<T, U>& p) const {
     return rhs_(f, l, p.second);
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse_left(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse_left(Iterator& f, const Iterator& l, Attribute& a) const {
     return lhs_(f, l, a);
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse_right(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse_right(Iterator& f, const Iterator& l, Attribute& a) const {
     return rhs_(f, l, a);
   }
 

--- a/libvast/vast/concept/parseable/core/sequence_choice.hpp
+++ b/libvast/vast/concept/parseable/core/sequence_choice.hpp
@@ -84,7 +84,7 @@ private:
   >
   static auto left_attr(Attribute& a)
     -> std::enable_if_t<
-         ! std::is_same<L, unused_type>{} && std::is_same<R, unused_type>{},
+         !std::is_same<L, unused_type>{} && std::is_same<R, unused_type>{},
          optional<L>&
        > {
     return a;
@@ -97,7 +97,7 @@ private:
   >
   static auto left_attr(std::tuple<Ts...>& t)
     -> std::enable_if_t<
-         ! std::is_same<L, unused_type>{} && ! std::is_same<R, unused_type>{},
+         !std::is_same<L, unused_type>{} && !std::is_same<R, unused_type>{},
          optional<L>&
        > {
     return std::get<0>(t);
@@ -120,7 +120,7 @@ private:
   >
   static auto right_attr(Attribute& a)
     -> std::enable_if_t<
-         std::is_same<L, unused_type>{} && ! std::is_same<R, unused_type>{},
+         std::is_same<L, unused_type>{} && !std::is_same<R, unused_type>{},
          optional<R>&
        > {
     return a;
@@ -133,7 +133,7 @@ private:
   >
   static auto right_attr(std::tuple<Ts...>& t)
     -> std::enable_if_t<
-         ! std::is_same<L, unused_type>{} && ! std::is_same<R, unused_type>{},
+         !std::is_same<L, unused_type>{} && !std::is_same<R, unused_type>{},
          optional<R>&
        > {
     return std::get<1>(t);

--- a/libvast/vast/concept/parseable/core/sequence_choice.hpp
+++ b/libvast/vast/concept/parseable/core/sequence_choice.hpp
@@ -57,7 +57,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     optional<rhs_attribute> rhs_attr;
     if (lhs_(f, l, left_attr(a)) && rhs_opt_(f, l, rhs_attr)) {
       right_attr(a) = std::move(rhs_attr);

--- a/libvast/vast/concept/parseable/detail/as_parser.hpp
+++ b/libvast/vast/concept/parseable/detail/as_parser.hpp
@@ -42,7 +42,7 @@ inline auto as_parser(std::string str) {
 template <typename T>
 auto as_parser(T x)
   -> std::enable_if_t<
-       std::is_arithmetic<T>{} && ! std::is_same<T, bool>::value,
+       std::is_arithmetic<T>{} && !std::is_same<T, bool>::value,
        decltype(ignore(string_parser{""}))
      > {
   return ignore(string_parser{std::to_string(x)});
@@ -60,7 +60,7 @@ using is_convertible_to_unary_parser =
   std::integral_constant<
     bool,
     std::is_convertible<T, std::string>{}
-    || (std::is_arithmetic<T>{} && ! std::is_same<T, bool>::value)
+    || (std::is_arithmetic<T>{} && !std::is_same<T, bool>::value)
   >;
 
 template <typename T, typename U>

--- a/libvast/vast/concept/parseable/detail/container.hpp
+++ b/libvast/vast/concept/parseable/detail/container.hpp
@@ -63,13 +63,13 @@ struct container {
   }
 
   template <typename Parser, typename Iterator>
-  static bool parse(Parser const& p, Iterator& f, Iterator const& l,
+  static bool parse(const Parser& p, Iterator& f, const Iterator& l,
                     unused_type) {
     return p(f, l, unused);
   }
 
   template <typename Parser, typename Iterator, typename Attribute>
-  static bool parse(Parser const& p, Iterator& f, Iterator const& l,
+  static bool parse(const Parser& p, Iterator& f, const Iterator& l,
                     Attribute& a) {
     if constexpr (!is_pair<typename Attribute::value_type>::value) {
       value_type x;

--- a/libvast/vast/concept/parseable/from_string.hpp
+++ b/libvast/vast/concept/parseable/from_string.hpp
@@ -41,7 +41,7 @@ template <
   typename Parser = make_parser<To>,
   typename... Args
 >
-auto from_string(std::string const& str, Args&&... args) {
+auto from_string(const std::string& str, Args&&... args) {
   auto f = str.begin();
   auto l = str.end();
   return from_string<To, Parser, std::string::const_iterator, Args...>(

--- a/libvast/vast/concept/parseable/from_string.hpp
+++ b/libvast/vast/concept/parseable/from_string.hpp
@@ -57,7 +57,7 @@ template <
 auto from_string(char const (&str)[N], Args&&... args) {
   auto f = str;
   auto l = str + N - 1; // No NUL byte.
-  return from_string<To, Parser, char const*, Args...>(
+  return from_string<To, Parser, const char*, Args...>(
     f, l, std::forward<Args>(args)...);
 }
 

--- a/libvast/vast/concept/parseable/numeric/bool.hpp
+++ b/libvast/vast/concept/parseable/numeric/bool.hpp
@@ -24,36 +24,36 @@ namespace detail {
 
 struct single_char_bool_policy {
   template <typename Iterator>
-  static bool parse_true(Iterator& f, Iterator const& l) {
+  static bool parse_true(Iterator& f, const Iterator& l) {
     return char_parser{'T'}(f, l, unused);
   }
 
   template <typename Iterator>
-  static bool parse_false(Iterator& f, Iterator const& l) {
+  static bool parse_false(Iterator& f, const Iterator& l) {
     return char_parser{'F'}(f, l, unused);
   }
 };
 
 struct zero_one_bool_policy {
   template <typename Iterator>
-  static bool parse_true(Iterator& f, Iterator const& l) {
+  static bool parse_true(Iterator& f, const Iterator& l) {
     return char_parser{'1'}(f, l, unused);
   }
 
   template <typename Iterator>
-  static bool parse_false(Iterator& f, Iterator const& l) {
+  static bool parse_false(Iterator& f, const Iterator& l) {
     return char_parser{'0'}(f, l, unused);
   }
 };
 
 struct literal_bool_policy {
   template <typename Iterator>
-  static bool parse_true(Iterator& f, Iterator const& l) {
+  static bool parse_true(Iterator& f, const Iterator& l) {
     return c_string_parser{"true"}(f, l, unused);
   }
 
   template <typename Iterator>
-  static bool parse_false(Iterator& f, Iterator const& l) {
+  static bool parse_false(Iterator& f, const Iterator& l) {
     return c_string_parser{"false"}(f, l, unused);
   }
 };
@@ -65,7 +65,7 @@ struct bool_parser : parser<bool_parser<Policy>> {
   using attribute = bool;
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     if (f == l)
       return false;
     if (Policy::parse_true(f, l))

--- a/libvast/vast/concept/parseable/numeric/byte.hpp
+++ b/libvast/vast/concept/parseable/numeric/byte.hpp
@@ -31,7 +31,7 @@ struct extract;
 template <>
 struct extract<1> {
   template <typename Iterator, typename Attribute>
-  static bool parse(Iterator& f, Iterator const& l, Attribute& a) {
+  static bool parse(Iterator& f, const Iterator& l, Attribute& a) {
     if (f == l)
       return false;
     a |= *f++ & 0xFF;
@@ -42,7 +42,7 @@ struct extract<1> {
 template <>
 struct extract<2> {
   template <typename Iterator, typename Attribute>
-  static bool parse(Iterator& f, Iterator const& l, Attribute& a) {
+  static bool parse(Iterator& f, const Iterator& l, Attribute& a) {
     if (!extract<1>::parse(f, l, a))
       return false;
     a <<= 8;
@@ -53,7 +53,7 @@ struct extract<2> {
 template <>
 struct extract<4> {
   template <typename Iterator, typename Attribute>
-  static bool parse(Iterator& f, Iterator const& l, Attribute& a) {
+  static bool parse(Iterator& f, const Iterator& l, Attribute& a) {
     if (!extract<2>::parse(f, l, a))
       return false;
     a <<= 8;
@@ -64,7 +64,7 @@ struct extract<4> {
 template <>
 struct extract<8> {
   template <typename Iterator, typename Attribute>
-  static bool parse(Iterator& f, Iterator const& l, Attribute& a) {
+  static bool parse(Iterator& f, const Iterator& l, Attribute& a) {
     if (!extract<4>::parse(f, l, a))
       return false;
     a <<= 8;
@@ -86,7 +86,7 @@ struct byte_parser : parser<byte_parser<T, Policy, Bytes>> {
   using attribute = T;
 
   template <typename Iterator>
-  static bool extract(Iterator& f, Iterator const& l, T& x) {
+  static bool extract(Iterator& f, const Iterator& l, T& x) {
     auto save = f;
     x = 0;
     if (!detail::extract<Bytes>::parse(save, l, x))
@@ -96,7 +96,7 @@ struct byte_parser : parser<byte_parser<T, Policy, Bytes>> {
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     for (auto i = 0u; i < Bytes; ++i)
       if (f != l)
         ++f;
@@ -106,7 +106,7 @@ struct byte_parser : parser<byte_parser<T, Policy, Bytes>> {
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, T& x) const {
+  bool parse(Iterator& f, const Iterator& l, T& x) const {
     if constexpr (std::is_same_v<Policy, policy::no_swap>){
       return extract(f, l, x);
     } else {
@@ -123,7 +123,7 @@ struct bytes_parser : parser<bytes_parser<N>> {
   using attribute = std::array<uint8_t, N>;
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, std::array<uint8_t, N>& x) const {
+  bool parse(Iterator& f, const Iterator& l, std::array<uint8_t, N>& x) const {
     auto save = f;
     for (auto i = 0u; i < N; i++) {
       if (save == l)

--- a/libvast/vast/concept/parseable/numeric/integral.hpp
+++ b/libvast/vast/concept/parseable/numeric/integral.hpp
@@ -53,7 +53,7 @@ struct integral_parser
   }
 
   template <typename Iterator, typename Attribute, typename F>
-  static auto accumulate(Iterator& f, Iterator const& l, Attribute& a, F acc) {
+  static auto accumulate(Iterator& f, const Iterator& l, Attribute& a, F acc) {
     int digits = 0;
     a = 0;
     while (f != l && isdigit(*f)) {
@@ -67,12 +67,12 @@ struct integral_parser
   }
 
   template <typename Iterator>
-  static auto parse_pos(Iterator& f, Iterator const& l, unused_type) {
+  static auto parse_pos(Iterator& f, const Iterator& l, unused_type) {
     return accumulate(f, l, unused, [](auto&, auto) {});
   }
 
   template <typename Iterator, typename Attribute>
-  static auto parse_pos(Iterator& f, Iterator const& l, Attribute& a) {
+  static auto parse_pos(Iterator& f, const Iterator& l, Attribute& a) {
     return accumulate(f, l, a, [](auto& n, auto x) {
       n *= Radix;
       n += x;
@@ -80,12 +80,12 @@ struct integral_parser
   }
 
   template <typename Iterator>
-  static auto parse_neg(Iterator& f, Iterator const& l, unused_type) {
+  static auto parse_neg(Iterator& f, const Iterator& l, unused_type) {
     return accumulate(f, l, unused, [](auto&, auto) {});
   }
 
   template <typename Iterator, typename Attribute>
-  static auto parse_neg(Iterator& f, Iterator const& l, Attribute& a) {
+  static auto parse_neg(Iterator& f, const Iterator& l, Attribute& a) {
     return accumulate(f, l, a, [](auto& n, auto x) {
       n *= Radix;
       n -= x;
@@ -93,17 +93,17 @@ struct integral_parser
   }
 
   template <typename Iterator, typename Attribute>
-  static bool parse_signed(Iterator& f, Iterator const& l, Attribute& a) {
+  static bool parse_signed(Iterator& f, const Iterator& l, Attribute& a) {
     return detail::parse_sign(f) ? parse_neg(f, l, a) : parse_pos(f, l, a);
   }
 
   template <typename Iterator, typename Attribute>
-  static bool parse_unsigned(Iterator& f, Iterator const& l, Attribute& a) {
+  static bool parse_unsigned(Iterator& f, const Iterator& l, Attribute& a) {
     return parse_pos(f, l, a);
   }
 
   template <typename Iterator, typename Attribute>
-  static bool dispatch(Iterator& f, Iterator const& l, Attribute& a) {
+  static bool dispatch(Iterator& f, const Iterator& l, Attribute& a) {
     if constexpr (std::is_signed_v<T>)
       return parse_signed(f, l, a);
     else
@@ -111,7 +111,7 @@ struct integral_parser
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     if (f == l)
       return false;
     auto save = f;

--- a/libvast/vast/concept/parseable/numeric/real.hpp
+++ b/libvast/vast/concept/parseable/numeric/real.hpp
@@ -44,7 +44,7 @@ struct real_parser : parser<real_parser<T, Policies...>> {
     >::value;
 
   template <typename Iterator>
-  static bool parse_dot(Iterator& f, Iterator const& l) {
+  static bool parse_dot(Iterator& f, const Iterator& l) {
     if (f == l || *f != '.')
       return false;
     ++f;
@@ -71,7 +71,7 @@ struct real_parser : parser<real_parser<T, Policies...>> {
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     if (f == l)
       return false;
     auto save = f;

--- a/libvast/vast/concept/parseable/parse.hpp
+++ b/libvast/vast/concept/parseable/parse.hpp
@@ -62,7 +62,7 @@ namespace detail {
 
 struct is_parseable {
   template <typename I, typename T>
-  static auto test(I* f, I const* l, T* x)
+  static auto test(I* f, const I* l, T* x)
     -> decltype(parse(*f, *l, *x), std::true_type());
 
   template <typename, typename>

--- a/libvast/vast/concept/parseable/parse.hpp
+++ b/libvast/vast/concept/parseable/parse.hpp
@@ -22,13 +22,13 @@
 namespace vast {
 
 template <typename Iterator, typename T, typename... Args>
-auto parse(Iterator& f, Iterator const& l, T& x, Args&&... args)
+auto parse(Iterator& f, const Iterator& l, T& x, Args&&... args)
   -> std::enable_if_t<has_parser<T>::value, bool> {
   return make_parser<T>{std::forward<Args>(args)...}(f, l, x);
 }
 
 template <typename Iterator, typename T, typename... Args>
-auto parse(Iterator& f, Iterator const& l, T& x, Args&&... args)
+auto parse(Iterator& f, const Iterator& l, T& x, Args&&... args)
   -> std::enable_if_t<!has_parser<T>::value && has_access_parser<T>::value,
                       bool> {
   return access::parser<T>{std::forward<Args>(args)...}(f, l, x);
@@ -37,19 +37,19 @@ auto parse(Iterator& f, Iterator const& l, T& x, Args&&... args)
 namespace detail {
 
 template <typename Iterator, typename T>
-bool conjunctive_parse(Iterator& f, Iterator const& l, T& x) {
+bool conjunctive_parse(Iterator& f, const Iterator& l, T& x) {
   return parse(f, l, x);
 }
 
 template <typename Iterator, typename T, typename... Ts>
-bool conjunctive_parse(Iterator& f, Iterator const& l, T& x, Ts&... xs) {
+bool conjunctive_parse(Iterator& f, const Iterator& l, T& x, Ts&... xs) {
   return conjunctive_parse(f, l, x) && conjunctive_parse(f, l, xs...);
 }
 
 } // namespace detail
 
 template <typename Iterator, typename T>
-auto parse(Iterator& f, Iterator const& l, T& x)
+auto parse(Iterator& f, const Iterator& l, T& x)
   -> std::enable_if_t<!has_parser<T>::value && has_access_state<T>::value,
                       bool> {
   bool r;

--- a/libvast/vast/concept/parseable/string/any.hpp
+++ b/libvast/vast/concept/parseable/string/any.hpp
@@ -22,7 +22,7 @@ struct any_parser : public parser<any_parser> {
   using attribute = char;
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     if (f == l)
       return false;
     detail::absorb(a, *f);

--- a/libvast/vast/concept/parseable/string/c_string.hpp
+++ b/libvast/vast/concept/parseable/string/c_string.hpp
@@ -28,7 +28,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     auto i = f;
     auto p = str_;
     while (*p != '\0')

--- a/libvast/vast/concept/parseable/string/c_string.hpp
+++ b/libvast/vast/concept/parseable/string/c_string.hpp
@@ -21,9 +21,9 @@ namespace vast {
 
 class c_string_parser : public parser<c_string_parser> {
 public:
-  using attribute = char const*;
+  using attribute = const char*;
 
-  c_string_parser(char const* str) : str_{str} {
+  c_string_parser(const char* str) : str_{str} {
     VAST_ASSERT(str != nullptr);
   }
 
@@ -40,11 +40,11 @@ public:
   }
 
 private:
-  char const* str_;
+  const char* str_;
 };
 
 template <>
-struct parser_registry<char const*> {
+struct parser_registry<const char*> {
   using type = c_string_parser;
 };
 

--- a/libvast/vast/concept/parseable/string/char.hpp
+++ b/libvast/vast/concept/parseable/string/char.hpp
@@ -28,7 +28,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     if (f == l || *f != c_)
       return false;
     detail::absorb(a, c_);

--- a/libvast/vast/concept/parseable/string/char_class.hpp
+++ b/libvast/vast/concept/parseable/string/char_class.hpp
@@ -42,7 +42,7 @@ public:
   using attribute = char;
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     if (f == l || !test_char(*f, CharClass{}))
       return false;
     detail::absorb(a, *f);

--- a/libvast/vast/concept/parseable/string/char_range.hpp
+++ b/libvast/vast/concept/parseable/string/char_range.hpp
@@ -26,7 +26,7 @@ public:
   using attribute = char;
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     if (f == l || !check<From, To, Ranges...>(*f))
       return false;
     detail::absorb(a, *f);

--- a/libvast/vast/concept/parseable/string/quoted_string.hpp
+++ b/libvast/vast/concept/parseable/string/quoted_string.hpp
@@ -31,7 +31,7 @@ public:
   quoted_string_parser() = default;
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     auto escaped_quote = Esc >> char_parser{Quote};
     auto p = Quote >> +(escaped_quote | (parsers::print - Quote)) >> Quote;
     return p(f, l, a);

--- a/libvast/vast/concept/parseable/string/string.hpp
+++ b/libvast/vast/concept/parseable/string/string.hpp
@@ -28,7 +28,7 @@ public:
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     auto i = f;
     auto begin = str_.begin();
     auto end = str_.end();
@@ -40,7 +40,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     a.clear();
     auto out = std::back_inserter(a);
     auto i = f;

--- a/libvast/vast/concept/parseable/string/symbol_table.hpp
+++ b/libvast/vast/concept/parseable/string/symbol_table.hpp
@@ -33,7 +33,7 @@ struct symbol_table : parser<symbol_table<T>> {
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     auto input = std::string{f, l};
     auto prefixes = symbols.prefix_of(input);
     if (prefixes.empty())

--- a/libvast/vast/concept/parseable/to.hpp
+++ b/libvast/vast/concept/parseable/to.hpp
@@ -24,7 +24,7 @@
 namespace vast {
 
 template <typename To, typename Iterator>
-auto to(Iterator& f, Iterator const& l)
+auto to(Iterator& f, const Iterator& l)
   -> std::enable_if_t<is_parseable<Iterator, To>{}, expected<To>> {
   expected<To> t{To{}};
   if (!parse(f, l, *t))

--- a/libvast/vast/concept/parseable/vast/address.hpp
+++ b/libvast/vast/concept/parseable/vast/address.hpp
@@ -79,7 +79,7 @@ struct address_parser : vast::parser<address_parser> {
     // already consumes the input "f00:" after the first repitition parser, thus
     // erroneously leaving only ":" for next rule `>> h16` to consume.
     auto h16_colon
-      = h16 >> ':' >> ! ':'_p
+      = h16 >> ':' >> !':'_p
       ;
     auto ls32
       = h16 >> ':' >> h16

--- a/libvast/vast/concept/parseable/vast/address.hpp
+++ b/libvast/vast/concept/parseable/vast/address.hpp
@@ -100,7 +100,7 @@ struct address_parser : vast::parser<address_parser> {
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     static auto v4 = make_v4();
     static auto v6 = make_v6();
     if (v4(f, l, unused))
@@ -116,13 +116,13 @@ struct access::parser<address> : vast::parser<access::parser<address>> {
   using attribute = address;
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     static auto const p = address_parser{};
     return p(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, address& a) const {
+  bool parse(Iterator& f, const Iterator& l, address& a) const {
     static auto const v4 = address_parser::make_v4();
     auto begin = f;
     if (v4(f, l, a.bytes_[12], a.bytes_[13], a.bytes_[14], a.bytes_[15])) {

--- a/libvast/vast/concept/parseable/vast/base.hpp
+++ b/libvast/vast/concept/parseable/vast/base.hpp
@@ -25,7 +25,7 @@ struct base_parser : parser<base_parser> {
   using attribute = base;
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     auto num = parsers::integral<size_t>;
     auto to_base = [](std::vector<size_t> xs) { return base{xs}; };
     auto to_uniform_base = [](std::tuple<size_t, optional<size_t>> tuple) {

--- a/libvast/vast/concept/parseable/vast/data.hpp
+++ b/libvast/vast/concept/parseable/vast/data.hpp
@@ -57,13 +57,13 @@ struct access::parser<data> : vast::parser<access::parser<data>> {
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     static auto p = make<Iterator>();
     return p(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, data& a) const {
+  bool parse(Iterator& f, const Iterator& l, data& a) const {
     using namespace parsers;
     static auto p = make<Iterator>();
     return p(f, l, a);

--- a/libvast/vast/concept/parseable/vast/endpoint.hpp
+++ b/libvast/vast/concept/parseable/vast/endpoint.hpp
@@ -25,7 +25,7 @@ struct endpoint_parser : parser<endpoint_parser> {
   using attribute = endpoint;
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, endpoint& e) const {
+  bool parse(Iterator& f, const Iterator& l, endpoint& e) const {
     using namespace parsers;
     using namespace std::string_literals;
     auto hostname = +(alnum | chr{'-'} | chr{'_'} | chr{'.'});

--- a/libvast/vast/concept/parseable/vast/expression.hpp
+++ b/libvast/vast/concept/parseable/vast/expression.hpp
@@ -76,13 +76,13 @@ struct predicate_parser : parser<predicate_parser> {
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     static auto p = make();
     return p(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, predicate& a) const {
+  bool parse(Iterator& f, const Iterator& l, predicate& a) const {
     using namespace parsers;
     static auto p = make();
     return p(f, l, a);
@@ -162,13 +162,13 @@ struct expression_parser : parser<expression_parser> {
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     static auto p = make<Iterator>();
     return p(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, expression& a) const {
+  bool parse(Iterator& f, const Iterator& l, expression& a) const {
     static auto p = make<Iterator>();
     return p(f, l, a);
   }

--- a/libvast/vast/concept/parseable/vast/expression.hpp
+++ b/libvast/vast/concept/parseable/vast/expression.hpp
@@ -125,14 +125,14 @@ struct expression_parser : parser<expression_parser> {
         if (std::get<0>(t) == logical_and) {
           con.emplace_back(std::move(std::get<1>(t)));
         } else if (std::get<0>(t) == logical_or) {
-          VAST_ASSERT(! con.empty());
+          VAST_ASSERT(!con.empty());
           if (con.size() == 1)
             dis.emplace_back(std::move(con[0]));
           else
             dis.emplace_back(std::move(con));
           con = conjunction{std::move(std::get<1>(t))};
         } else {
-          VAST_ASSERT(! "negations must not exist here");
+          VAST_ASSERT(!"negations must not exist here");
         }
       if (con.size() == 1)
         dis.emplace_back(std::move(con[0]));

--- a/libvast/vast/concept/parseable/vast/http.hpp
+++ b/libvast/vast/concept/parseable/vast/http.hpp
@@ -43,13 +43,13 @@ struct http_header_parser : parser<http_header_parser> {
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     static auto p = make();
     return p(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, http::header& a) const {
+  bool parse(Iterator& f, const Iterator& l, http::header& a) const {
     static auto p = make();
     a.name.clear();
     a.value.clear();
@@ -84,13 +84,13 @@ struct http_request_parser : parser<http_request_parser> {
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     static auto p = make();
     return p(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, http::request& a) const {
+  bool parse(Iterator& f, const Iterator& l, http::request& a) const {
     static auto p = make();
     return p(f, l, a.method, a.uri, a.protocol, a.version, a.headers, a.body);
   }

--- a/libvast/vast/concept/parseable/vast/json.hpp
+++ b/libvast/vast/concept/parseable/vast/json.hpp
@@ -27,7 +27,7 @@ struct json_parser : parser<json_parser> {
   using attribute = json;
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, json& x) const {
+  bool parse(Iterator& f, const Iterator& l, json& x) const {
     using namespace parsers;
     rule<Iterator, json> j;
     auto ws = ignore(*parsers::space);

--- a/libvast/vast/concept/parseable/vast/key.hpp
+++ b/libvast/vast/concept/parseable/vast/key.hpp
@@ -29,7 +29,7 @@ struct key_parser : parser<key_parser> {
   using attribute = key;
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     // FIXME: we currently cannot parse character sequences into containers,
     // e.g., (alpha | '_') >> +(alnum ...). Until we have enhanced the
     // framework, we'll just bail out when we find a colon at the beginning.

--- a/libvast/vast/concept/parseable/vast/offset.hpp
+++ b/libvast/vast/concept/parseable/vast/offset.hpp
@@ -27,7 +27,7 @@ struct offset_parser : parser<offset_parser> {
   using attribute = offset;
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     static auto p = parsers::u32 % ',';
     return p(f, l, a);
   }

--- a/libvast/vast/concept/parseable/vast/pattern.hpp
+++ b/libvast/vast/concept/parseable/vast/pattern.hpp
@@ -28,12 +28,12 @@ struct access::parser<pattern> : vast::parser<access::parser<pattern>> {
   using attribute = pattern;
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     return pattern_parser{}(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, pattern& a) const {
+  bool parse(Iterator& f, const Iterator& l, pattern& a) const {
     return pattern_parser{}(f, l, a.str_);
   }
 };

--- a/libvast/vast/concept/parseable/vast/port.hpp
+++ b/libvast/vast/concept/parseable/vast/port.hpp
@@ -25,14 +25,14 @@ struct access::parser<port> : vast::parser<access::parser<port>> {
   using attribute = port;
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     using namespace parsers;
     auto p = u16 >> '/' >> ("?"_p | "tcp" | "udp" | "icmp");
     return p(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, port& a) const {
+  bool parse(Iterator& f, const Iterator& l, port& a) const {
     using namespace parsers;
     static auto p
       =  u16

--- a/libvast/vast/concept/parseable/vast/schema.hpp
+++ b/libvast/vast/concept/parseable/vast/schema.hpp
@@ -27,7 +27,7 @@ struct schema_parser : parser<schema_parser> {
   using attribute = schema;
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, schema& sch) const {
+  bool parse(Iterator& f, const Iterator& l, schema& sch) const {
     type_table symbols;
     auto to_type = [&](std::tuple<std::string, type> t) -> type {
       auto& name = std::get<0>(t);

--- a/libvast/vast/concept/parseable/vast/subnet.hpp
+++ b/libvast/vast/concept/parseable/vast/subnet.hpp
@@ -34,13 +34,13 @@ struct access::parser<subnet> : vast::parser<access::parser<subnet>> {
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     static auto p = make();
     return p(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, subnet& a) const {
+  bool parse(Iterator& f, const Iterator& l, subnet& a) const {
     static auto p = make();
     if (!p(f, l, a.network_, a.length_))
       return false;

--- a/libvast/vast/concept/parseable/vast/time.hpp
+++ b/libvast/vast/concept/parseable/vast/time.hpp
@@ -42,7 +42,7 @@ struct duration_parser : parser<duration_parser<Rep, Period>> {
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     using namespace parsers;
     auto save = f;
     Rep i;
@@ -130,13 +130,13 @@ struct ymdhms_parser : vast::parser<ymdhms_parser> {
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     static auto p = make();
     return p(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, timestamp& tp) const {
+  bool parse(Iterator& f, const Iterator& l, timestamp& tp) const {
     using namespace std::chrono;
     using namespace date;
     auto secs = 0;
@@ -176,7 +176,7 @@ struct timestamp_parser : parser<timestamp_parser> {
   using attribute = timestamp;
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     static auto plus = [](timespan span) {
       return timestamp::clock::now() + span;
     };

--- a/libvast/vast/concept/parseable/vast/type.hpp
+++ b/libvast/vast/concept/parseable/vast/type.hpp
@@ -57,7 +57,7 @@ private:
 struct type_parser : parser<type_parser> {
   using attribute = type;
 
-  type_parser(type_table const* symbols = nullptr)
+  type_parser(const type_table* symbols = nullptr)
     : symbol_type{symbols} {
   }
 
@@ -187,7 +187,7 @@ struct type_parser : parser<type_parser> {
     return type_type(f, l, a);
   }
 
-  type_table const* symbol_type;
+  const type_table* symbol_type;
 };
 
 template <>

--- a/libvast/vast/concept/parseable/vast/type.hpp
+++ b/libvast/vast/concept/parseable/vast/type.hpp
@@ -36,7 +36,7 @@ public:
       add(pair.first, pair.second);
   }
 
-  bool add(std::string const& name, type t) {
+  bool add(const std::string& name, type t) {
     if (name.empty() || name != t.name())
       return false;
     t.name(name);
@@ -45,7 +45,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     return symbols_(f, l, a);
   }
 
@@ -69,7 +69,7 @@ struct type_parser : parser<type_parser> {
   };
 
   template <typename Iterator, typename Attribute>
-  bool parse(Iterator& f, Iterator const& l, Attribute& a) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     // Whitespace
     static auto ws = ignore(*parsers::space);
     // Attributes: type meta data

--- a/libvast/vast/concept/parseable/vast/uri.hpp
+++ b/libvast/vast/concept/parseable/vast/uri.hpp
@@ -62,13 +62,13 @@ struct uri_parser : parser<uri_parser> {
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, unused_type) const {
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
     static auto p = make();
     return p(f, l, unused);
   }
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, uri& u) const {
+  bool parse(Iterator& f, const Iterator& l, uri& u) const {
     static auto p = make();
     return p(f, l, u.scheme, u.host, u.port, u.path, u.query, u.fragment);
   }

--- a/libvast/vast/concept/parseable/vast/uuid.hpp
+++ b/libvast/vast/concept/parseable/vast/uuid.hpp
@@ -27,7 +27,7 @@ struct uuid_parser : parser<uuid_parser> {
   // TODO: parser for unused type.
 
   template <typename Iterator>
-  bool parse(Iterator& f, Iterator const& l, uuid& a) const {
+  bool parse(Iterator& f, const Iterator& l, uuid& a) const {
     // TODO: convert to declarative parser.
     if (f == l)
       return false;

--- a/libvast/vast/concept/printable/core/action.hpp
+++ b/libvast/vast/concept/printable/core/action.hpp
@@ -39,7 +39,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool print(Iterator& out, Attribute const& attr) const {
+  bool print(Iterator& out, const Attribute& attr) const {
     if constexpr (action_traits::no_args_returns_void) {
       action_();
       return printer_.print(out, attr);

--- a/libvast/vast/concept/printable/core/and.hpp
+++ b/libvast/vast/concept/printable/core/and.hpp
@@ -27,7 +27,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool print(Iterator& out, Attribute const&) const {
+  bool print(Iterator& out, const Attribute&) const {
     return printer_.print(out, unused);
   }
 

--- a/libvast/vast/concept/printable/core/choice.hpp
+++ b/libvast/vast/concept/printable/core/choice.hpp
@@ -68,13 +68,13 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool print(Iterator& out, Attribute const& a) const {
+  bool print(Iterator& out, const Attribute& a) const {
     return print_left<Lhs>(out, a) || print_right(out, a);
   }
 
 private:
   template <typename Left, typename Iterator, typename Attribute>
-  auto print_left(Iterator& out, Attribute const& a) const
+  auto print_left(Iterator& out, const Attribute& a) const
   -> std::enable_if_t<is_choice_printer<Left>{}, bool> {
     return lhs_.print(out, a); // recurse
   }
@@ -86,7 +86,7 @@ private:
   }
 
   template <typename Left, typename Iterator, typename Attribute>
-  auto print_left(Iterator& out, Attribute const& a) const
+  auto print_left(Iterator& out, const Attribute& a) const
   -> std::enable_if_t<!is_choice_printer<Left>::value, bool> {
     auto x = get_if<lhs_attribute>(a);
     return x && lhs_.print(out, *x);
@@ -98,7 +98,7 @@ private:
   }
 
   template <typename Iterator, typename Attribute>
-  auto print_right(Iterator& out, Attribute const& a) const {
+  auto print_right(Iterator& out, const Attribute& a) const {
     auto x = get_if<rhs_attribute>(a);
     return x && rhs_.print(out, *x);
   }

--- a/libvast/vast/concept/printable/core/guard.hpp
+++ b/libvast/vast/concept/printable/core/guard.hpp
@@ -37,13 +37,13 @@ public:
   }
 
   template <typename Iterator, typename Attribute, typename G = Guard>
-  auto print(Iterator& out, Attribute const& a) const
+  auto print(Iterator& out, const Attribute& a) const
   -> std::enable_if_t<detail::guard_traits<G>::no_args_returns_bool, bool> {
     return guard_() && printer_.print(out, a);
   }
 
   template <typename Iterator, typename Attribute, typename G = Guard>
-  auto print(Iterator& out, Attribute const& a) const
+  auto print(Iterator& out, const Attribute& a) const
   -> std::enable_if_t<detail::guard_traits<G>::one_arg_returns_bool, bool> {
     return guard_(a) && printer_.print(out, a);
   }

--- a/libvast/vast/concept/printable/core/kleene.hpp
+++ b/libvast/vast/concept/printable/core/kleene.hpp
@@ -32,7 +32,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool print(Iterator& out, Attribute const& a) const {
+  bool print(Iterator& out, const Attribute& a) const {
     using std::begin;
     using std::end;
     auto f = begin(a);

--- a/libvast/vast/concept/printable/core/list.hpp
+++ b/libvast/vast/concept/printable/core/list.hpp
@@ -33,7 +33,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool print(Iterator& out, Attribute const& a) const {
+  bool print(Iterator& out, const Attribute& a) const {
     using std::begin;
     using std::end;
     auto f = begin(a);

--- a/libvast/vast/concept/printable/core/literal.hpp
+++ b/libvast/vast/concept/printable/core/literal.hpp
@@ -26,11 +26,11 @@ inline auto operator"" _P(char c) {
   return literal_printer{c};
 }
 
-inline auto operator"" _P(char const* str) {
+inline auto operator"" _P(const char* str) {
   return literal_printer{str};
 }
 
-inline auto operator"" _P(char const* str, size_t size) {
+inline auto operator"" _P(const char* str, size_t size) {
   return literal_printer{{str, size}};
 }
 

--- a/libvast/vast/concept/printable/core/maybe.hpp
+++ b/libvast/vast/concept/printable/core/maybe.hpp
@@ -30,7 +30,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool print(Iterator& out, Attribute const& a) const {
+  bool print(Iterator& out, const Attribute& a) const {
     printer_.print(out, a);
     return true;
   }

--- a/libvast/vast/concept/printable/core/not.hpp
+++ b/libvast/vast/concept/printable/core/not.hpp
@@ -27,7 +27,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool print(Iterator& out, Attribute const&) const {
+  bool print(Iterator& out, const Attribute&) const {
     return !printer_.print(out, unused);
   }
 

--- a/libvast/vast/concept/printable/core/optional.hpp
+++ b/libvast/vast/concept/printable/core/optional.hpp
@@ -44,7 +44,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool print(Iterator& out, Attribute const& a) const {
+  bool print(Iterator& out, const Attribute& a) const {
     return !a || printer_.print(out, *a);
   }
 

--- a/libvast/vast/concept/printable/core/plus.hpp
+++ b/libvast/vast/concept/printable/core/plus.hpp
@@ -33,7 +33,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool print(Iterator& out, Attribute const& a) const {
+  bool print(Iterator& out, const Attribute& a) const {
     using std::begin;
     using std::end;
     auto f = begin(a);

--- a/libvast/vast/concept/printable/core/printer.hpp
+++ b/libvast/vast/concept/printable/core/printer.hpp
@@ -47,7 +47,7 @@ struct printer {
 
   // FIXME: don't ignore ADL.
   template <typename Range, typename Attribute = unused_type>
-  auto operator()(Range&& r, Attribute const& a = unused) const
+  auto operator()(Range&& r, const Attribute& a = unused) const
   -> decltype(std::begin(r), std::end(r), bool()) {
     auto out = std::back_inserter(r);
     return derived().print(out, a);
@@ -55,26 +55,26 @@ struct printer {
 
   // FIXME: don't ignore ADL.
   template <typename Range, typename A0, typename A1, typename... As>
-  auto operator()(Range&& r, A0 const& a0, A1 const& a1, As const&... as) const
+  auto operator()(Range&& r, const A0& a0, const A1& a1, const As&... as) const
   -> decltype(std::begin(r), std::end(r), bool()) {
     return operator()(r, std::tie(a0, a1, as...));
   }
 
   template <typename Iterator, typename Attribute = unused_type>
-  auto operator()(Iterator&& out, Attribute const& a = unused) const
+  auto operator()(Iterator&& out, const Attribute& a = unused) const
   -> decltype(*out, ++out, bool()) {
     return derived().print(out, a);
   }
 
   template <typename Iterator, typename A0, typename A1, typename... As>
-  auto operator()(Iterator&& out, A0 const& a0, A1 const& a1, As const&... as) const
+  auto operator()(Iterator&& out, const A0& a0, const A1& a1, const As&... as) const
   -> decltype(*out, ++out, bool()) {
     return operator()(out, std::tie(a0, a1, as...));
   }
 
 private:
-  Derived const& derived() const {
-    return static_cast<Derived const&>(*this);
+  const Derived& derived() const {
+    return static_cast<const Derived&>(*this);
   }
 };
 

--- a/libvast/vast/concept/printable/core/sequence.hpp
+++ b/libvast/vast/concept/printable/core/sequence.hpp
@@ -71,7 +71,7 @@ public:
   }
 
   template <typename Iterator, typename Attribute>
-  bool print(Iterator& out, Attribute const& a) const {
+  bool print(Iterator& out, const Attribute& a) const {
     return print_left(out, a) && print_right(out, a);
   }
 
@@ -109,13 +109,13 @@ private:
   }
 
   template <typename L, typename T>
-  static auto get_helper(T const& x)
-  -> std::enable_if_t<is_sequence_printer<L>{}, T const&> {
+  static auto get_helper(const T& x)
+  -> std::enable_if_t<is_sequence_printer<L>{}, const T&> {
     return x;
   }
 
   template <typename L, typename T>
-  static auto get_helper(T const& x)
+  static auto get_helper(const T& x)
   -> std::enable_if_t<
        ! is_sequence_printer<L>::value,
        decltype(std::get<0>(x))
@@ -124,12 +124,12 @@ private:
   }
 
   template <typename Iterator, typename... Ts>
-  bool print_left(Iterator& out, std::tuple<Ts...> const& t) const {
+  bool print_left(Iterator& out, const std::tuple<Ts...>& t) const {
     return lhs_.print(out, get_helper<lhs_type>(t));
   }
 
   template <typename Iterator, typename... Ts>
-  bool print_right(Iterator& out, std::tuple<Ts...> const& t) const {
+  bool print_right(Iterator& out, const std::tuple<Ts...>& t) const {
     return rhs_.print(out, std::get<depth()>(t));
   }
 
@@ -144,22 +144,22 @@ private:
   }
 
   template <typename Iterator, typename T, typename U>
-  bool print_left(Iterator& out, std::pair<T, U> const& p) const {
+  bool print_left(Iterator& out, const std::pair<T, U>& p) const {
     return lhs_.print(out, p.first);
   }
 
   template <typename Iterator, typename T, typename U>
-  bool print_right(Iterator& out, std::pair<T, U> const& p) const {
+  bool print_right(Iterator& out, const std::pair<T, U>& p) const {
     return rhs_.print(out, p.second);
   }
 
   template <typename Iterator, typename Attribute>
-  bool print_left(Iterator& out, Attribute const& a) const {
+  bool print_left(Iterator& out, const Attribute& a) const {
     return lhs_.print(out, a);
   }
 
   template <typename Iterator, typename Attribute>
-  bool print_right(Iterator& out, Attribute const& a) const {
+  bool print_right(Iterator& out, const Attribute& a) const {
     return rhs_.print(out, a);
   }
 

--- a/libvast/vast/concept/printable/core/sequence.hpp
+++ b/libvast/vast/concept/printable/core/sequence.hpp
@@ -97,8 +97,8 @@ private:
   static constexpr auto depth_helper()
   -> std::enable_if_t<
        is_sequence_printer<T>::value
-        && ! std::is_same<typename T::lhs_attribute, unused_type>::value
-        && ! std::is_same<typename T::rhs_attribute, unused_type>::value,
+        && !std::is_same<typename T::lhs_attribute, unused_type>::value
+        && !std::is_same<typename T::rhs_attribute, unused_type>::value,
        size_t
      > {
     return 1 + depth_helper<typename T::lhs_type>();

--- a/libvast/vast/concept/printable/detail/as_printer.hpp
+++ b/libvast/vast/concept/printable/detail/as_printer.hpp
@@ -42,7 +42,7 @@ inline auto as_printer(std::string str) {
 template <typename T>
 auto as_printer(T x)
 -> std::enable_if_t<
-     std::is_arithmetic<T>{} && ! std::is_same<T, bool>::value,
+     std::is_arithmetic<T>{} && !std::is_same<T, bool>::value,
      literal_printer
    > {
   return literal_printer{x};
@@ -60,7 +60,7 @@ using is_convertible_to_unary_printer =
   std::integral_constant<
     bool,
     std::is_convertible<T, std::string>{}
-    || (std::is_arithmetic<T>{} && ! std::is_same<T, bool>::value)
+    || (std::is_arithmetic<T>{} && !std::is_same<T, bool>::value)
   >;
 
 template <typename T, typename U>

--- a/libvast/vast/concept/printable/detail/print_delimited.hpp
+++ b/libvast/vast/concept/printable/detail/print_delimited.hpp
@@ -44,7 +44,7 @@ bool print_delimited(InputIterator begin, InputIterator end,
 /// Prints a delimited Iterator range.
 template <typename InputIterator, typename OutputIterator, typename Delimiter>
 bool print_delimited(InputIterator begin, InputIterator end,
-                     OutputIterator&& out, Delimiter const& delim) {
+                     OutputIterator&& out, const Delimiter& delim) {
   if (begin == end)
     return true;
   if (!print(out, *begin))

--- a/libvast/vast/concept/printable/print.hpp
+++ b/libvast/vast/concept/printable/print.hpp
@@ -62,7 +62,7 @@ namespace detail {
 
 struct is_printable {
   template <typename I, typename T>
-  static auto test(I* out, T const* x) -> decltype(print(*out, *x), std::true_type());
+  static auto test(I* out, const T* x) -> decltype(print(*out, *x), std::true_type());
 
   template <typename, typename>
   static auto test(...) -> std::false_type;

--- a/libvast/vast/concept/printable/print.hpp
+++ b/libvast/vast/concept/printable/print.hpp
@@ -22,13 +22,13 @@
 namespace vast {
 
 template <typename Iterator, typename T, typename... Args>
-auto print(Iterator&& out, T const& x, Args&&... args)
+auto print(Iterator&& out, const T& x, Args&&... args)
   -> std::enable_if_t<has_printer<T>::value, bool> {
   return make_printer<T>{std::forward<Args>(args)...}.print(out, x);
 }
 
 template <typename Iterator, typename T, typename... Args>
-auto print(Iterator&& out, T const& x, Args&&... args)
+auto print(Iterator&& out, const T& x, Args&&... args)
   -> std::enable_if_t<!has_printer<T>::value && has_access_printer<T>::value,
                       bool> {
   return access::printer<T>{std::forward<Args>(args)...}.print(out, x);
@@ -37,19 +37,19 @@ auto print(Iterator&& out, T const& x, Args&&... args)
 //namespace detail {
 //
 //template <typename Iterator, typename T>
-//bool conjunctive_print(Iterator& out, T const& x) {
+//bool conjunctive_print(Iterator& out, const T& x) {
 //  return print(out, x);
 //}
 //
 //template <typename Iterator, typename T, typename... Ts>
-//bool conjunctive_print(Iterator& out, T const& x, Ts const&... xs) {
+//bool conjunctive_print(Iterator& out, const T& x, const Ts&... xs) {
 //  return conjunctive_print(out, x) && conjunctive_print(out, xs...);
 //}
 //
 //} // namespace detail
 //
 //template <typename Iterator, typename T>
-//auto print(Iterator&& out, T const& x)
+//auto print(Iterator&& out, const T& x)
 //  -> std::enable_if_t<!has_printer<T>::value && has_access_state<T>::value,
 //                      bool> {
 //  bool r;

--- a/libvast/vast/concept/printable/std/vector.hpp
+++ b/libvast/vast/concept/printable/std/vector.hpp
@@ -26,10 +26,10 @@ template <typename T>
 struct std_vector_printer : printer<std_vector_printer<T>> {
   using attribute = std::vector<T>;
 
-  std_vector_printer(std::string const& delim = ", ") : delim_{delim} {}
+  std_vector_printer(const std::string& delim = ", ") : delim_{delim} {}
 
   template <typename Iterator>
-  bool print(Iterator& out, attribute const& a) const {
+  bool print(Iterator& out, const attribute& a) const {
     return detail::print_delimited(a.begin(), a.end(), out, delim_);
   }
 

--- a/libvast/vast/concept/printable/stream.hpp
+++ b/libvast/vast/concept/printable/stream.hpp
@@ -22,7 +22,7 @@
 namespace vast {
 
 template <typename Char, typename Traits, typename T>
-auto operator<<(std::basic_ostream<Char, Traits>& out, T const& x)
+auto operator<<(std::basic_ostream<Char, Traits>& out, const T& x)
   -> std::enable_if_t<
        is_printable<std::ostreambuf_iterator<Char>, T>::value, decltype(out)
      > {

--- a/libvast/vast/concept/printable/string/literal.hpp
+++ b/libvast/vast/concept/printable/string/literal.hpp
@@ -53,7 +53,7 @@ public:
   literal_printer(char const(&str)[N]) : str_{str} {
   }
 
-  literal_printer(char const* str) : str_{str} {
+  literal_printer(const char* str) : str_{str} {
   }
 
   literal_printer(std::string str) : str_(std::move(str)) {

--- a/libvast/vast/concept/printable/string/string.hpp
+++ b/libvast/vast/concept/printable/string/string.hpp
@@ -36,7 +36,7 @@ struct string_printer : printer<string_printer> {
   }
 
   template <typename Iterator>
-  static bool print_string(Iterator& out, char const* str) {
+  static bool print_string(Iterator& out, const char* str) {
     while (*str != '\0')
       if (!printers::any.print(out, *str++))
         return false;
@@ -70,7 +70,7 @@ struct printer_registry<char[N]> {
 };
 
 template <>
-struct printer_registry<char const*> {
+struct printer_registry<const char*> {
   using type = string_printer;
 };
 

--- a/libvast/vast/concept/printable/string/string.hpp
+++ b/libvast/vast/concept/printable/string/string.hpp
@@ -44,7 +44,7 @@ struct string_printer : printer<string_printer> {
   }
 
   template <typename Iterator>
-  static bool print_string(Iterator& out, std::string const& str) {
+  static bool print_string(Iterator& out, const std::string& str) {
     return print_string(out, str.begin(), str.end());
   }
 
@@ -54,7 +54,7 @@ struct string_printer : printer<string_printer> {
   }
 
   template <typename Iterator, typename Attribute>
-  bool print(Iterator& out, Attribute const& str) const {
+  bool print(Iterator& out, const Attribute& str) const {
     return print_string(out, str);
   }
 };

--- a/libvast/vast/concept/printable/vast/address.hpp
+++ b/libvast/vast/concept/printable/vast/address.hpp
@@ -31,7 +31,7 @@ struct access::printer<address> : vast::printer<access::printer<address>> {
   using attribute = address;
 
   template <typename Iterator>
-  bool print(Iterator& out, address const& a) const {
+  bool print(Iterator& out, const address& a) const {
     char buf[INET6_ADDRSTRLEN];
     std::memset(buf, 0, sizeof(buf));
     auto result = a.is_v4()

--- a/libvast/vast/concept/printable/vast/attribute.hpp
+++ b/libvast/vast/concept/printable/vast/attribute.hpp
@@ -26,9 +26,9 @@ struct attribute_printer : printer<attribute_printer> {
   using attribute = vast::attribute;
 
   template <typename Iterator>
-  bool print(Iterator& out, vast::attribute const& attr) const {
+  bool print(Iterator& out, const vast::attribute& attr) const {
     using namespace printers;
-    auto prepend_eq = [](std::string const& x) { return '=' + x; };
+    auto prepend_eq = [](const std::string& x) { return '=' + x; };
     auto p = '&'_P << str << -(str ->* prepend_eq);
     return p(out, attr.key, attr.value);
   }

--- a/libvast/vast/concept/printable/vast/bitmap.hpp
+++ b/libvast/vast/concept/printable/vast/bitmap.hpp
@@ -25,7 +25,7 @@ struct bitmap_printer : printer<bitmap_printer<Bitmap, Policy>> {
   using attribute = Bitmap;
 
   template <class Iterator>
-  bool print(Iterator& out, Bitmap const& bm) const {
+  bool print(Iterator& out, const Bitmap& bm) const {
     auto p = *printers::bits<typename Bitmap::block_type, Policy>;
     return p.print(out, bit_range(bm));
   }

--- a/libvast/vast/concept/printable/vast/bits.hpp
+++ b/libvast/vast/concept/printable/vast/bits.hpp
@@ -33,7 +33,7 @@ struct bits_printer : printer<bits_printer<T , Policy>> {
   using word_type = typename bits<T>::word_type;
 
   template <class Iterator, class P = Policy>
-  auto print(Iterator& out, bits<T> const& b) const
+  auto print(Iterator& out, const bits<T>& b) const
   -> std::enable_if_t<std::is_same<P, policy::rle>::value, bool> {
     auto print_run = [&](auto bit, auto length) {
       using size_type = typename word_type::size_type;
@@ -64,7 +64,7 @@ struct bits_printer : printer<bits_printer<T , Policy>> {
   }
 
   template <class Iterator, class P = Policy>
-  auto print(Iterator& out, bits<T> const& b) const
+  auto print(Iterator& out, const bits<T>& b) const
   -> std::enable_if_t<std::is_same<P, policy::expanded>::value, bool> {
     if (b.size() > word_type::width) {
       auto c = b.data() ? '1' : '0';

--- a/libvast/vast/concept/printable/vast/bitvector.hpp
+++ b/libvast/vast/concept/printable/vast/bitvector.hpp
@@ -36,7 +36,7 @@ struct bitvector_printer : printer<bitvector_printer<Bitvector, Order>> {
     std::is_same<Order, policy::msb_to_lsb>::value;
 
   template <class Iterator>
-  bool print(Iterator& out, Bitvector const& bv) const {
+  bool print(Iterator& out, const Bitvector& bv) const {
     auto render = [&](auto f, auto l) {
       for (; f != l; ++f)
         if (!printers::any.print(out, *f ? '1' : '0'))

--- a/libvast/vast/concept/printable/vast/compression.hpp
+++ b/libvast/vast/concept/printable/vast/compression.hpp
@@ -24,7 +24,7 @@ struct compression_printer : printer<compression_printer> {
   using attribute = compression;
 
   template <typename Iterator>
-  bool print(Iterator& out, compression const& method) const {
+  bool print(Iterator& out, const compression& method) const {
     using namespace printers;
     switch (method) {
       case compression::null:

--- a/libvast/vast/concept/printable/vast/data.hpp
+++ b/libvast/vast/concept/printable/vast/data.hpp
@@ -39,7 +39,7 @@ struct data_printer : printer<data_printer> {
     }
 
     template <typename T>
-    bool operator()(T const& x) const {
+    bool operator()(const T& x) const {
       return make_printer<T>{}(out_, x);
     }
 
@@ -47,10 +47,10 @@ struct data_printer : printer<data_printer> {
       return printers::integral<integer, policy::force_sign>(out_, x);
     }
 
-    bool operator()(std::string const& str) const {
+    bool operator()(const std::string& str) const {
       // TODO: create a printer that escapes the output on the fly, as opposed
       // to going through an extra copy.
-      auto escaped = printers::str ->* [](std::string const& x) {
+      auto escaped = printers::str ->* [](const std::string& x) {
         return detail::byte_escape(x, "\"");
       };
       auto p = '"' << escaped << '"';
@@ -61,7 +61,7 @@ struct data_printer : printer<data_printer> {
   };
 
   template <typename Iterator>
-  bool print(Iterator& out, data const& d) const {
+  bool print(Iterator& out, const data& d) const {
     return visit(visitor<Iterator>{out}, d);
   }
 };
@@ -79,7 +79,7 @@ struct vector_printer : printer<vector_printer> {
   using attribute = vector;
 
   template <typename Iterator>
-  bool print(Iterator& out, vector const& v) const {
+  bool print(Iterator& out, const vector& v) const {
     auto p = '[' << ~(data_printer{} % ", ") << ']';
     return p.print(out, v);
   }
@@ -94,7 +94,7 @@ struct set_printer : printer<set_printer> {
   using attribute = set;
 
   template <typename Iterator>
-  bool print(Iterator& out, set const& s) const {
+  bool print(Iterator& out, const set& s) const {
     auto p = '{' << ~(data_printer{} % ", ") << '}';
     return p.print(out, s);
   }
@@ -109,7 +109,7 @@ struct table_printer : printer<table_printer> {
   using attribute = table;
 
   template <typename Iterator>
-  bool print(Iterator& out, table const& t) const {
+  bool print(Iterator& out, const table& t) const {
     auto pair = (data_printer{} << " -> " << data_printer{});
     auto p = '{' << ~(pair % ", ") << '}';
     return p.print(out, t);

--- a/libvast/vast/concept/printable/vast/error.hpp
+++ b/libvast/vast/concept/printable/vast/error.hpp
@@ -24,7 +24,7 @@ struct error_printer : printer<error_printer> {
   using attribute = error;
 
   template <typename Iterator>
-  bool print(Iterator& out, error const& e) const {
+  bool print(Iterator& out, const error& e) const {
     auto msg = to_string(e);
     return printers::str.print(out, msg);
   }

--- a/libvast/vast/concept/printable/vast/event.hpp
+++ b/libvast/vast/concept/printable/vast/event.hpp
@@ -28,7 +28,7 @@ struct event_printer : printer<event_printer> {
   using attribute = event;
 
   template <typename Iterator>
-  bool print(Iterator& out, event const& e) const {
+  bool print(Iterator& out, const event& e) const {
     using namespace printers;
     static auto p = str << str << u64 << chr<'|'>
                     << make_printer<timestamp>{} << str

--- a/libvast/vast/concept/printable/vast/expression.hpp
+++ b/libvast/vast/concept/printable/vast/expression.hpp
@@ -41,44 +41,44 @@ struct expression_printer : printer<expression_printer> {
       return print(out_, nil);
     }
 
-    bool operator()(conjunction const& c) const {
+    bool operator()(const conjunction& c) const {
       auto p = '{' << (expression_printer{} % " && ") << '}';
       return p(out_, c);
     }
 
-    bool operator()(disjunction const& d) const {
+    bool operator()(const disjunction& d) const {
       auto p = '(' << (expression_printer{} % " || ") << ')';
       return p(out_, d);
     }
 
-    bool operator()(negation const& n) const {
+    bool operator()(const negation& n) const {
       auto p = "! " << expression_printer{};
       return p(out_, n.expr());
     }
 
-    bool operator()(predicate const& p) const {
+    bool operator()(const predicate& p) const {
       auto op = ' ' << make_printer<relational_operator>{} << ' ';
       return visit(*this, p.lhs) && op(out_, p.op) && visit(*this, p.rhs);
     }
 
-    bool operator()(attribute_extractor const& e) const {
+    bool operator()(const attribute_extractor& e) const {
       return ('&' << printers::str)(out_, e.attr);
     }
 
-    bool operator()(type_extractor const& e) const {
+    bool operator()(const type_extractor& e) const {
       return (':' << printers::type<policy::name_only>)(out_, e.type);
     }
 
-    bool operator()(key_extractor const& e) const {
+    bool operator()(const key_extractor& e) const {
       return printers::key(out_, e.key);
     }
 
-    bool operator()(data_extractor const& e) const {
+    bool operator()(const data_extractor& e) const {
       auto p = printers::type<policy::name_only> << ~('@' << printers::offset);
       return p(out_, e.type, e.offset);
     }
 
-    bool operator()(data const& d) const {
+    bool operator()(const data& d) const {
       return printers::data(out_, d);
     }
 
@@ -86,7 +86,7 @@ struct expression_printer : printer<expression_printer> {
   };
 
   template <typename Iterator, typename T>
-  auto print(Iterator& out, T const& x) const
+  auto print(Iterator& out, const T& x) const
     -> std::enable_if_t<
          std::is_same<T, attribute_extractor>::value
          || std::is_same<T, key_extractor>::value
@@ -102,7 +102,7 @@ struct expression_printer : printer<expression_printer> {
   }
 
   template <typename Iterator>
-  bool print(Iterator& out, expression const& e) const
+  bool print(Iterator& out, const expression& e) const
   {
     return visit(visitor<Iterator>{out}, e);
   }

--- a/libvast/vast/concept/printable/vast/filesystem.hpp
+++ b/libvast/vast/concept/printable/vast/filesystem.hpp
@@ -24,7 +24,7 @@ struct path_printer : printer<path_printer> {
   using attribute = path;
 
   template <typename Iterator>
-  bool print(Iterator& out, path const& p) const {
+  bool print(Iterator& out, const path& p) const {
     return printers::str.print(out, p.str());
   }
 };

--- a/libvast/vast/concept/printable/vast/http.hpp
+++ b/libvast/vast/concept/printable/vast/http.hpp
@@ -29,7 +29,7 @@ struct http_header_printer : printer<http_header_printer> {
   using attribute = http::header;
 
   template <typename Iterator>
-  bool print(Iterator& out, http::header const& hdr) const {
+  bool print(Iterator& out, const http::header& hdr) const {
     using namespace printers;
     auto p = str << ": " << str;
     return p(out, hdr.name, hdr.value);
@@ -45,7 +45,7 @@ struct http_response_printer : printer<http::response> {
   using attribute = http::response;
 
   template <typename Iterator>
-  bool print(Iterator& out, http::response const& res) const {
+  bool print(Iterator& out, const http::response& res) const {
     using namespace printers;
     auto version = real_printer<double, 1>{};
     auto p 

--- a/libvast/vast/concept/printable/vast/json.hpp
+++ b/libvast/vast/concept/printable/vast/json.hpp
@@ -26,7 +26,7 @@ namespace vast {
 //  using attribute = json::type;
 //
 //  template <typename Iterator>
-//  bool print(Iterator& out, json::type const& t) {
+//  bool print(Iterator& out, const json::type& t) {
 //    using namespace printers;
 //    switch (t) {
 //      default:
@@ -66,7 +66,7 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
   struct print_visitor {
     print_visitor(Iterator& out) : out_{out} {}
 
-    bool operator()(none const&) {
+    bool operator()(const none&) {
       return printers::str.print(out_, "null");
     }
 
@@ -86,11 +86,11 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
       return printers::str.print(out_, str);
     }
 
-    bool operator()(std::string const& str) {
+    bool operator()(const std::string& str) {
       return printers::str.print(out_, detail::json_escape(str));
     }
 
-    bool operator()(json::array const& a) {
+    bool operator()(const json::array& a) {
       using namespace printers;
       if (depth_ == 0 && !pad())
         return false;
@@ -122,7 +122,7 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
       return any.print(out_, ']');
     }
 
-    bool operator()(json::object const& o) {
+    bool operator()(const json::object& o) {
       using namespace printers;
       if (depth_ == 0 && !pad())
         return false;
@@ -183,7 +183,7 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
   };
 
   template <typename Iterator, typename T>
-  auto print(Iterator& out, T const& x) const
+  auto print(Iterator& out, const T& x) const
   -> std::enable_if_t<
     !std::is_same<json::jsonize<T>, std::false_type>::value,
     bool
@@ -192,7 +192,7 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
   }
 
   template <typename Iterator>
-  bool print(Iterator& out, json const& j) const {
+  bool print(Iterator& out, const json& j) const {
     return visit(print_visitor<Iterator>{out}, j);
   }
 };

--- a/libvast/vast/concept/printable/vast/key.hpp
+++ b/libvast/vast/concept/printable/vast/key.hpp
@@ -26,7 +26,7 @@ struct key_printer : printer<key_printer> {
   using attribute = key;
 
   template <typename Iterator>
-  bool print(Iterator& out, key const& k) const {
+  bool print(Iterator& out, const key& k) const {
     return detail::print_delimited(k.begin(), k.end(), out, key::delimiter);
   }
 };

--- a/libvast/vast/concept/printable/vast/offset.hpp
+++ b/libvast/vast/concept/printable/vast/offset.hpp
@@ -26,7 +26,7 @@ struct offset_printer : printer<offset_printer> {
   using attribute = offset;
 
   template <typename Iterator>
-  bool print(Iterator& out, offset const& o) const {
+  bool print(Iterator& out, const offset& o) const {
     using delim = char_printer<','>;
     return detail::print_delimited<size_t, delim>(o.begin(), o.end(), out);
   }

--- a/libvast/vast/concept/printable/vast/operator.hpp
+++ b/libvast/vast/concept/printable/vast/operator.hpp
@@ -25,7 +25,7 @@ struct arithmetic_operator_printer : printer<arithmetic_operator_printer> {
   using attribute = arithmetic_operator;
 
   template <typename Iterator>
-  bool print(Iterator& out, arithmetic_operator const& op) const {
+  bool print(Iterator& out, const arithmetic_operator& op) const {
     switch (op) {
       default:
         die("missing case for arithmetic operator");
@@ -57,7 +57,7 @@ struct relational_operator_printer : printer<relational_operator_printer> {
   using attribute = relational_operator;
 
   template <typename Iterator>
-  bool print(Iterator& out, relational_operator const& op) const {
+  bool print(Iterator& out, const relational_operator& op) const {
     switch (op) {
       default:
         die("missing case for relational operator");
@@ -93,7 +93,7 @@ struct boolean_operator_printer : printer<boolean_operator_printer> {
   using attribute = boolean_operator;
 
   template <typename Iterator>
-  bool print(Iterator& out, boolean_operator const& op) const {
+  bool print(Iterator& out, const boolean_operator& op) const {
     switch (op) {
       default:
         die("missing case for boolean operator");

--- a/libvast/vast/concept/printable/vast/optional.hpp
+++ b/libvast/vast/concept/printable/vast/optional.hpp
@@ -26,7 +26,7 @@ struct optional_printer : printer<optional_printer<T>> {
   using attribute = optional<T>;
 
   template <typename Iterator>
-  bool print(Iterator& out, optional<T> const& o) const {
+  bool print(Iterator& out, const optional<T>& o) const {
     static auto p = make_printer<T>{};
     static auto n = make_printer<none>{};
     return o ? p.print(out, *o) : n.print(out, nil);

--- a/libvast/vast/concept/printable/vast/pattern.hpp
+++ b/libvast/vast/concept/printable/vast/pattern.hpp
@@ -28,7 +28,7 @@ struct access::printer<vast::pattern>
   using attribute = pattern;
 
   template <typename Iterator>
-  bool print(Iterator& out, pattern const& pat) const {
+  bool print(Iterator& out, const pattern& pat) const {
     auto p = '/' << printers::str << '/';
     return p.print(out, pat.str_);
   }

--- a/libvast/vast/concept/printable/vast/port.hpp
+++ b/libvast/vast/concept/printable/vast/port.hpp
@@ -26,7 +26,7 @@ struct port_printer : vast::printer<port_printer> {
   using attribute = port;
 
   template <typename Iterator>
-  bool print(Iterator& out, port const& p) const {
+  bool print(Iterator& out, const port& p) const {
     using namespace printers;
     if (!(u16(out, p.number()) && chr<'/'>(out)))
       return false;

--- a/libvast/vast/concept/printable/vast/schema.hpp
+++ b/libvast/vast/concept/printable/vast/schema.hpp
@@ -26,7 +26,7 @@ struct schema_printer : printer<schema_printer> {
   using attribute = schema;
 
   template <typename Iterator>
-  bool print(Iterator& out, schema const& s) const {
+  bool print(Iterator& out, const schema& s) const {
     auto p = "type "
           << printers::str
           << " = "

--- a/libvast/vast/concept/printable/vast/subnet.hpp
+++ b/libvast/vast/concept/printable/vast/subnet.hpp
@@ -26,7 +26,7 @@ struct subnet_printer : printer<subnet_printer> {
   using attribute = subnet;
 
   template <typename Iterator>
-  bool print(Iterator& out, subnet const& sn) const {
+  bool print(Iterator& out, const subnet& sn) const {
     using namespace printers;
     return (addr << chr<'/'> << u8)(out, sn.network(), sn.length());
   }

--- a/libvast/vast/concept/printable/vast/type.hpp
+++ b/libvast/vast/concept/printable/vast/type.hpp
@@ -35,7 +35,7 @@ struct enumeration_type_printer : printer<enumeration_type_printer> {
   using attribute = enumeration_type;
 
   template <typename Iterator>
-  bool print(Iterator& out, enumeration_type const& e) const {
+  bool print(Iterator& out, const enumeration_type& e) const {
     using namespace printers;
     auto p = "enum {"_P << (str % ", ") << '}';
     auto a = detail::make_attr_printer(e);
@@ -53,7 +53,7 @@ struct printer_registry<enumeration_type> {
     using attribute = TYPE;                                                    \
                                                                                \
     template <typename Iterator>                                               \
-    bool print(Iterator& out, TYPE const& t) const {                           \
+    bool print(Iterator& out, const TYPE& t) const {                           \
       using namespace printers;                                                \
       auto p = DESC##_P << detail::make_attr_printer(t);                       \
       return p.print(out, t.attributes());                                     \
@@ -85,7 +85,7 @@ VAST_DEFINE_BASIC_TYPE_PRINTER(port_type, "port")
     using attribute = TYPE;                                                    \
                                                                                \
     template <typename Iterator>                                               \
-    bool print(Iterator& out, TYPE const&) const;                              \
+    bool print(Iterator& out, const TYPE&) const;                              \
   };                                                                           \
                                                                                \
   template <>                                                                  \
@@ -123,7 +123,7 @@ struct type_printer : printer<type_printer<Policy>> {
   static_assert(show_name || show_type, "must show something");
 
   template <typename Iterator>
-  bool print(Iterator& out, type const& t) const {
+  bool print(Iterator& out, const type& t) const {
     if (show_name && !t.name().empty()) {
       auto guard = printers::eps.with([] { return show_type; });
       auto p = (printers::str << ~(&guard << " = "));
@@ -170,21 +170,21 @@ struct printer_registry<type> {
 // -- implementation of recursive type printers ------------------------------
 
 template <typename Iterator>
-bool vector_type_printer::print(Iterator& out, vector_type const& t) const {
+bool vector_type_printer::print(Iterator& out, const vector_type& t) const {
   auto p = "vector<" << type_printer<policy::name_only>{} << '>';
   auto a = detail::make_attr_printer(t);
   return (p << a)(out, t.value_type, t.attributes());
 }
 
 template <typename Iterator>
-bool set_type_printer::print(Iterator& out, set_type const& t) const {
+bool set_type_printer::print(Iterator& out, const set_type& t) const {
   auto p = "set<" << type_printer<policy::name_only>{} << '>';
   auto a = detail::make_attr_printer(t);
   return (p << a)(out, t.value_type, t.attributes());
 }
 
 template <typename Iterator>
-bool table_type_printer::print(Iterator& out, table_type const& t) const {
+bool table_type_printer::print(Iterator& out, const table_type& t) const {
   using namespace printers;
   auto p =  "table<"
          << type_printer<policy::name_only>{}
@@ -199,7 +199,7 @@ struct record_field_printer : printer<record_field_printer> {
   using attribute = record_field;
 
   template <typename Iterator>
-  bool print(Iterator& out, record_field const& f) const {
+  bool print(Iterator& out, const record_field& f) const {
     auto p = printers::str << ": " << type_printer<policy::name_only>{};
     return p(out, f.name, f.type);
   }
@@ -211,14 +211,14 @@ struct printer_registry<record_field> {
 };
 
 template <typename Iterator>
-bool record_type_printer::print(Iterator& out, record_type const& t) const {
+bool record_type_printer::print(Iterator& out, const record_type& t) const {
   auto p = "record{"_P << (record_field_printer{} % ", ") << '}';
   auto a = detail::make_attr_printer(t);
   return (p << a)(out, t.fields, t.attributes());
 }
 
 template <typename Iterator>
-bool alias_type_printer::print(Iterator& out, alias_type const& t) const {
+bool alias_type_printer::print(Iterator& out, const alias_type& t) const {
   auto p = type_printer<policy::name_only>{};
   auto a = detail::make_attr_printer(t);
   return (p << a)(out, t.value_type, t.attributes());

--- a/libvast/vast/concept/printable/vast/uri.hpp
+++ b/libvast/vast/concept/printable/vast/uri.hpp
@@ -30,7 +30,7 @@ struct key_value_printer : printer<key_value_printer> {
   using attribute = std::pair<std::string,std::string>;
 
   template <typename Iterator>
-  bool print(Iterator& out, std::pair<std::string,std::string> const& kv) const {
+  bool print(Iterator& out, const std::pair<std::string,std::string>& kv) const {
     using namespace printers;
     return str.print(out, detail::percent_escape(kv.first)) 
         && str.print(out, "=") 
@@ -47,7 +47,7 @@ struct uri_printer : printer<uri_printer> {
   using attribute = uri;
   
   template <typename Iterator>
-  bool print(Iterator& out, uri const& u) const {
+  bool print(Iterator& out, const uri& u) const {
     using namespace printers;
     
     if (u.scheme != "") {

--- a/libvast/vast/concept/printable/vast/uuid.hpp
+++ b/libvast/vast/concept/printable/vast/uuid.hpp
@@ -28,7 +28,7 @@ struct access::printer<uuid> : vast::printer<access::printer<uuid>> {
   using attribute = uuid;
 
   template <typename Iterator>
-  bool print(Iterator& out, uuid const& u) const {
+  bool print(Iterator& out, const uuid& u) const {
     static auto byte = printers::any << printers::any;
     for (size_t i = 0; i < 16; ++i) {
       auto hi = detail::byte_to_char((u.id_[i] >> 4) & 0x0f);

--- a/libvast/vast/concept/printable/vast/value.hpp
+++ b/libvast/vast/concept/printable/vast/value.hpp
@@ -23,7 +23,7 @@ struct value_printer : printer<value_printer> {
   using attribute = value;
 
   template <typename Iterator>
-  bool print(Iterator& out, value const& v) const {
+  bool print(Iterator& out, const value& v) const {
     static auto const p = make_printer<data>{};
     return p.print(out, v.data());
   }

--- a/libvast/vast/concept/support/unused_type.hpp
+++ b/libvast/vast/concept/support/unused_type.hpp
@@ -23,42 +23,42 @@ struct unused_type : detail::equality_comparable<unused_type>,
   unused_type() = default;
 
   template <typename T>
-  unused_type(T const&) {
+  unused_type(const T&) {
   }
 
-  unused_type& operator=(unused_type const&) = default;
+  unused_type& operator=(const unused_type&) = default;
 
-  unused_type const& operator=(unused_type const&) const {
+  const unused_type& operator=(const unused_type&) const {
     return *this;
   }
 
   template <typename T>
-  unused_type& operator=(T const&) {
+  unused_type& operator=(const T&) {
     return *this;
   }
 
   template <typename T>
-  unused_type const& operator=(T const&) const {
+  const unused_type& operator=(const T&) const {
     return *this;
   }
 
   template <typename T>
-  unused_type const& operator+=(T&&) const {
+  const unused_type& operator+=(T&&) const {
     return *this;
   }
 
   template <typename T>
-  unused_type const& operator-=(T&&) const {
+  const unused_type& operator-=(T&&) const {
     return *this;
   }
 
   template <typename T>
-  unused_type const& operator*=(T&&) const {
+  const unused_type& operator*=(T&&) const {
     return *this;
   }
 
   template <typename T>
-  unused_type const& operator/=(T&&) const {
+  const unused_type& operator/=(T&&) const {
     return *this;
   }
 };

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -143,10 +143,10 @@ public:
     : data_(data_type<T>(std::forward<T>(x))) {
   }
 
-  data& operator+=(data const& rhs);
+  data& operator+=(const data& rhs);
 
-  friend bool operator==(data const& lhs, data const& rhs);
-  friend bool operator<(data const& lhs, data const& rhs);
+  friend bool operator==(const data& lhs, const data& rhs);
+  friend bool operator<(const data& lhs, const data& rhs);
 
   template <class Inspector>
   friend auto inspect(Inspector&f, data& d) {
@@ -190,21 +190,21 @@ private:
 /// @param o The offset to access.
 /// @returns A pointer to the data at *o* or `nullptr` if *o* does not
 ///          describe a valid offset.
-data const* get(vector const& v, offset const& o);
-data const* get(data const& d, offset const& o);
+data const* get(const vector& v, const offset& o);
+data const* get(const data& d, const offset& o);
 
 /// Flattens a vector.
 /// @param xs The vector to flatten.
 /// @returns The flattened vector.
 /// @see unflatten
-vector flatten(vector const& xs);
+vector flatten(const vector& xs);
 vector flatten(vector&& xs);
 
 /// Flattens a vector.
 /// @param x The vector to flatten.
 /// @returns The flattened vector as `data` if *x* is a `vector`.
 /// @see unflatten
-data flatten(data const& x);
+data flatten(const data& x);
 data flatten(data&& x);
 
 /// Unflattens a vector according to a record type.
@@ -212,8 +212,8 @@ data flatten(data&& x);
 /// @param rt The type that defines the vector structure.
 /// @returns The unflattened vector of *xs* according to *rt*.
 /// @see flatten
-optional<vector> unflatten(vector const& xs, record_type const& rt);
-optional<vector> unflatten(vector&& xs, record_type const& rt);
+optional<vector> unflatten(const vector& xs, const record_type& rt);
+optional<vector> unflatten(vector&& xs, const record_type& rt);
 
 /// Unflattens a vector according to a record type.
 /// @param x The vector to unflatten according to *t*.
@@ -221,26 +221,26 @@ optional<vector> unflatten(vector&& xs, record_type const& rt);
 /// @returns The unflattened vector of *x* according to *t* if *x* is a
 ///          `vector` and *t* a `record_type`.
 /// @see flatten
-optional<vector> unflatten(data const& x, type const& t);
-optional<vector> unflatten(data&& x, type const& t);
+optional<vector> unflatten(const data& x, const type& t);
+optional<vector> unflatten(data&& x, const type& t);
 
 /// Evaluates a data predicate.
 /// @param lhs The LHS of the predicate.
 /// @param op The relational operator.
 /// @param rhs The RHS of the predicate.
-bool evaluate(data const& lhs, relational_operator op, data const& rhs);
+bool evaluate(const data& lhs, relational_operator op, const data& rhs);
 
 // -- convertible -------------------------------------------------------------
 
-bool convert(vector const& v, json& j);
-bool convert(set const& v, json& j);
-bool convert(table const& v, json& j);
-bool convert(data const& v, json& j);
+bool convert(const vector& v, json& j);
+bool convert(const set& v, json& j);
+bool convert(const table& v, json& j);
+bool convert(const data& v, json& j);
 
 /// Converts data with a type to "zipped" JSON, i.e., the JSON object for
 /// records contains the field names from the type corresponding to the given
 /// data.
-bool convert(data const& v, json& j, type const& t);
+bool convert(const data& v, json& j, const type& t);
 
 } // namespace vast
 

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -190,8 +190,8 @@ private:
 /// @param o The offset to access.
 /// @returns A pointer to the data at *o* or `nullptr` if *o* does not
 ///          describe a valid offset.
-data const* get(const vector& v, const offset& o);
-data const* get(const data& d, const offset& o);
+const data* get(const vector& v, const offset& o);
+const data* get(const data& d, const offset& o);
 
 /// Flattens a vector.
 /// @param xs The vector to flatten.

--- a/libvast/vast/detail/cache.hpp
+++ b/libvast/vast/detail/cache.hpp
@@ -148,7 +148,7 @@ public:
   /// the function default-constructs a value of `mapped_type`.
   /// @param key The key to lookup.
   /// @returns The value corresponding to *key*.
-  mapped_type& operator[](key_type const& x) {
+  mapped_type& operator[](const key_type& x) {
     auto i = tracker_.find(x);
     if (i == tracker_.end())
       return insert({x, {}}).first->second;
@@ -189,7 +189,7 @@ public:
   /// Removes an entry for a given key without invoking the eviction callback.
   /// @param x The key to remove.
   /// @returns The number of entries removed.
-  size_t erase(key_type const& x) {
+  size_t erase(const key_type& x) {
     auto i = tracker_.find(x);
     if (i == tracker_.end())
       return 0;

--- a/libvast/vast/detail/chrono_io.hpp
+++ b/libvast/vast/detail/chrono_io.hpp
@@ -68,8 +68,8 @@ class string_literal
 public:
     using const_iterator = const CharT*;
 
-    string_literal(string_literal const&) = default;
-    string_literal& operator=(string_literal const&) = delete;
+    string_literal(const string_literal&) = default;
+    string_literal& operator=(const string_literal&) = delete;
 
     template <std::size_t N1 = 2,
               class = std::enable_if_t<N1 == N>>
@@ -94,7 +94,7 @@ public:
     }
 
     template <class CharT2, class = std::enable_if_t<!std::is_same<CharT2, CharT>{}>>
-    constexpr string_literal(string_literal<CharT2, N> const& a) noexcept
+    constexpr string_literal(const string_literal<CharT2, N>& a) noexcept
         : p_{}
     {
         for (std::size_t i = 0; i < N; ++i)
@@ -120,7 +120,7 @@ public:
     constexpr const_iterator begin() const noexcept {return p_;}
     constexpr const_iterator end()   const noexcept {return p_ + N-1;}
 
-    constexpr CharT const& operator[](std::size_t n) const noexcept
+    constexpr const CharT& operator[](std::size_t n) const noexcept
     {
         return p_[n];
     }

--- a/libvast/vast/detail/compressedbuf.hpp
+++ b/libvast/vast/detail/compressedbuf.hpp
@@ -65,7 +65,7 @@ protected:
 
   int_type overflow(int_type c) override;
 
-  std::streamsize xsputn(char_type const* s, std::streamsize n) override;
+  std::streamsize xsputn(const char_type* s, std::streamsize n) override;
 
   // -- get area -------------------------------------------------------------
 

--- a/libvast/vast/detail/fdoutbuf.hpp
+++ b/libvast/vast/detail/fdoutbuf.hpp
@@ -27,7 +27,7 @@ public:
 
 protected:
   int_type overflow(int_type c) override;
-  std::streamsize xsputn(char const* s, std::streamsize n) override;
+  std::streamsize xsputn(const char* s, std::streamsize n) override;
 
 private:
   int fd_;

--- a/libvast/vast/detail/iterator.hpp
+++ b/libvast/vast/detail/iterator.hpp
@@ -111,7 +111,7 @@ private:
   }
 
   const Derived& derived() const {
-    return *static_cast<Derived const*>(this);
+    return *static_cast<const Derived*>(this);
   }
 
 public:

--- a/libvast/vast/detail/iterator.hpp
+++ b/libvast/vast/detail/iterator.hpp
@@ -30,7 +30,7 @@ class iterator_access {
 
 public:
   template <typename Facade>
-  static decltype(auto) dereference(Facade const& f) {
+  static decltype(auto) dereference(const Facade& f) {
     return f.dereference();
   }
 
@@ -50,12 +50,12 @@ public:
   }
 
   template <typename Facade1, typename Facade2>
-  static bool equals(Facade1 const& f1, Facade2 const& f2) {
+  static bool equals(const Facade1& f1, const Facade2& f2) {
     return f1.equals(f2);
   }
 
   template <typename Facade1, typename Facade2>
-  static auto distance_from(Facade1 const& f1, Facade2 const& f2) {
+  static auto distance_from(const Facade1& f1, const Facade2& f2) {
     return f2.distance_to(f1);
   }
 
@@ -80,7 +80,7 @@ private:
   template <typename R, typename P>
   struct operator_arrow_dispatch {
     struct proxy {
-      explicit proxy(R const& x) : ref(x) {
+      explicit proxy(const R& x) : ref(x) {
       }
 
       R* operator->() {
@@ -92,7 +92,7 @@ private:
 
     using result_type = proxy;
 
-    static result_type apply(R const& x) {
+    static result_type apply(const R& x) {
       return result_type{x};
     }
   };
@@ -110,7 +110,7 @@ private:
     return *static_cast<Derived*>(this);
   }
 
-  Derived const& derived() const {
+  const Derived& derived() const {
     return *static_cast<Derived const*>(this);
   }
 
@@ -132,7 +132,7 @@ public:
     >;
 
   struct postfix_increment_proxy {
-    explicit postfix_increment_proxy(Derived const& x) : value(*x) {
+    explicit postfix_increment_proxy(const Derived& x) : value(*x) {
     }
 
     value_type& operator*() const {
@@ -201,29 +201,29 @@ public:
     return result -= x;
   }
 
-  friend bool operator==(iterator_facade const& x, iterator_facade const& y) {
-    return iterator_access::equals(static_cast<Derived const&>(x),
-                                   static_cast<Derived const&>(y));
+  friend bool operator==(const iterator_facade& x, const iterator_facade& y) {
+    return iterator_access::equals(static_cast<const Derived&>(x),
+                                   static_cast<const Derived&>(y));
   }
 
-  friend bool operator<(iterator_facade const& x, iterator_facade const& y) {
-    return 0 > iterator_access::distance_from(static_cast<Derived const&>(x),
-                                              static_cast<Derived const&>(y));
+  friend bool operator<(const iterator_facade& x, const iterator_facade& y) {
+    return 0 > iterator_access::distance_from(static_cast<const Derived&>(x),
+                                              static_cast<const Derived&>(y));
   }
 
-  friend Derived operator+(iterator_facade const& x, difference_type n) {
-    Derived tmp{static_cast<Derived const&>(x)};
+  friend Derived operator+(const iterator_facade& x, difference_type n) {
+    Derived tmp{static_cast<const Derived&>(x)};
     return tmp += n;
   }
 
-  friend Derived operator+(difference_type n, iterator_facade const& x) {
-    Derived tmp{static_cast<Derived const&>(x)};
+  friend Derived operator+(difference_type n, const iterator_facade& x) {
+    Derived tmp{static_cast<const Derived&>(x)};
     return tmp += n;
   }
 
-  friend auto operator-(iterator_facade const& x, iterator_facade const& y) {
-    return iterator_access::distance_from(static_cast<Derived const&>(x),
-                                          static_cast<Derived const&>(y));
+  friend auto operator-(const iterator_facade& x, const iterator_facade& y) {
+    return iterator_access::distance_from(static_cast<const Derived&>(x),
+                                          static_cast<const Derived&>(y));
   }
 
 protected:
@@ -252,11 +252,11 @@ class iterator_adaptor
 
     iterator_adaptor() = default;
 
-    explicit iterator_adaptor(Base const& b)
+    explicit iterator_adaptor(const Base& b)
       : iterator_{b} {
     }
 
-    Base const& base() const {
+    const Base& base() const {
       return iterator_;
     }
 
@@ -272,7 +272,7 @@ class iterator_adaptor
       return *iterator_;
     }
 
-    bool equals(iterator_adaptor const& other) const {
+    bool equals(const iterator_adaptor& other) const {
       return iterator_ == other.base();
     }
 
@@ -288,7 +288,7 @@ class iterator_adaptor
       --iterator_;
     }
 
-    Difference distance_to(iterator_adaptor const& other) const {
+    Difference distance_to(const iterator_adaptor& other) const {
       return other.base() - iterator_;
     }
 

--- a/libvast/vast/detail/line_range.hpp
+++ b/libvast/vast/detail/line_range.hpp
@@ -27,7 +27,7 @@ class line_range : range_facade<line_range> {
 public:
   line_range(std::istream& input);
 
-  std::string const& get() const;
+  const std::string& get() const;
 
   void next();
 

--- a/libvast/vast/detail/math.hpp
+++ b/libvast/vast/detail/math.hpp
@@ -95,7 +95,7 @@ constexpr T pow(T base) {
 /// @returns The integer logarithm of *x*.
 template <int base, typename T>
 constexpr int ilog(T x) {
-  static_assert(! (base <= 0), "ilog is not useful for base <= 0");
+  static_assert(!(base <= 0), "ilog is not useful for base <= 0");
   static_assert(base != 1, "ilog is not useful for base == 1");
   static_assert(std::is_integral<T>{}, "ilog only works on integral types");
   return x > 0 ? ilog_helper<base>(x) : -1;

--- a/libvast/vast/detail/operators.hpp
+++ b/libvast/vast/detail/operators.hpp
@@ -18,37 +18,37 @@ namespace vast::detail {
 
 template <typename T, typename U = T>
 struct equality_comparable {
-  friend bool operator!=(T const& x, U const& y) {
+  friend bool operator!=(const T& x, const U& y) {
     return !(x == y);
   }
 };
 
 template <typename T, typename U = T>
 struct less_than_comparable {
-  friend bool operator>(T const& x, U const& y) {
+  friend bool operator>(const T& x, const U& y) {
     return y < x;
   }
 
-  friend bool operator<=(T const& x, U const& y) {
+  friend bool operator<=(const T& x, const U& y) {
     return !(y < x);
   }
 
-  friend bool operator>=(T const& x, U const& y) {
+  friend bool operator>=(const T& x, const U& y) {
     return !(x < y);
   }
 };
 
 template <typename T, typename U = T>
 struct partially_ordered {
-  friend bool operator>(T const& x, U const& y) {
+  friend bool operator>(const T& x, const U& y) {
     return y < x;
   }
 
-  friend bool operator<=(T const& x, U const& y) {
+  friend bool operator<=(const T& x, const U& y) {
     return x < y || x == y;
   }
 
-  friend bool operator>=(T const& x, U const& y) {
+  friend bool operator>=(const T& x, const U& y) {
     return y < x || x == y;
   }
 };
@@ -60,7 +60,7 @@ struct totally_ordered : equality_comparable<T, U>,
 #define VAST_BINARY_OPERATOR_NON_COMMUTATIVE(NAME, OP)                         \
   template <typename T, typename U = T>                                        \
   struct NAME {                                                                \
-    friend T operator OP(T const& x, U const& y) {                             \
+    friend T operator OP(const T& x, const U& y) {                             \
       T t(x);                                                                  \
       t OP## = y;                                                              \
       return t;                                                                \
@@ -70,7 +70,7 @@ struct totally_ordered : equality_comparable<T, U>,
 #define VAST_BINARY_OPERATOR_COMMUTATIVE(NAME, OP)                             \
   template <typename T, typename U = T>                                        \
   struct NAME {                                                                \
-    friend T operator OP(T const& x, U const& y) {                             \
+    friend T operator OP(const T& x, const U& y) {                             \
       T t(x);                                                                  \
       t OP## = y;                                                              \
       return t;                                                                \

--- a/libvast/vast/detail/posix.hpp
+++ b/libvast/vast/detail/posix.hpp
@@ -23,7 +23,7 @@ namespace vast::detail {
 /// Constructs a UNIX domain socket.
 /// @param path The file system path where to construct the socket.
 /// @returns The descriptor of the domain socket on success or -1 on failure.
-int uds_listen(std::string const& path);
+int uds_listen(const std::string& path);
 
 /// Accepts a UNIX domain socket.
 /// @param socket The file descriptor created with ::uds_listen.
@@ -33,7 +33,7 @@ int uds_accept(int socket);
 /// Connects to UNIX domain socket.
 /// @param path The file system path where to the existing domain socket.
 /// @returns The descriptor of the domain socket on success or -1 on failure.
-int uds_connect(std::string const& path);
+int uds_connect(const std::string& path);
 
 /// Sends a file descriptor over a UNIX domain socket.
 /// @param socket The domain socket descriptor.
@@ -53,17 +53,17 @@ public:
   /// Creates a UNIX domain socket listening server at a given path.
   /// @param path The filesystem path where to construct the socket.
   /// @returns A file descriptor to the listening docket.
-  static int listen(std::string const& path);
+  static int listen(const std::string& path);
 
   /// Creates a UNIX domain socket server and blocks to accept a connection.
   /// @param path The filesystem path where to construct the socket.
   /// @returns A UNIX domain socket handle.
-  static unix_domain_socket accept(std::string const& path);
+  static unix_domain_socket accept(const std::string& path);
 
   /// Creates a UNIX domain socket client by connecting to an existing server.
   /// @param path The filesystem path identifying the server socket.
   /// @returns A UNIX domain socket handle.
-  static unix_domain_socket connect(std::string const& path);
+  static unix_domain_socket connect(const std::string& path);
 
   /// Constructs a UNIX domain socket.
   /// @param fd The file descriptor to the socket. Default to -1, an invalid

--- a/libvast/vast/detail/posix.hpp
+++ b/libvast/vast/detail/posix.hpp
@@ -127,7 +127,7 @@ bool read(int fd, void* buffer, size_t bytes, size_t* got = nullptr);
 /// @param bytes The number of bytes to write into *fd* from *buffer*.
 /// @param put If not-nullptr, receives the number of bytes actually read.
 /// @returns `true` on successful reading.
-bool write(int fd, void const* buffer, size_t bytes, size_t* put = nullptr);
+bool write(int fd, const void* buffer, size_t bytes, size_t* put = nullptr);
 
 /// Wraps `seek(2)`.
 /// @param fd A seekable file descriptor.

--- a/libvast/vast/detail/random.hpp
+++ b/libvast/vast/detail/random.hpp
@@ -43,7 +43,7 @@ public:
       return scale_;
     }
 
-    friend bool operator==(param_type const& lhs, param_type const& rhs) {
+    friend bool operator==(const param_type& lhs, const param_type& rhs) {
       return lhs.shape_ == rhs.shape_ && lhs.scale_ == rhs.scale_;
     }
 
@@ -63,7 +63,7 @@ public:
   result_type operator()(URNG& g);
 
   template <typename URNG>
-  result_type operator()(URNG& g, param_type const& parm);
+  result_type operator()(URNG& g, const param_type& parm);
 
   param_type param() const {
     return params_;
@@ -81,8 +81,8 @@ public:
     return params_.scale();
   }
 
-  friend bool operator==(pareto_distribution const& lhs,
-                         pareto_distribution const& rhs) {
+  friend bool operator==(const pareto_distribution& lhs,
+                         const pareto_distribution& rhs) {
     return lhs.params_ == rhs.params_;
   }
 
@@ -91,7 +91,7 @@ private:
 };
 
 template <typename R>
-R pdf(pareto_distribution<R> const& dist, R x) {
+R pdf(const pareto_distribution<R>& dist, R x) {
   auto shape = dist.shape();
   auto scale = dist.scale();
   if (x < scale)
@@ -100,7 +100,7 @@ R pdf(pareto_distribution<R> const& dist, R x) {
 }
 
 template <typename R>
-R cdf(pareto_distribution<R> const& dist, R x) {
+R cdf(const pareto_distribution<R>& dist, R x) {
   auto shape = dist.shape();
   auto scale = dist.scale();
   if (x <= scale)
@@ -109,7 +109,7 @@ R cdf(pareto_distribution<R> const& dist, R x) {
 }
 
 template <typename R>
-R quantile(pareto_distribution<R> const& dist, R p) {
+R quantile(const pareto_distribution<R>& dist, R p) {
   auto shape = dist.shape();
   auto scale = dist.scale();
   if (p == 0)
@@ -128,7 +128,7 @@ R pareto_distribution<R>::operator()(URNG& g) {
 template <typename R>
 template <typename URNG>
 R pareto_distribution<R>::operator()(
-  URNG& g, typename pareto_distribution<R>::param_type const& parm) {
+  URNG& g, const typename pareto_distribution<R>::param_type& parm) {
   return pareto_distribution<R>{parm}(g);
 }
 

--- a/libvast/vast/detail/range.hpp
+++ b/libvast/vast/detail/range.hpp
@@ -33,7 +33,7 @@ public:
   }
 
   bool empty() const {
-    auto d = static_cast<Derived const*>(this);
+    auto d = static_cast<const Derived*>(this);
     return d->begin() == d->end();
   }
 };
@@ -93,7 +93,7 @@ private:
   friend iterator;
 
   bool complete() const {
-    return static_cast<Derived const*>(this)->done();
+    return static_cast<const Derived*>(this)->done();
   }
 
   void increment() {
@@ -105,7 +105,7 @@ private:
 public:
 #endif
   decltype(auto) dereference() const {
-    return static_cast<Derived const*>(this)->get();
+    return static_cast<const Derived*>(this)->get();
   }
 };
 

--- a/libvast/vast/detail/range.hpp
+++ b/libvast/vast/detail/range.hpp
@@ -57,7 +57,7 @@ private:
   explicit range_iterator(Range& rng) : rng_{&rng} {
   }
 
-  bool equals(range_iterator const&) const {
+  bool equals(const range_iterator&) const {
     return rng_->complete();
   }
 

--- a/libvast/vast/detail/range_map.hpp
+++ b/libvast/vast/detail/range_map.hpp
@@ -202,7 +202,7 @@ public:
   /// @param p The point to lookup.
   /// @returns A pointer to the value associated with the half-open interval
   ///          *[a,b)* if *a <= p < b* and `nullptr` otherwise.
-  Value const* lookup(const Point& p) const {
+  const Value* lookup(const Point& p) const {
     auto i = locate(p, map_.lower_bound(p));
     return i != map_.end() ? &i->second.second : nullptr;
   }
@@ -214,9 +214,9 @@ public:
   ///          and `nullptr` otherwise. If the last component points to a
   ///          valid value, then the first two represent *[a,b)* and *[0,0)*
   ///          otherwise.
-  std::tuple<Point, Point, Value const*> find(const Point& p) const {
+  std::tuple<Point, Point, const Value*> find(const Point& p) const {
     // GCC 4.9 still has an explicit tuple ctor.
-    using tuple_type = std::tuple<Point, Point, Value const*>;
+    using tuple_type = std::tuple<Point, Point, const Value*>;
     auto i = locate(p, map_.lower_bound(p));
     if (i == map_.end())
       return tuple_type{0, 0, nullptr};

--- a/libvast/vast/detail/range_map.hpp
+++ b/libvast/vast/detail/range_map.hpp
@@ -35,9 +35,9 @@ class range_map {
 
 public:
   struct entry {
-    Point const& left;
-    Point const& right;
-    Value const& value;
+    const Point& left;
+    const Point& right;
+    const Value& value;
   };
 
   class const_iterator
@@ -202,7 +202,7 @@ public:
   /// @param p The point to lookup.
   /// @returns A pointer to the value associated with the half-open interval
   ///          *[a,b)* if *a <= p < b* and `nullptr` otherwise.
-  Value const* lookup(Point const& p) const {
+  Value const* lookup(const Point& p) const {
     auto i = locate(p, map_.lower_bound(p));
     return i != map_.end() ? &i->second.second : nullptr;
   }
@@ -214,7 +214,7 @@ public:
   ///          and `nullptr` otherwise. If the last component points to a
   ///          valid value, then the first two represent *[a,b)* and *[0,0)*
   ///          otherwise.
-  std::tuple<Point, Point, Value const*> find(Point const& p) const {
+  std::tuple<Point, Point, Value const*> find(const Point& p) const {
     // GCC 4.9 still has an explicit tuple ctor.
     using tuple_type = std::tuple<Point, Point, Value const*>;
     auto i = locate(p, map_.lower_bound(p));
@@ -263,14 +263,14 @@ private:
   }
 
   // Finds the interval of a point.
-  map_const_iterator locate(Point const& p, map_const_iterator lb) const {
+  map_const_iterator locate(const Point& p, map_const_iterator lb) const {
     if ((lb != map_.end() && p == left(lb))
         || (lb != map_.begin() && p < right(--lb)))
       return lb;
     return map_.end();
   }
 
-  map_iterator locate(Point const& p, map_iterator lb) {
+  map_iterator locate(const Point& p, map_iterator lb) {
     if ((lb != map_.end() && p == left(lb))
         || (lb != map_.begin() && p < right(--lb)))
       return lb;

--- a/libvast/vast/detail/stack_vector.hpp
+++ b/libvast/vast/detail/stack_vector.hpp
@@ -48,7 +48,7 @@ struct stack_vector : private stack_container<T, N>, short_vector<T, N> {
   stack_vector() : vector_type(this->arena_) {
   }
 
-  stack_vector(size_t n, T const& x) : vector_type(n, x, this->arena_) {
+  stack_vector(size_t n, const T& x) : vector_type(n, x, this->arena_) {
   }
 
   explicit stack_vector(size_t n) : vector_type(n, this->arena_) {
@@ -63,7 +63,7 @@ struct stack_vector : private stack_container<T, N>, short_vector<T, N> {
     : vector_type(first, last, this->arena_) {
   }
 
-  stack_vector(stack_vector const& other)
+  stack_vector(const stack_vector& other)
     : vector_type(other, this->arena_) {
   }
 
@@ -72,7 +72,7 @@ struct stack_vector : private stack_container<T, N>, short_vector<T, N> {
     : vector_type(std::move(other), this->arena_) {
   }
 
-  stack_vector& operator=(stack_vector const& other) {
+  stack_vector& operator=(const stack_vector& other) {
     static_cast<vector_type&>(*this) = other;
     return *this;
   }

--- a/libvast/vast/detail/string.hpp
+++ b/libvast/vast/detail/string.hpp
@@ -74,7 +74,7 @@ auto hex_unescaper = [](auto& f, auto l, auto out) {
   if (f == l)
     return false;
   auto lo = *f++;
-  if (! std::isxdigit(hi) || ! std::isxdigit(lo))
+  if (!std::isxdigit(hi) || !std::isxdigit(lo))
     return false;
   *out++ = hex_to_byte(hi, lo);
   return true;
@@ -208,7 +208,7 @@ auto json_unescaper = [](auto& f, auto l, auto out) {
         std::copy(bytes.begin(), bytes.end(), out);
       } else {
         // Hex-unescape the XX portion of \u00XX.
-        if (! std::isxdigit(bytes[2]) || ! std::isxdigit(bytes[3]))
+        if (!std::isxdigit(bytes[2]) || !std::isxdigit(bytes[3]))
           return false;
         *out++ = hex_to_byte(bytes[2], bytes[3]);
       }

--- a/libvast/vast/detail/string.hpp
+++ b/libvast/vast/detail/string.hpp
@@ -33,7 +33,7 @@ namespace vast::detail {
 /// @param escaper The escaper to use.
 /// @returns The escaped version of *str*.
 template <class Escaper>
-std::string escape(std::string const& str, Escaper escaper) {
+std::string escape(const std::string& str, Escaper escaper) {
   std::string result;
   result.reserve(str.size());
   auto f = str.begin();
@@ -49,7 +49,7 @@ std::string escape(std::string const& str, Escaper escaper) {
 /// @param unescaper The unescaper to use.
 /// @returns The unescaped version of *str*.
 template <class Unescaper>
-std::string unescape(std::string const& str, Unescaper unescaper) {
+std::string unescape(const std::string& str, Unescaper unescaper) {
   std::string result;
   result.reserve(str.size());
   auto f = str.begin();
@@ -243,7 +243,7 @@ auto percent_unescaper = [](auto& f, auto l, auto out) {
   return hex_unescaper(++f, l, out);
 };
 
-auto double_escaper = [](std::string const& esc) {
+auto double_escaper = [](const std::string& esc) {
   return [&](auto& f, auto, auto out) {
     if (esc.find(*f) != std::string::npos)
       *out++ = *f;
@@ -251,7 +251,7 @@ auto double_escaper = [](std::string const& esc) {
   };
 };
 
-auto double_unescaper = [](std::string const& esc) {
+auto double_unescaper = [](const std::string& esc) {
   return [&](auto& f, auto l, auto out) -> bool {
     auto x = *f++;
     if (f == l) {
@@ -271,7 +271,7 @@ auto double_unescaper = [](std::string const& esc) {
 /// @param str The string to escape.
 /// @returns The escaped string of *str*.
 /// @relates bytes_escape_all byte_unescape
-std::string byte_escape(std::string const& str);
+std::string byte_escape(const std::string& str);
 
 /// Escapes all non-printable characters in a string with `\xAA` where `AA` is
 /// the byte in hexadecimal representation, plus a given list of extra
@@ -280,33 +280,33 @@ std::string byte_escape(std::string const& str);
 /// @param extra The extra characters to escape.
 /// @returns The escaped string of *str*.
 /// @relates bytes_escape_all byte_unescape
-std::string byte_escape(std::string const& str, std::string const& extra);
+std::string byte_escape(const std::string& str, const std::string& extra);
 
 /// Escapes all characters in a string with `\xAA` where `AA` is
 /// the byte in hexadecimal representation of the character.
 /// @param str The string to escape.
 /// @returns The escaped string of *str*.
 /// @relates byte_unescape
-std::string byte_escape_all(std::string const& str);
+std::string byte_escape_all(const std::string& str);
 
 /// Unescapes a byte-escaped string, i.e., replaces all occurrences of `\xAA`
 /// with the value of the byte `AA`.
 /// @param str The string to unescape.
 /// @returns The unescaped string of *str*.
 /// @relates byte_escape bytes_escape_all
-std::string byte_unescape(std::string const& str);
+std::string byte_unescape(const std::string& str);
 
 /// Escapes a string according to JSON escaping.
 /// @param str The string to escape.
 /// @returns The escaped string.
 /// @relates json_unescape
-std::string json_escape(std::string const& str);
+std::string json_escape(const std::string& str);
 
 /// Unescapes a string escaped with JSON escaping.
 /// @param str The string to unescape.
 /// @returns The unescaped string.
 /// @relates json_escape
-std::string json_unescape(std::string const& str);
+std::string json_unescape(const std::string& str);
 
 /// Escapes a string according to percent-encoding.
 /// @note This function escapes all non-*unreserved* characters as listed in
@@ -316,27 +316,27 @@ std::string json_unescape(std::string const& str);
 /// @param str The string to escape.
 /// @returns The escaped string.
 /// @relates percent_unescape
-std::string percent_escape(std::string const& str);
+std::string percent_escape(const std::string& str);
 
 /// Unescapes a percent-encoded string.
 /// @param str The string to unescape.
 /// @returns The unescaped string.
 /// @relates percent_escape
-std::string percent_unescape(std::string const& str);
+std::string percent_unescape(const std::string& str);
 
 /// Escapes a string by repeating characters from a special set.
 /// @param str The string to escape.
 /// @param esc The set of characters to double-escape.
 /// @returns The escaped string.
 /// @relates double_unescape
-std::string double_escape(std::string const& str, std::string const& esc);
+std::string double_escape(const std::string& str, const std::string& esc);
 
 /// Unescapes a string by removing consecutive character sequences.
 /// @param str The string to unescape.
 /// @param esc The set of repeated characters to unescape.
 /// @returns The unescaped string.
 /// @relates double_escape
-std::string double_unescape(std::string const& str, std::string const& esc);
+std::string double_unescape(const std::string& str, const std::string& esc);
 
 /// Replaces find and replace all occurences of a substring.
 /// @param str The string in which to replace a substring.
@@ -362,8 +362,8 @@ std::string replace_all(std::string str, const std::string& search,
 ///          with a range *[start, end)*.
 template <typename Iterator>
 std::vector<std::pair<Iterator, Iterator>>
-split(Iterator begin, Iterator end, std::string const& sep,
-      std::string const& esc = "", size_t max_splits = -1,
+split(Iterator begin, Iterator end, const std::string& sep,
+      const std::string& esc = "", size_t max_splits = -1,
       bool include_sep = false) {
   VAST_ASSERT(!sep.empty());
   std::vector<std::pair<Iterator, Iterator>> pos;
@@ -417,8 +417,8 @@ split(Iterator begin, Iterator end, std::string const& sep,
 }
 
 std::vector<std::pair<std::string::const_iterator, std::string::const_iterator>>
-inline split(std::string const& str, std::string const& sep,
-             std::string const& esc = "", size_t max_splits = -1,
+inline split(const std::string& str, const std::string& sep,
+             const std::string& esc = "", size_t max_splits = -1,
              bool include_sep = false) {
   return split(str.begin(), str.end(), sep, esc, max_splits, include_sep);
 }
@@ -427,7 +427,7 @@ inline split(std::string const& str, std::string const& sep,
 /// @param v The vector of iterator pairs from ::split.
 /// @returns a vector of strings with the split elements.
 template <typename Iterator>
-auto to_strings(std::vector<std::pair<Iterator, Iterator>> const& v) {
+auto to_strings(const std::vector<std::pair<Iterator, Iterator>>& v) {
   std::vector<std::string> strs;
   strs.resize(v.size());
   for (size_t i = 0; i < v.size(); ++i)
@@ -437,14 +437,14 @@ auto to_strings(std::vector<std::pair<Iterator, Iterator>> const& v) {
 
 /// Combines ::split and ::to_strings.
 template <typename Iterator>
-auto split_to_str(Iterator begin, Iterator end, std::string const& sep,
-                  std::string const& esc = "", size_t max_splits = -1,
+auto split_to_str(Iterator begin, Iterator end, const std::string& sep,
+                  const std::string& esc = "", size_t max_splits = -1,
                   bool include_sep = false) {
   return to_strings(split(begin, end, sep, esc, max_splits, include_sep));
 }
 
-inline auto split_to_str(std::string const& str, std::string const& sep,
-                         std::string const& esc = "", size_t max_splits = -1,
+inline auto split_to_str(const std::string& str, const std::string& sep,
+                         const std::string& esc = "", size_t max_splits = -1,
                          bool include_sep = false) {
   return split_to_str(str.begin(), str.end(), sep, esc, max_splits,
                       include_sep);
@@ -456,7 +456,7 @@ inline auto split_to_str(std::string const& str, std::string const& sep,
 /// @param sep The string to insert between each element of the sequence.
 /// @returns The joined string.
 template <typename Iterator, typename Predicate>
-std::string join(Iterator begin, Iterator end, std::string const& sep,
+std::string join(Iterator begin, Iterator end, const std::string& sep,
                  Predicate p) {
   std::string result;
   if (begin != end)
@@ -467,12 +467,12 @@ std::string join(Iterator begin, Iterator end, std::string const& sep,
 }
 
 template <typename Iterator>
-std::string join(Iterator begin, Iterator end, std::string const& sep) {
+std::string join(Iterator begin, Iterator end, const std::string& sep) {
   return join(begin, end, sep, [](auto&& x) -> decltype(x) { return x; });
 }
 
 template <typename T>
-std::string join(std::vector<T> const& v, std::string const& sep) {
+std::string join(const std::vector<T>& v, const std::string& sep) {
   if constexpr (std::is_same_v<T, std::string>) {
     return join(v.begin(), v.end(), sep);
   } else {
@@ -490,14 +490,14 @@ std::string join(std::vector<T> const& v, std::string const& sep) {
 /// @param str The substring to check at the start of *[begin, end)*.
 /// @returns `true` iff *str* occurs at the beginning of *[begin, end)*.
 template <typename Iterator>
-bool starts_with(Iterator begin, Iterator end, std::string const& str) {
+bool starts_with(Iterator begin, Iterator end, const std::string& str) {
   using diff = typename std::iterator_traits<Iterator>::difference_type;
   if (static_cast<diff>(str.size()) > end - begin)
     return false;
   return std::equal(str.begin(), str.end(), begin);
 }
 
-inline bool starts_with(std::string const& str, std::string const& start) {
+inline bool starts_with(const std::string& str, const std::string& start) {
   return starts_with(str.begin(), str.end(), start);
 }
 
@@ -507,13 +507,13 @@ inline bool starts_with(std::string const& str, std::string const& start) {
 /// @param str The substring to check at the end of *[begin, end)*.
 /// @returns `true` iff *str* occurs at the end of *[begin, end)*.
 template <typename Iterator>
-bool ends_with(Iterator begin, Iterator end, std::string const& str) {
+bool ends_with(Iterator begin, Iterator end, const std::string& str) {
   using diff = typename std::iterator_traits<Iterator>::difference_type;
   return static_cast<diff>(str.size()) <= end - begin
          && std::equal(str.begin(), str.end(), end - str.size());
 }
 
-inline bool ends_with(std::string const& str, std::string const& end) {
+inline bool ends_with(const std::string& str, const std::string& end) {
   return ends_with(str.begin(), str.end(), end);
 }
 
@@ -533,7 +533,7 @@ public:
     skip_[key] = value;
   }
 
-  Value operator[](Key const& key) const {
+  Value operator[](const Key& key) const {
     auto i = skip_.find(key);
     return i == skip_.end() ? default_ : i->second;
   }

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -151,8 +151,8 @@ using void_t = void;
 struct nonesuch {
   nonesuch() = delete;
   ~nonesuch() = delete;
-  nonesuch(nonesuch const&) = delete;
-  void operator=(nonesuch const&) = delete;
+  nonesuch(const nonesuch&) = delete;
+  void operator=(const nonesuch&) = delete;
 };
 
 namespace {

--- a/libvast/vast/detail/varbyte.hpp
+++ b/libvast/vast/detail/varbyte.hpp
@@ -81,8 +81,8 @@ encode(T x, void* sink) {
 /// @returns The number of bytes read from *source*.
 template <class T>
 std::enable_if_t<std::is_integral<T>{} && std::is_unsigned<T>{}, size_t>
-decode(T& x, void const* source) {
-  auto in = reinterpret_cast<uint8_t const*>(source);
+decode(T& x, const void* source) {
+  auto in = reinterpret_cast<const uint8_t*>(source);
   size_t i = 0;
   uint8_t low7;
   x = 0;

--- a/libvast/vast/detail/variadic_serialization.hpp
+++ b/libvast/vast/detail/variadic_serialization.hpp
@@ -33,12 +33,12 @@ void process(Processor& proc, T&& x, Ts&&... xs) {
 }
 
 template <class T>
-void write(caf::serializer& sink, T const& x) {
+void write(caf::serializer& sink, const T& x) {
   sink << x;
 }
 
 template <class T, class... Ts>
-void write(caf::serializer& sink, T const& x, Ts const&... xs) {
+void write(caf::serializer& sink, const T& x, const Ts&... xs) {
   write(sink, x);
   write(sink, xs...);
 }

--- a/libvast/vast/die.hpp
+++ b/libvast/vast/die.hpp
@@ -20,7 +20,7 @@ namespace vast {
 
 /// Terminates the process immediately.
 /// @param msg The message to print before terminating.
-[[noreturn]] void die(std::string const& = "");
+[[noreturn]] void die(const std::string& = "");
 
 } // namespace vast
 

--- a/libvast/vast/event.hpp
+++ b/libvast/vast/event.hpp
@@ -69,8 +69,8 @@ public:
   /// @returns The event timestamp.
   vast::timestamp timestamp() const;
 
-  friend bool operator==(event const& x, event const& y);
-  friend bool operator<(event const& x, event const& y);
+  friend bool operator==(const event& x, const event& y);
+  friend bool operator<(const event& x, const event& y);
 
   template <class Inspector>
   friend auto inspect(Inspector&f, event& e) {
@@ -82,12 +82,12 @@ private:
   vast::timestamp timestamp_;
 };
 
-bool convert(event const& e, json& j);
+bool convert(const event& e, json& j);
 
 /// Flattens an event.
 /// @param e The event to flatten.
 /// @returns The flattened event.
-event flatten(event const& e);
+event flatten(const event& e);
 
 } // namespace vast
 

--- a/libvast/vast/ewah_bitmap.hpp
+++ b/libvast/vast/ewah_bitmap.hpp
@@ -154,7 +154,7 @@ public:
 private:
   void scan();
 
-  ewah_bitmap const* bm_;
+  const ewah_bitmap* bm_;
   size_t next_ = 0;
   size_t num_dirty_ = 0;
 };

--- a/libvast/vast/ewah_bitmap.hpp
+++ b/libvast/vast/ewah_bitmap.hpp
@@ -103,7 +103,7 @@ public:
 
   size_type size() const;
 
-  block_vector const& blocks() const;
+  const block_vector& blocks() const;
 
   // -- modifiers ------------------------------------------------------------
 
@@ -117,7 +117,7 @@ public:
 
   // -- concepts -------------------------------------------------------------
 
-  friend bool operator==(ewah_bitmap const& x, ewah_bitmap const& y);
+  friend bool operator==(const ewah_bitmap& x, const ewah_bitmap& y);
 
   template <class Inspector>
   friend auto inspect(Inspector&f, ewah_bitmap& bm) {
@@ -146,7 +146,7 @@ public:
 
   ewah_bitmap_range() = default;
 
-  explicit ewah_bitmap_range(ewah_bitmap const& bm);
+  explicit ewah_bitmap_range(const ewah_bitmap& bm);
 
   void next();
   bool done() const;
@@ -159,7 +159,7 @@ private:
   size_t num_dirty_ = 0;
 };
 
-ewah_bitmap_range bit_range(ewah_bitmap const& bm);
+ewah_bitmap_range bit_range(const ewah_bitmap& bm);
 
 } // namespace vast
 

--- a/libvast/vast/expression.hpp
+++ b/libvast/vast/expression.hpp
@@ -39,10 +39,10 @@ struct attribute_extractor : detail::totally_ordered<attribute_extractor> {
 
   std::string attr;
 
-  friend bool operator==(attribute_extractor const&,
-                         attribute_extractor const&);
-  friend bool operator<(attribute_extractor const&,
-                        attribute_extractor const&);
+  friend bool operator==(const attribute_extractor&,
+                         const attribute_extractor&);
+  friend bool operator<(const attribute_extractor&,
+                        const attribute_extractor&);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, attribute_extractor& ex) {
@@ -56,8 +56,8 @@ struct key_extractor : detail::totally_ordered<key_extractor> {
 
   vast::key key;
 
-  friend bool operator==(key_extractor const& lhs, key_extractor const& rhs);
-  friend bool operator<(key_extractor const& lhs, key_extractor const& rhs);
+  friend bool operator==(const key_extractor& lhs, const key_extractor& rhs);
+  friend bool operator<(const key_extractor& lhs, const key_extractor& rhs);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, key_extractor& ex) {
@@ -71,8 +71,8 @@ struct type_extractor : detail::totally_ordered<type_extractor> {
 
   vast::type type;
 
-  friend bool operator==(type_extractor const& lhs, type_extractor const& rhs);
-  friend bool operator<(type_extractor const& lhs, type_extractor const& rhs);
+  friend bool operator==(const type_extractor& lhs, const type_extractor& rhs);
+  friend bool operator<(const type_extractor& lhs, const type_extractor& rhs);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, type_extractor& ex) {
@@ -91,8 +91,8 @@ struct data_extractor : detail::totally_ordered<data_extractor> {
   vast::type type;
   vast::offset offset;
 
-  friend bool operator==(data_extractor const& lhs, data_extractor const& rhs);
-  friend bool operator<(data_extractor const& lhs, data_extractor const& rhs);
+  friend bool operator==(const data_extractor& lhs, const data_extractor& rhs);
+  friend bool operator<(const data_extractor& lhs, const data_extractor& rhs);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, data_extractor& ex) {
@@ -118,8 +118,8 @@ struct predicate : detail::totally_ordered<predicate> {
   relational_operator op;
   operand rhs;
 
-  friend bool operator==(predicate const& lhs, predicate const& rhs);
-  friend bool operator<(predicate const& lhs, predicate const& rhs);
+  friend bool operator==(const predicate& lhs, const predicate& rhs);
+  friend bool operator<(const predicate& lhs, const predicate& rhs);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, predicate& p) {
@@ -142,18 +142,18 @@ struct negation : detail::totally_ordered<negation> {
   negation();
   negation(expression expr);
 
-  negation(negation const& other);
+  negation(const negation& other);
   negation(negation&& other) noexcept;
 
-  negation& operator=(negation const& other);
+  negation& operator=(const negation& other);
   negation& operator=(negation&& other) noexcept;
 
   // Access the contained expression.
-  expression const& expr() const;
+  const expression& expr() const;
   expression& expr();
 
-  friend bool operator==(negation const& lhs, negation const& rhs);
-  friend bool operator<(negation const& lhs, negation const& rhs);
+  friend bool operator==(const negation& lhs, const negation& rhs);
+  friend bool operator<(const negation& lhs, const negation& rhs);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, negation& n) {
@@ -190,8 +190,8 @@ public:
   expression(T&& x) : node_{std::forward<T>(x)} {
   }
 
-  friend bool operator==(expression const& lhs, expression const& rhs);
-  friend bool operator<(expression const& lhs, expression const& rhs);
+  friend bool operator==(const expression& lhs, const expression& rhs);
+  friend bool operator<(const expression& lhs, const expression& rhs);
 
   template <class Inspector>
   friend auto inspect(Inspector&f, expression& e) {
@@ -212,7 +212,7 @@ private:
 ///
 /// @param expr The expression to normalize.
 /// @returns The normalized expression.
-expression normalize(expression const& expr);
+expression normalize(const expression& expr);
 
 /// [Normalizes](@ref normalize) and [validates](@ref validator) an expression.
 /// @param expr The expression to normalize and validate.

--- a/libvast/vast/expression_visitors.hpp
+++ b/libvast/vast/expression_visitors.hpp
@@ -35,19 +35,19 @@ class event;
 /// disjunction one level in the tree.
 struct hoister {
   expression operator()(none) const;
-  expression operator()(conjunction const& c) const;
-  expression operator()(disjunction const& d) const;
-  expression operator()(negation const& n) const;
-  expression operator()(predicate const& p) const;
+  expression operator()(const conjunction& c) const;
+  expression operator()(const disjunction& d) const;
+  expression operator()(const negation& n) const;
+  expression operator()(const predicate& p) const;
 };
 
 /// Ensures that extractors always end up on the LHS of a predicate.
 struct aligner {
   expression operator()(none) const;
-  expression operator()(conjunction const& c) const;
-  expression operator()(disjunction const& d) const;
-  expression operator()(negation const& n) const;
-  expression operator()(predicate const& p) const;
+  expression operator()(const conjunction& c) const;
+  expression operator()(const disjunction& d) const;
+  expression operator()(const negation& n) const;
+  expression operator()(const predicate& p) const;
 };
 
 /// Pushes negations down to the predicate level and removes double negations.
@@ -55,10 +55,10 @@ struct denegator {
   denegator(bool negate = false);
 
   expression operator()(none) const;
-  expression operator()(conjunction const& c) const;
-  expression operator()(disjunction const& d) const;
-  expression operator()(negation const& n) const;
-  expression operator()(predicate const& p) const;
+  expression operator()(const conjunction& c) const;
+  expression operator()(const disjunction& d) const;
+  expression operator()(const negation& n) const;
+  expression operator()(const predicate& p) const;
 
   bool negate_ = false;
 };
@@ -66,34 +66,34 @@ struct denegator {
 /// Removes duplicate predicates from conjunctions and disjunctions.
 struct deduplicator {
   expression operator()(none) const;
-  expression operator()(conjunction const& c) const;
-  expression operator()(disjunction const& d) const;
-  expression operator()(negation const& n) const;
-  expression operator()(predicate const& p) const;
+  expression operator()(const conjunction& c) const;
+  expression operator()(const disjunction& d) const;
+  expression operator()(const negation& n) const;
+  expression operator()(const predicate& p) const;
 };
 
 /// Extracts all predicates from an expression.
 struct predicatizer {
   std::vector<predicate> operator()(none) const;
-  std::vector<predicate> operator()(conjunction const& c) const;
-  std::vector<predicate> operator()(disjunction const& d) const;
-  std::vector<predicate> operator()(negation const& n) const;
-  std::vector<predicate> operator()(predicate const& p) const;
+  std::vector<predicate> operator()(const conjunction& c) const;
+  std::vector<predicate> operator()(const disjunction& d) const;
+  std::vector<predicate> operator()(const negation& n) const;
+  std::vector<predicate> operator()(const predicate& p) const;
 };
 
 /// Ensures that LHS and RHS of a predicate fit together.
 struct validator {
   expected<void> operator()(none);
-  expected<void> operator()(conjunction const& c);
-  expected<void> operator()(disjunction const& d);
-  expected<void> operator()(negation const& n);
-  expected<void> operator()(predicate const& p);
-  expected<void> operator()(attribute_extractor const& ex, data const& d);
-  expected<void> operator()(type_extractor const& ex, data const& d);
-  expected<void> operator()(key_extractor const& ex, data const& d);
+  expected<void> operator()(const conjunction& c);
+  expected<void> operator()(const disjunction& d);
+  expected<void> operator()(const negation& n);
+  expected<void> operator()(const predicate& p);
+  expected<void> operator()(const attribute_extractor& ex, const data& d);
+  expected<void> operator()(const type_extractor& ex, const data& d);
+  expected<void> operator()(const key_extractor& ex, const data& d);
 
   template <typename T, typename U>
-  expected<void> operator()(T const& lhs, U const& rhs) {
+  expected<void> operator()(const T& lhs, const U& rhs) {
     return make_error(ec::syntax_error, "incompatible predicate operands", lhs,
                       rhs);
   }
@@ -111,10 +111,10 @@ struct time_restrictor {
   time_restrictor(timestamp first, timestamp second);
 
   bool operator()(none) const;
-  bool operator()(conjunction const& con) const;
-  bool operator()(disjunction const& dis) const;
-  bool operator()(negation const& n) const;
-  bool operator()(predicate const& p) const;
+  bool operator()(const conjunction& con) const;
+  bool operator()(const disjunction& dis) const;
+  bool operator()(const negation& n) const;
+  bool operator()(const predicate& p) const;
 
   timestamp first_;
   timestamp last_;
@@ -123,67 +123,67 @@ struct time_restrictor {
 /// Transforms all ::key_extractor and ::type_extractor predicates into
 /// ::data_extractor instances according to a given type.
 struct type_resolver {
-  type_resolver(type const& t);
+  type_resolver(const type& t);
 
   expected<expression> operator()(none);
-  expected<expression> operator()(conjunction const& c);
-  expected<expression> operator()(disjunction const& d);
-  expected<expression> operator()(negation const& n);
-  expected<expression> operator()(predicate const& p);
-  expected<expression> operator()(type_extractor const& ex, data const& d);
-  expected<expression> operator()(data const& d, type_extractor const& ex);
-  expected<expression> operator()(key_extractor const& ex, data const& d);
-  expected<expression> operator()(data const& d, key_extractor const& e);
+  expected<expression> operator()(const conjunction& c);
+  expected<expression> operator()(const disjunction& d);
+  expected<expression> operator()(const negation& n);
+  expected<expression> operator()(const predicate& p);
+  expected<expression> operator()(const type_extractor& ex, const data& d);
+  expected<expression> operator()(const data& d, const type_extractor& ex);
+  expected<expression> operator()(const key_extractor& ex, const data& d);
+  expected<expression> operator()(const data& d, const key_extractor& e);
 
   template <typename T, typename U>
-  expected<expression> operator()(T const& lhs, U const& rhs) {
+  expected<expression> operator()(const T& lhs, const U& rhs) {
     return {predicate{lhs, op_, rhs}};
   }
 
   relational_operator op_;
-  type const& type_;
+  const type& type_;
 };
 
 // Tailors an expression to a specific type by pruning all unecessary branches
 // and resolving keys into the corresponding data extractors.
 struct type_pruner {
-  type_pruner(type const& event_type);
+  type_pruner(const type& event_type);
 
   expression operator()(none);
-  expression operator()(conjunction const& c);
-  expression operator()(disjunction const& d);
-  expression operator()(negation const& n);
-  expression operator()(predicate const& p);
+  expression operator()(const conjunction& c);
+  expression operator()(const disjunction& d);
+  expression operator()(const negation& n);
+  expression operator()(const predicate& p);
 
   relational_operator op_;
-  type const& type_;
+  const type& type_;
 };
 
 /// Evaluates an event over a [resolved](@ref type_extractor) expression.
 struct event_evaluator {
-  event_evaluator(event const& e);
+  event_evaluator(const event& e);
 
   bool operator()(none);
-  bool operator()(conjunction const& c);
-  bool operator()(disjunction const& d);
-  bool operator()(negation const& n);
-  bool operator()(predicate const& p);
-  bool operator()(attribute_extractor const& e, data const& d);
-  bool operator()(key_extractor const&, data const&);
-  bool operator()(type_extractor const&, data const&);
-  bool operator()(data_extractor const& e, data const& d);
+  bool operator()(const conjunction& c);
+  bool operator()(const disjunction& d);
+  bool operator()(const negation& n);
+  bool operator()(const predicate& p);
+  bool operator()(const attribute_extractor& e, const data& d);
+  bool operator()(const key_extractor&, const data&);
+  bool operator()(const type_extractor&, const data&);
+  bool operator()(const data_extractor& e, const data& d);
 
   template <typename T>
-  bool operator()(data const& d, T const& x) {
+  bool operator()(const data& d, const T& x) {
     return (*this)(x, d);
   }
 
   template <typename T, typename U>
-  bool operator()(T const&, U const&) {
+  bool operator()(const T&, const U&) {
     return false;
   }
 
-  event const& event_;
+  const event& event_;
   relational_operator op_;
 };
 
@@ -193,20 +193,20 @@ struct event_evaluator {
 /// match. For disjunctions, at least one operand must match.
 struct matcher {
   bool operator()(none);
-  bool operator()(conjunction const&);
-  bool operator()(disjunction const&);
-  bool operator()(negation const&);
-  bool operator()(predicate const&);
-  bool operator()(attribute_extractor const&, data const&);
-  bool operator()(data_extractor const&, data const&);
+  bool operator()(const conjunction&);
+  bool operator()(const disjunction&);
+  bool operator()(const negation&);
+  bool operator()(const predicate&);
+  bool operator()(const attribute_extractor&, const data&);
+  bool operator()(const data_extractor&, const data&);
 
   template <typename T>
-  bool operator()(data const& d, T const& x) {
+  bool operator()(const data& d, const T& x) {
     return (*this)(x, d);
   }
 
   template <typename T, typename U>
-  bool operator()(T const&, U const&) {
+  bool operator()(const T&, const U&) {
     return false;
   }
 

--- a/libvast/vast/filesystem.hpp
+++ b/libvast/vast/filesystem.hpp
@@ -76,8 +76,8 @@ public:
   /// @param str The string representing of a path.
   path(std::string str);
 
-  path& operator/=(path const& p);
-  path& operator+=(path const& p);
+  path& operator/=(const path& p);
+  path& operator+=(const path& p);
 
   /// Checks whether the path is empty.
   /// @param `true` if the path is empty.
@@ -121,7 +121,7 @@ public:
 
   /// Retrieves the underlying string representation.
   /// @returns The string representation of the path.
-  std::string const& str() const;
+  const std::string& str() const;
 
   //
   // Filesystem operations
@@ -142,8 +142,8 @@ public:
   /// @returns `true` if the path is a symlink.
   bool is_symlink() const;
 
-  friend bool operator==(path const& x, path const& y);
-  friend bool operator<(path const& x, path const& y);
+  friend bool operator==(const path& x, const path& y);
+  friend bool operator<(const path& x, const path& y);
 
   template <class Inspector>
   friend auto inspect(Inspector&f, path& p) {
@@ -158,8 +158,8 @@ constexpr bool close_on_destruction = true;
 
 /// A simple file abstraction.
 class file {
-  file(file const&) = delete;
-  file& operator=(file const&) = delete;
+  file(const file&) = delete;
+  file& operator=(const file&) = delete;
 
 public:
 /// The native type of a file.
@@ -237,7 +237,7 @@ public:
 
   /// Retrieves the ::path for this file.
   /// @returns The ::path for this file.
-  vast::path const& path() const;
+  const vast::path& path() const;
 
   /// Retrieves the native handle for this file.
   /// @returns The native handle.
@@ -259,15 +259,15 @@ public:
       : public detail::iterator_facade<
           iterator,
           std::input_iterator_tag,
-          path const&,
-          path const&
+          const path&,
+          const path&
         > {
   public:
     iterator(directory* dir = nullptr);
 
     void increment();
-    path const& dereference() const;
-    bool equals(iterator const& other) const;
+    const path& dereference() const;
+    bool equals(const iterator& other) const;
 
   private:
     path current_;
@@ -285,7 +285,7 @@ public:
 
   /// Retrieves the ::path for this file.
   /// @returns The ::path for this file.
-  vast::path const& path() const;
+  const vast::path& path() const;
 
 private:
   vast::path path_;
@@ -297,32 +297,32 @@ private:
 /// Splits the string at the path separator.
 /// @param p The path to split.
 /// @returns A vector of the path components.
-std::vector<path> split(path const& p);
+std::vector<path> split(const path& p);
 
 /// Checks whether the path exists on the filesystem.
 /// @param p The path to check for existance.
 /// @returns `true` if *p* exists.
-bool exists(path const& p);
+bool exists(const path& p);
 
 /// Creates a symlink (aka. "soft link").
 /// @param target The existing file that should be linked.
 /// @param link The symlink that points to *target*.
-void create_symlink(path const& target, path const& link);
+void create_symlink(const path& target, const path& link);
 
 /// Deletes the path on the filesystem.
 /// @param p The path to a directory to delete.
 /// @returns `true` if *p* has been successfully deleted.
-bool rm(path const& p);
+bool rm(const path& p);
 
 /// If the path does not exist, create it as directory.
 /// @param p The path to a directory to create.
 /// @returns `true` on success or if *p* exists already.
-expected<void> mkdir(path const& p);
+expected<void> mkdir(const path& p);
 
 // Loads file contents into a string.
 // @param p The path of the file to load.
 // @returns The contents of the file *p*.
-expected<std::string> load_contents(path const& p);
+expected<std::string> load_contents(const path& p);
 
 } // namespace vast
 
@@ -330,7 +330,7 @@ namespace std {
 
 template <>
 struct hash<vast::path> {
-  size_t operator()(vast::path const& p) const {
+  size_t operator()(const vast::path& p) const {
     return hash<std::string>{}(p.str());
   }
 };

--- a/libvast/vast/filesystem.hpp
+++ b/libvast/vast/filesystem.hpp
@@ -41,9 +41,9 @@ class path : detail::totally_ordered<path>,
 
 public:
 #ifdef VAST_WINDOWS
-  static constexpr char const* separator = "\\";
+  static constexpr const char* separator = "\\";
 #else
-  static constexpr char const* separator = "/";
+  static constexpr const char* separator = "/";
 #endif
 
   /// The maximum length of a path.
@@ -70,7 +70,7 @@ public:
 
   /// Constructs a path from a C string.
   /// @param str The string representing of a path.
-  path(char const* str);
+  path(const char* str);
 
   /// Constructs a path from a string.
   /// @param str The string representing of a path.
@@ -227,7 +227,7 @@ public:
   /// @param size The number of bytes to write.
   /// @param put The number of bytes written.
   /// @returns `true` on success.
-  bool write(void const* source, size_t size, size_t* put = nullptr);
+  bool write(const void* source, size_t size, size_t* put = nullptr);
 
   /// Seeks the file forward.
   /// @param bytes The number of bytes to seek forward relative to the current
@@ -271,7 +271,7 @@ public:
 
   private:
     path current_;
-    directory const* dir_ = nullptr;
+    const directory* dir_ = nullptr;
   };
 
   /// Constructs a directory stream.

--- a/libvast/vast/format/ascii.hpp
+++ b/libvast/vast/format/ascii.hpp
@@ -25,7 +25,7 @@ struct ascii_printer : printer<ascii_printer> {
   using attribute = event;
 
   template <class Iterator>
-  bool print(Iterator&& out, event const& e) const {
+  bool print(Iterator&& out, const event& e) const {
     return event_printer{}.print(out, e);
   }
 };

--- a/libvast/vast/format/ascii.hpp
+++ b/libvast/vast/format/ascii.hpp
@@ -34,7 +34,7 @@ class writer : public format::writer<ascii_printer>{
 public:
   using format::writer<ascii_printer>::writer;
 
-  char const* name() const {
+  const char* name() const {
     return "ascii-writer";
   }
 };

--- a/libvast/vast/format/bgpdump.hpp
+++ b/libvast/vast/format/bgpdump.hpp
@@ -119,7 +119,7 @@ class reader : public format::reader<bgpdump_parser> {
 public:
   using format::reader<bgpdump_parser>::reader;
 
-  expected<void> schema(vast::schema const& sch);
+  expected<void> schema(const vast::schema& sch);
 
   expected<vast::schema> schema() const;
 

--- a/libvast/vast/format/bgpdump.hpp
+++ b/libvast/vast/format/bgpdump.hpp
@@ -123,7 +123,7 @@ public:
 
   expected<vast::schema> schema() const;
 
-  char const* name() const;
+  const char* name() const;
 };
 
 } // namespace vast::format::bgpdump

--- a/libvast/vast/format/bro.hpp
+++ b/libvast/vast/format/bro.hpp
@@ -42,37 +42,37 @@ namespace bro {
 /// Parses non-container types.
 template <class Iterator, class Attribute>
 struct bro_parser {
-  bro_parser(Iterator& f, Iterator const& l, Attribute& attr)
+  bro_parser(Iterator& f, const Iterator& l, Attribute& attr)
     : f_{f},
       l_{l},
       attr_{attr} {
   }
 
   template <class Parser>
-  bool parse(Parser const& p) const {
+  bool parse(const Parser& p) const {
     return p(f_, l_, attr_);
   }
 
   template <class T>
-  bool operator()(T const&) const {
+  bool operator()(const T&) const {
     return false;
   }
 
-  bool operator()(boolean_type const&) const {
+  bool operator()(const boolean_type&) const {
     return parse(parsers::tf);
   }
 
-  bool operator()(integer_type const&) const {
+  bool operator()(const integer_type&) const {
     static auto p = parsers::i64 ->* [](integer x) { return x; };
     return parse(p);
   }
 
-  bool operator()(count_type const&) const {
+  bool operator()(const count_type&) const {
     static auto p = parsers::u64 ->* [](count x) { return x; };
     return parse(p);
   }
 
-  bool operator()(timestamp_type const&) const {
+  bool operator()(const timestamp_type&) const {
     static auto p = parsers::real ->* [](real x) {
       auto i = std::chrono::duration_cast<timespan>(double_seconds(x));
       return timestamp{i};
@@ -80,43 +80,43 @@ struct bro_parser {
     return parse(p);
   }
 
-  bool operator()(timespan_type const&) const {
+  bool operator()(const timespan_type&) const {
     static auto p = parsers::real ->* [](real x) {
       return std::chrono::duration_cast<timespan>(double_seconds(x));
     };
     return parse(p);
   }
 
-  bool operator()(string_type const&) const {
+  bool operator()(const string_type&) const {
     static auto p = +parsers::any
       ->* [](std::string x) { return detail::byte_unescape(x); };
     return parse(p);
   }
 
-  bool operator()(pattern_type const&) const {
+  bool operator()(const pattern_type&) const {
     static auto p = +parsers::any
       ->* [](std::string x) { return detail::byte_unescape(x); };
     return parse(p);
   }
 
-  bool operator()(address_type const&) const {
+  bool operator()(const address_type&) const {
     static auto p = parsers::addr ->* [](address x) { return x; };
     return parse(p);
   }
 
-  bool operator()(subnet_type const&) const {
+  bool operator()(const subnet_type&) const {
     static auto p = parsers::net ->* [](subnet x) { return x; };
     return parse(p);
   }
 
-  bool operator()(port_type const&) const {
+  bool operator()(const port_type&) const {
     static auto p = parsers::u16
       ->* [](uint16_t x) { return port{x, port::unknown}; };
     return parse(p);
   }
 
   Iterator& f_;
-  Iterator const& l_;
+  const Iterator& l_;
   Attribute& attr_;
 };
 
@@ -125,41 +125,41 @@ template <class Iterator, class Attribute>
 struct bro_parser_factory {
   using result_type = rule<Iterator, Attribute>;
 
-  bro_parser_factory(std::string const& set_separator)
+  bro_parser_factory(const std::string& set_separator)
     : set_separator_{set_separator} {
   }
 
   template <class T>
-  result_type operator()(T const&) const {
+  result_type operator()(const T&) const {
     return {};
   }
 
-  result_type operator()(boolean_type const&) const {
+  result_type operator()(const boolean_type&) const {
     return parsers::tf;
   }
 
-  result_type operator()(integer_type const&) const {
+  result_type operator()(const integer_type&) const {
     return parsers::i64 ->* [](integer x) { return x; };
   }
 
-  result_type operator()(count_type const&) const {
+  result_type operator()(const count_type&) const {
     return parsers::u64 ->* [](count x) { return x; };
   }
 
-  result_type operator()(timestamp_type const&) const {
+  result_type operator()(const timestamp_type&) const {
     return parsers::real ->* [](real x) {
       auto i = std::chrono::duration_cast<timespan>(double_seconds(x));
       return timestamp{i};
     };
   }
 
-  result_type operator()(timespan_type const&) const {
+  result_type operator()(const timespan_type&) const {
     return parsers::real ->* [](real x) {
       return std::chrono::duration_cast<timespan>(double_seconds(x));
     };
   }
 
-  result_type operator()(string_type const&) const {
+  result_type operator()(const string_type&) const {
     if (set_separator_.empty())
       return +parsers::any
         ->* [](std::string x) { return detail::byte_unescape(x); };
@@ -168,7 +168,7 @@ struct bro_parser_factory {
                ->*[](std::string x) { return detail::byte_unescape(x); };
   }
 
-  result_type operator()(pattern_type const&) const {
+  result_type operator()(const pattern_type&) const {
     if (set_separator_.empty())
       return +parsers::any
         ->* [](std::string x) { return detail::byte_unescape(x); };
@@ -177,19 +177,19 @@ struct bro_parser_factory {
         ->* [](std::string x) { return detail::byte_unescape(x); };
   }
 
-  result_type operator()(address_type const&) const {
+  result_type operator()(const address_type&) const {
     return parsers::addr ->* [](address x) { return x; };
   }
 
-  result_type operator()(subnet_type const&) const {
+  result_type operator()(const subnet_type&) const {
     return parsers::net ->* [](subnet x) { return x; };
   }
 
-  result_type operator()(port_type const&) const {
+  result_type operator()(const port_type&) const {
     return parsers::u16 ->* [](uint16_t x) { return port{x, port::unknown}; };
   }
 
-  result_type operator()(set_type const& t) const {
+  result_type operator()(const set_type& t) const {
     auto set_insert = [](std::vector<Attribute> v) {
       set s;
       for (auto& x : v)
@@ -199,18 +199,18 @@ struct bro_parser_factory {
     return (visit(*this, t.value_type) % set_separator_) ->* set_insert;
   }
 
-  result_type operator()(vector_type const& t) const {
+  result_type operator()(const vector_type& t) const {
     return (visit(*this, t.value_type) % set_separator_)
       ->* [](std::vector<Attribute> x) { return vector(std::move(x)); };
   }
 
-  std::string const& set_separator_;
+  const std::string& set_separator_;
 };
 
 /// Constructs a Bro data parser from a type and set separator.
 template <class Iterator, class Attribute = data>
 rule<Iterator, Attribute>
-make_bro_parser(type const& t, std::string const& set_separator = ",") {
+make_bro_parser(const type& t, const std::string& set_separator = ",") {
   rule<Iterator, Attribute> r;
   auto sep = is_container(t) ? set_separator : "";
   return visit(bro_parser_factory<Iterator, Attribute>{sep}, t);
@@ -218,7 +218,7 @@ make_bro_parser(type const& t, std::string const& set_separator = ",") {
 
 /// Parses non-container Bro data.
 template <class Iterator, class Attribute = data>
-bool bro_basic_parse(type const& t, Iterator& f, Iterator const& l,
+bool bro_basic_parse(const type& t, Iterator& f, const Iterator& l,
                      Attribute& attr) {
   return visit(bro_parser<Iterator, Attribute>{f, l, attr}, t);
 }
@@ -234,7 +234,7 @@ public:
 
   expected<event> read();
 
-  expected<void> schema(vast::schema const& sch);
+  expected<void> schema(const vast::schema& sch);
 
   expected<vast::schema> schema() const;
 
@@ -269,7 +269,7 @@ public:
 
   ~writer();
 
-  expected<void> write(event const& e);
+  expected<void> write(const event& e);
 
   expected<void> flush();
 

--- a/libvast/vast/format/csv.hpp
+++ b/libvast/vast/format/csv.hpp
@@ -40,21 +40,21 @@ struct value_printer : printer<value_printer> {
     }
 
     template <class T>
-    bool operator()(T const&, none) {
+    bool operator()(const T&, none) {
       return true;
     }
 
     template <class T, class U>
-    auto operator()(T const&, U const& x)
+    auto operator()(const T&, const U& x)
     -> std::enable_if_t<!std::is_same<U, none>::value, bool> {
       return make_printer<U>{}.print(out_, x);
     }
 
-    bool operator()(real_type const&, real r) {
+    bool operator()(const real_type&, real r) {
       return real_printer<real, 6>{}.print(out_, r);
     }
 
-    bool operator()(string_type const&, std::string const& str) {
+    bool operator()(const string_type&, const std::string& str) {
       using printers::chr;
       using printers::eps;
       auto escape = [&] {
@@ -67,7 +67,7 @@ struct value_printer : printer<value_printer> {
       return p.print(out_, unused);
     }
 
-    bool operator()(record_type const& r, vector const& v) {
+    bool operator()(const record_type& r, const vector& v) {
       VAST_ASSERT(!v.empty());
       VAST_ASSERT(r.fields.size() == v.size());
       using printers::eps;
@@ -82,27 +82,27 @@ struct value_printer : printer<value_printer> {
       return p.print(out_, v);
     }
 
-    bool operator()(vector_type const& t, vector const& v) {
+    bool operator()(const vector_type& t, const vector& v) {
       return render(v, t.value_type, set_separator);
     }
 
-    bool operator()(set_type const& t, set const& s) {
+    bool operator()(const set_type& t, const set& s) {
       return render(s, t.value_type, set_separator);
     }
 
-    bool operator()(table_type const&, table const&) {
+    bool operator()(const table_type&, const table&) {
       return false; // not yet supported
     }
 
   private:
     template <class Container, class Sep>
-    bool render(Container& c, type const& t, Sep const& sep) {
+    bool render(Container& c, const type& t, const Sep& sep) {
       using printers::eps;
       using printers::str;
       if (c.empty())
         return str.print(out_, empty);
       auto f = this;
-      auto elem = eps.with([&](data const& x) { return visit(*f, t, x); });
+      auto elem = eps.with([&](const data& x) { return visit(*f, t, x); });
       auto p = (elem % sep);
       return p.print(out_, c);
     }
@@ -111,7 +111,7 @@ struct value_printer : printer<value_printer> {
   };
 
   template <class Iterator>
-  bool print(Iterator& out, event const& e) const {
+  bool print(Iterator& out, const event& e) const {
     using namespace printers;
     // Print a new header each time we encounter a new event type.
     auto header = eps.with([&] {
@@ -129,7 +129,7 @@ struct value_printer : printer<value_printer> {
       return p.print(out, hdr);
     });
     // Print event data.
-    auto name = str.with([](std::string const& x) { return !x.empty(); });
+    auto name = str.with([](const std::string& x) { return !x.empty(); });
     auto comma = chr<','>;
     auto ts = u64 ->* [](timestamp t) { return t.time_since_epoch().count(); };
     auto f = [&] { visit(renderer<Iterator>{out}, e.type(), e.data()); };

--- a/libvast/vast/format/csv.hpp
+++ b/libvast/vast/format/csv.hpp
@@ -146,7 +146,7 @@ class writer : public format::writer<value_printer>{
 public:
   using format::writer<value_printer>::writer;
 
-  char const* name() const {
+  const char* name() const {
     return "csv-writer";
   }
 };

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -25,7 +25,7 @@ struct event_printer : printer<event_printer> {
   using attribute = event;
 
   template <class Iterator>
-  bool print(Iterator& out, event const& e) const {
+  bool print(Iterator& out, const event& e) const {
     vast::json j;
     return convert(e, j) && printers::json<policy::oneline>.print(out, j);
   }

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -35,7 +35,7 @@ class writer : public format::writer<event_printer>{
 public:
   using format::writer<event_printer>::writer;
 
-  char const* name() const {
+  const char* name() const {
     return "json-writer";
   }
 };

--- a/libvast/vast/format/pcap.hpp
+++ b/libvast/vast/format/pcap.hpp
@@ -42,7 +42,7 @@ struct connection : detail::equality_comparable<connection> {
   port sport;
   port dport;
 
-  friend bool operator==(connection const& lhs, connection const& rhs) {
+  friend bool operator==(const connection& lhs, const connection& rhs) {
     return lhs.src == rhs.src
       && lhs.dst == rhs.dst
       && lhs.sport == rhs.sport
@@ -51,7 +51,7 @@ struct connection : detail::equality_comparable<connection> {
 };
 
 template <class Hasher>
-void hash_append(Hasher& h, connection const& c) {
+void hash_append(Hasher& h, const connection& c) {
   hash_append(h, c.src, c.dst, c.sport.number(), c.dport.number());
 }
 
@@ -63,7 +63,7 @@ namespace std {
 
 template <>
 struct hash<vast::format::pcap::connection> {
-  size_t operator()(vast::format::pcap::connection const& c) const {
+  size_t operator()(const vast::format::pcap::connection& c) const {
     return vast::uhash<vast::xxhash>{}(c);
   }
 };
@@ -99,7 +99,7 @@ public:
 
   expected<event> read();
 
-  expected<void> schema(vast::schema const& sch);
+  expected<void> schema(const vast::schema& sch);
 
   expected<vast::schema> schema() const;
 
@@ -137,7 +137,7 @@ public:
 
   ~writer();
 
-  expected<void> write(event const& e);
+  expected<void> write(const event& e);
 
   expected<void> flush();
 

--- a/libvast/vast/format/writer.hpp
+++ b/libvast/vast/format/writer.hpp
@@ -35,7 +35,7 @@ public:
   explicit writer(std::unique_ptr<std::ostream> out) : out_{std::move(out)} {
   }
 
-  expected<void> write(event const& e) {
+  expected<void> write(const event& e) {
     auto i = std::ostreambuf_iterator<char>(*out_);
     if (!printer_.print(i, e))
       return make_error(ec::print_error, "failed to print event:", e);

--- a/libvast/vast/http.hpp
+++ b/libvast/vast/http.hpp
@@ -35,7 +35,7 @@ struct message {
   std::vector<http::header> headers;
   std::string body;
 
-  http::header const* header(std::string const& name) const;
+  http::header const* header(const std::string& name) const;
 };
 
 /// A HTTP request message.

--- a/libvast/vast/http.hpp
+++ b/libvast/vast/http.hpp
@@ -35,7 +35,7 @@ struct message {
   std::vector<http::header> headers;
   std::string body;
 
-  http::header const* header(const std::string& name) const;
+  const http::header* header(const std::string& name) const;
 };
 
 /// A HTTP request message.

--- a/libvast/vast/json.hpp
+++ b/libvast/vast/json.hpp
@@ -86,7 +86,7 @@ public:
 
     array() = default;
 
-    array(super const& s) : super(s) {
+    array(const super& s) : super(s) {
     }
 
     array(super&& s) : super(std::move(s)) {
@@ -100,7 +100,7 @@ public:
 
     object() = default;
 
-    object(super const& s) : super(s) {
+    object(const super& s) : super(s) {
     }
 
     object(super&& s) : super(std::move(s)) {
@@ -141,36 +141,36 @@ private:
 private:
   struct less_than {
     template <typename T>
-    bool operator()(T const& x, T const& y) {
+    bool operator()(const T& x, const T& y) {
       return x < y;
     }
 
     template <typename T, typename U>
-    bool operator()(T const&, U const&) {
+    bool operator()(const T&, const U&) {
       return false;
     }
   };
 
   struct equals {
     template <typename T>
-    bool operator()(T const& x, T const& y) {
+    bool operator()(const T& x, const T& y) {
       return x == y;
     }
 
     template <typename T, typename U>
-    bool operator()(T const&, U const&) {
+    bool operator()(const T&, const U&) {
       return false;
     }
   };
 
-  friend bool operator<(json const& x, json const& y) {
+  friend bool operator<(const json& x, const json& y) {
     if (x.value_.index() == y.value_.index())
       return visit(less_than{}, x.value_, y.value_);
     else
       return x.value_.index() < y.value_.index();
   }
 
-  friend bool operator==(json const& x, json const& y) {
+  friend bool operator==(const json& x, const json& y) {
     return visit(equals{}, x.value_, y.value_);
   }
 };
@@ -195,7 +195,7 @@ bool convert(T x, json& j) {
 }
 
 template <typename T>
-bool convert(std::vector<T> const& v, json& j) {
+bool convert(const std::vector<T>& v, json& j) {
   json::array a;
   for (auto& x : v) {
     json i;
@@ -208,7 +208,7 @@ bool convert(std::vector<T> const& v, json& j) {
 }
 
 template <typename K, typename V>
-bool convert(std::map<K, V> const& m, json& j) {
+bool convert(const std::map<K, V>& m, json& j) {
   json::object o;
   for (auto& p : m) {
     auto k = to<std::string>(p.first);
@@ -222,7 +222,7 @@ bool convert(std::map<K, V> const& m, json& j) {
 }
 
 template <typename T, typename... Opts>
-json to_json(T const& x, Opts&&... opts) {
+json to_json(const T& x, Opts&&... opts) {
   json j;
   if (convert(x, j, std::forward<Opts>(opts)...))
     return j;

--- a/libvast/vast/load.hpp
+++ b/libvast/vast/load.hpp
@@ -48,7 +48,7 @@ expected<void> load(Source&& in, Ts&&... xs) {
         caf::stream_deserializer<detail::compressedbuf&> s{compressed};
         detail::read(s, std::forward<Ts>(xs)...);
       }
-    } catch (std::exception const& e) {
+    } catch (const std::exception& e) {
       return make_error(ec::unspecified, e.what());
     }
     return {};

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -31,7 +31,7 @@ struct formatter {
   template <class Stream, class T>
   struct is_streamable {
     template <class S, class U>
-    static auto test(U const* x)
+    static auto test(const U* x)
     -> decltype(std::declval<S&>() << *x, std::true_type());
 
     template <class, class>

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -42,7 +42,7 @@ struct formatter {
   };
 
   template <class T>
-  formatter& operator<<(T const& x) {
+  formatter& operator<<(const T& x) {
     if constexpr (is_streamable<std::ostringstream, T>::value) {
       message << x;
       return *this;
@@ -65,21 +65,21 @@ struct formatter {
   }
 
   template <class... Ts>
-  formatter& operator<<(caf::typed_actor<Ts...> const& a) {
+  formatter& operator<<(const caf::typed_actor<Ts...>& a) {
     return *this << a->address();
   }
 
-  formatter& operator<<(caf::actor const& a) {
+  formatter& operator<<(const caf::actor& a) {
     return *this << a->address();
   }
 
-  formatter& operator<<(caf::actor_addr const& a) {
+  formatter& operator<<(const caf::actor_addr& a) {
     message << a.id();
     return *this;
   }
 
   // E.g., self->current_sender()
-  formatter& operator<<(caf::strong_actor_ptr const& a) {
+  formatter& operator<<(const caf::strong_actor_ptr& a) {
     if (a)
       message << a->id();
     else

--- a/libvast/vast/null_bitmap.hpp
+++ b/libvast/vast/null_bitmap.hpp
@@ -54,14 +54,14 @@ public:
 
   // -- concepts -------------------------------------------------------------
 
-  friend bool operator==(null_bitmap const& x, null_bitmap const& y);
+  friend bool operator==(const null_bitmap& x, const null_bitmap& y);
 
   template <class Inspector>
   friend auto inspect(Inspector&f, null_bitmap& bm) {
     return f(bm.bitvector_);
   }
 
-  friend null_bitmap_range bit_range(null_bitmap const& bm);
+  friend null_bitmap_range bit_range(const null_bitmap& bm);
 
 private:
   bitvector_type bitvector_;
@@ -72,7 +72,7 @@ class null_bitmap_range
 public:
   using word_type = null_bitmap::word_type;
 
-  explicit null_bitmap_range(null_bitmap const& bm);
+  explicit null_bitmap_range(const null_bitmap& bm);
 
   void next();
   bool done() const;

--- a/libvast/vast/null_bitmap.hpp
+++ b/libvast/vast/null_bitmap.hpp
@@ -80,7 +80,7 @@ public:
 private:
   void scan();
 
-  null_bitmap::bitvector_type const* bitvector_;
+  const null_bitmap::bitvector_type* bitvector_;
   typename null_bitmap::bitvector_type::block_vector::const_iterator block_;
   typename null_bitmap::bitvector_type::block_vector::const_iterator end_;
 };

--- a/libvast/vast/pattern.hpp
+++ b/libvast/vast/pattern.hpp
@@ -37,7 +37,7 @@ public:
   ///
   /// @param str The glob expression.
   /// @returns A pattern for the glob expression *str*.
-  static pattern glob(std::string const& str);
+  static pattern glob(const std::string& str);
 
   /// Default-constructs an empty pattern.
   pattern() = default;
@@ -49,24 +49,24 @@ public:
   /// Matches a string against the pattern.
   /// @param str The string to match.
   /// @returns `true` if the pattern matches exactly *str*.
-  bool match(std::string const& str) const;
+  bool match(const std::string& str) const;
 
   /// Searches a pattern in a string.
   /// @param str The string to search.
   /// @returns `true` if the pattern matches inside *str*.
-  bool search(std::string const& str) const;
+  bool search(const std::string& str) const;
 
   const std::string& string() const;
 
-  friend bool operator==(pattern const& lhs, pattern const& rhs);
-  friend bool operator<(pattern const& lhs, pattern const& rhs);
+  friend bool operator==(const pattern& lhs, const pattern& rhs);
+  friend bool operator<(const pattern& lhs, const pattern& rhs);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, pattern& p) {
     return f(p.str_);
   }
 
-  friend bool convert(pattern const& p, json& j);
+  friend bool convert(const pattern& p, json& j);
 
 private:
   std::string str_;

--- a/libvast/vast/port.hpp
+++ b/libvast/vast/port.hpp
@@ -57,8 +57,8 @@ public:
   /// @param t The new port type.
   void type(port_type t);
 
-  friend bool operator==(port const& x, port const& y);
-  friend bool operator<(port const& x, port const& y);
+  friend bool operator==(const port& x, const port& y);
+  friend bool operator<(const port& x, const port& y);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, port& p) {
@@ -70,7 +70,7 @@ private:
   port_type type_ = unknown;
 };
 
-bool convert(port const& p, json& j);
+bool convert(const port& p, json& j);
 
 } // namespace vast
 

--- a/libvast/vast/schema.hpp
+++ b/libvast/vast/schema.hpp
@@ -55,7 +55,7 @@ public:
   /// Retrieves the type for a given name.
   /// @param name The name of the type to lookup.
   /// @returns The type with name *name* or `nullptr if no such type exists.
-  type const* find(const std::string& name) const;
+  const type* find(const std::string& name) const;
 
   // -- container API ----------------------------------------------------------
 

--- a/libvast/vast/schema.hpp
+++ b/libvast/vast/schema.hpp
@@ -39,23 +39,23 @@ public:
   using const_iterator = std::vector<type>::const_iterator;
   using iterator = std::vector<type>::iterator;
 
-  friend bool operator==(schema const& x, schema const& y);
+  friend bool operator==(const schema& x, const schema& y);
 
   /// Merges two schemata.
   /// @param s1 The first schema.
   /// @param s2 The second schema.
   /// @returns The union of *s1* and *s2* schema if the .
-  static optional<schema> merge(schema const& s1, schema const& s2);
+  static optional<schema> merge(const schema& s1, const schema& s2);
 
   /// Adds a new type to the schema.
   /// @param t The type to add.
   /// @returns `true` on success.
-  bool add(type const& t);
+  bool add(const type& t);
 
   /// Retrieves the type for a given name.
   /// @param name The name of the type to lookup.
   /// @returns The type with name *name* or `nullptr if no such type exists.
-  type const* find(std::string const& name) const;
+  type const* find(const std::string& name) const;
 
   // -- container API ----------------------------------------------------------
 
@@ -65,14 +65,14 @@ public:
   bool empty() const;
   void clear();
 
-  friend void serialize(caf::serializer& sink, schema const& sch);
+  friend void serialize(caf::serializer& sink, const schema& sch);
   friend void serialize(caf::deserializer& source, schema& sch);
 
 private:
   std::vector<type> types_;
 };
 
-bool convert(schema const& s, json& j);
+bool convert(const schema& s, json& j);
 
 } // namespace vast
 

--- a/libvast/vast/subnet.hpp
+++ b/libvast/vast/subnet.hpp
@@ -37,7 +37,7 @@ public:
   /// Checks whether this subnet includes a given address.
   /// @param addr The address to test for containment.
   /// @returns `true` if *addr* is an element of this subnet.
-  bool contains(address const& addr) const;
+  bool contains(const address& addr) const;
 
   /// Checks whether this subnet includes another subnet.
   /// For two subnets *A* and *B*, the subset relationship *A ⊆ B* holds true
@@ -47,25 +47,25 @@ public:
   /// of *A*.
   /// @param other The subnet to test for containment.
   /// @returns `true` if *other* is contained within this subnet.
-  bool contains(subnet const& other) const;
+  bool contains(const subnet& other) const;
 
   /// Retrieves the network address of the prefix.
   /// @returns The prefix address.
-  address const& network() const;
+  const address& network() const;
 
   /// Retrieves the prefix length.
   /// @returns The prefix length.
   uint8_t length() const;
 
-  friend bool operator==(subnet const& x, subnet const& y);
-  friend bool operator<(subnet const& x, subnet const& y);
+  friend bool operator==(const subnet& x, const subnet& y);
+  friend bool operator<(const subnet& x, const subnet& y);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, subnet& sn) {
     return f(sn.network_, sn.length_);
   }
 
-  friend bool convert(subnet const& sn, json& j);
+  friend bool convert(const subnet& sn, json& j);
 
 private:
   bool initialize();

--- a/libvast/vast/system/accountant.hpp
+++ b/libvast/vast/system/accountant.hpp
@@ -52,7 +52,7 @@ using accountant_type =
 /// @param filename The path of the file containing the accounting details.
 accountant_type::behavior_type
 accountant(accountant_type::stateful_pointer<accountant_state> self,
-           path const& filename);
+           const path& filename);
 
 } // namespace vast::system
 

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -71,7 +71,7 @@ struct archive_state {
   detail::cache<uuid, segment> cache;
   segment active;
   accountant_type accountant;
-  char const* name = "archive";
+  const char* name = "archive";
 };
 
 using archive_type = caf::typed_actor<

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -45,16 +45,16 @@ public:
 
   void add(batch&& b);
 
-  expected<std::vector<event>> extract(bitmap const& bm) const;
+  expected<std::vector<event>> extract(const bitmap& bm) const;
 
-  uuid const& id() const;
+  const uuid& id() const;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, segment& s) {
     return f(s.batches_, s.bytes_, s.id_);
   }
 
-  friend uint64_t bytes(segment const& s);
+  friend uint64_t bytes(const segment& s);
 
 private:
   // TODO: use a vector & binary_search for O(1) append and O(log N) search.

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -44,7 +44,7 @@ struct exporter_state {
   std::chrono::steady_clock::time_point start;
   query_statistics stats;
   uuid id;
-  char const* name = "exporter";
+  const char* name = "exporter";
 };
 
 /// The EXPORTER receives index hits, looks up the corresponding events in the

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -97,7 +97,7 @@ struct index_state {
   std::unordered_map<uuid, lookup_state> lookups;
   size_t capacity;
   path dir;
-  char const* name = "index";
+  const char* name = "index";
 };
 
 /// Indexes events in horizontal partitions.

--- a/libvast/vast/system/sink.hpp
+++ b/libvast/vast/system/sink.hpp
@@ -36,7 +36,7 @@ namespace vast::system {
 struct Writer {
   Writer();
 
-  expected<void> write(event const&);
+  expected<void> write(const event&);
 
   expected<void> flush();
 

--- a/libvast/vast/system/sink.hpp
+++ b/libvast/vast/system/sink.hpp
@@ -40,7 +40,7 @@ struct Writer {
 
   expected<void> flush();
 
-  char const* name() const;
+  const char* name() const;
 };
 #endif
 

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -182,7 +182,7 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader&& reader) {
         return *sch;
       return sch.error();
     },
-    [=](put_atom, schema const& sch) -> result<void> {
+    [=](put_atom, const schema& sch) -> result<void> {
       auto r = self->state.reader.schema(sch);
       if (r)
         return {};
@@ -192,7 +192,7 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader&& reader) {
       VAST_DEBUG(self, "sets filter expression to:", expr);
       self->state.filter = std::move(expr);
     },
-    [=](sink_atom, actor const& sink) {
+    [=](sink_atom, const actor& sink) {
       VAST_ASSERT(sink);
       VAST_DEBUG(self, "registers sink", sink);
       self->send(self->state.sink, sys_atom::value, put_atom::value, sink);

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -49,7 +49,7 @@ struct Reader {
 
   expected<vast::schema> schema() const;
 
-  char const* name() const;
+  const char* name() const;
 };
 #endif
 
@@ -66,7 +66,7 @@ struct source_state {
   accountant_type accountant;
   caf::actor sink;
   Reader reader;
-  char const* name;
+  const char* name;
 };
 
 /// An event producer.

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -375,7 +375,7 @@ struct record_type
       vast::key key() const;
       size_t depth() const;
 
-      detail::stack_vector<record_field const*, 64> trace;
+      detail::stack_vector<const record_field*, 64> trace;
       vast::offset offset;
     };
 
@@ -389,7 +389,7 @@ struct record_type
     const range_state& get() const;
 
     range_state state_;
-    detail::stack_vector<record_type const*, 64> records_;
+    detail::stack_vector<const record_type*, 64> records_;
   };
 
   /// Constructs a record type from a list of fields.
@@ -426,12 +426,12 @@ struct record_type
   /// Retrieves the type at a given key.
   /// @param k The key to resolve.
   /// @returns The type at key *k* or `nullptr` if *k* doesn't resolve.
-  type const* at(const key& k) const;
+  const type* at(const key& k) const;
 
   /// Retrieves the type at a given offset.
   /// @param o The offset to resolve.
   /// @returns The type at offset *o* or `nullptr` if *o* doesn't resolve.
-  type const* at(const offset& o) const;
+  const type* at(const offset& o) const;
 
   friend bool operator==(const record_type& x, const record_type& y);
   friend bool operator<(const record_type& x, const record_type& y);

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -117,11 +117,11 @@ public:
 
   /// Retrieves the name of the type.
   /// @returns The name of the type.
-  std::string const& name() const;
+  const std::string& name() const;
 
   /// Retrieves the type attributes.
   std::vector<attribute>& attributes();
-  std::vector<attribute> const& attributes() const;
+  const std::vector<attribute>& attributes() const;
   type& attributes(std::initializer_list<attribute> list);
 
   /// Checks whether the hash digest of two types is equal.
@@ -138,7 +138,7 @@ public:
 
   friend auto& expose(type& t);
 
-  friend bool convert(type const& t, json& j);
+  friend bool convert(const type& t, json& j);
 
 private:
   struct impl;
@@ -175,7 +175,7 @@ public:
     return *static_cast<Derived*>(this);
   }
 
-  std::string const& name() const {
+  const std::string& name() const {
     return name_;
   }
 
@@ -183,7 +183,7 @@ public:
     return attributes_;
   }
 
-  std::vector<attribute> const& attributes() const {
+  const std::vector<attribute>& attributes() const {
     return attributes_;
   }
 
@@ -204,12 +204,12 @@ struct basic_type : concrete_type<Derived> {
 
 #define VAST_DEFINE_DATA_TYPE(T, U)                                           \
 struct T : basic_type<T>, detail::totally_ordered<T> {                        \
-  friend bool operator==(T const& x, T const& y) {                            \
+  friend bool operator==(const T& x, const T& y) {                            \
     return static_cast<const base_type&>(x) ==                                \
            static_cast<const base_type&>(y);                                  \
   }                                                                           \
                                                                               \
-  friend bool operator<(T const& x, T const& y) {                             \
+  friend bool operator<(const T& x, const T& y) {                             \
     return static_cast<const base_type&>(x) <                                 \
            static_cast<const base_type&>(y);                                  \
   }                                                                           \
@@ -379,14 +379,14 @@ struct record_type
       vast::offset offset;
     };
 
-    each(record_type const& r);
+    each(const record_type& r);
 
   private:
     friend detail::range_facade<each>;
 
     void next();
     bool done() const;
-    range_state const& get() const;
+    const range_state& get() const;
 
     range_state state_;
     detail::stack_vector<record_type const*, 64> records_;
@@ -401,37 +401,37 @@ struct record_type
   /// Attemps to resolve a ::key to an ::offset.
   /// @param k The key to resolve.
   /// @returns The ::offset corresponding to *k*.
-  expected<offset> resolve(key const& k) const;
+  expected<offset> resolve(const key& k) const;
 
   /// Attemps to resolve an ::offset to a ::key.
   /// @param o The offset to resolve.
   /// @returns The ::key corresponding to *o*.
-  expected<key> resolve(offset const& o) const;
+  expected<key> resolve(const offset& o) const;
 
   /// Finds all offset-key pairs for an *exact* key in this and nested records.
   /// @param k The key to resolve.
   /// @returns The offset-key pairs corresponding to the found *k*.
-  std::vector<std::pair<offset, key>> find(key const& k) const;
+  std::vector<std::pair<offset, key>> find(const key& k) const;
 
   /// Finds all offset-key pairs for a *prefix* key in this and nested records.
   /// @param k The key to resolve.
   /// @returns The offset-key pairs corresponding to the found *k*.
-  std::vector<std::pair<offset, key>> find_prefix(key const& k) const;
+  std::vector<std::pair<offset, key>> find_prefix(const key& k) const;
 
   /// Finds all offset-key pairs for a *suffix* key in this and nested records.
   /// @param k The key to resolve.
   /// @returns The offset-key pairs corresponding to the found *k*.
-  std::vector<std::pair<offset, key>> find_suffix(key const& k) const;
+  std::vector<std::pair<offset, key>> find_suffix(const key& k) const;
 
   /// Retrieves the type at a given key.
   /// @param k The key to resolve.
   /// @returns The type at key *k* or `nullptr` if *k* doesn't resolve.
-  type const* at(key const& k) const;
+  type const* at(const key& k) const;
 
   /// Retrieves the type at a given offset.
   /// @param o The offset to resolve.
   /// @returns The type at offset *o* or `nullptr` if *o* doesn't resolve.
-  type const* at(offset const& o) const;
+  type const* at(const offset& o) const;
 
   friend bool operator==(const record_type& x, const record_type& y);
   friend bool operator<(const record_type& x, const record_type& y);
@@ -449,16 +449,16 @@ struct record_type
 /// Recursively flattens the arguments of a record type.
 /// @param rec the record to flatten.
 /// @returns The flattened record type.
-record_type flatten(record_type const& rec);
+record_type flatten(const record_type& rec);
 
-type flatten(type const& t);
+type flatten(const type& t);
 
 /// Unflattens a flattened record type.
 /// @param rec the record to unflatten.
 /// @returns The unflattened record type.
-record_type unflatten(record_type const& rec);
+record_type unflatten(const record_type& rec);
 
-type unflatten(type const& t);
+type unflatten(const type& t);
 
 /// An alias of another type.
 struct alias_type
@@ -501,11 +501,11 @@ bool is_container(const type& t);
 /// @param x The first type.
 /// @param y The second type.
 /// @returns `true` *iff* *x* and *y* are congruent.
-bool congruent(type const& x, type const& y);
+bool congruent(const type& x, const type& y);
 
-bool congruent(type const& x, data const& y);
+bool congruent(const type& x, const data& y);
 
-bool congruent(data const& x, type const& y);
+bool congruent(const data& x, const type& y);
 
 /// Checks whether the types of two nodes in a predicate are compatible with
 /// each other, i.e., whether operator evaluation for the given types is
@@ -516,22 +516,22 @@ bool congruent(data const& x, type const& y);
 /// @param op The operator under which to compare *lhs* and *rhs*.
 /// @param rhs The RHS of *op*.
 /// @returns `true` if *lhs* and *rhs* are compatible to each other under *op*.
-bool compatible(type const& lhs, relational_operator op, type const& rhs);
+bool compatible(const type& lhs, relational_operator op, const type& rhs);
 
-bool compatible(type const& lhs, relational_operator op, data const& rhs);
+bool compatible(const type& lhs, relational_operator op, const data& rhs);
 
-bool compatible(data const& lhs, relational_operator op, type const& rhs);
+bool compatible(const data& lhs, relational_operator op, const type& rhs);
 
 /// Checks whether data and type fit together (and can form a ::value).
 /// @param t The type that describes *d*.
 /// @param d The raw data to be checked against *t*.
 /// @returns `true` if *t* is a valid type for *d*.
-bool type_check(type const& t, data const& d);
+bool type_check(const type& t, const data& d);
 
 /// Default-construct a data instance for a given type.
 /// @param t The type to construct ::data from.
 /// @returns a default-constructed instance of type *t*.
-data construct(type const& t);
+data construct(const type& t);
 
 // -- implementation details -------------------------------------------------
 
@@ -585,7 +585,7 @@ namespace std {
 
 template <>
 struct hash<vast::type> {
-  size_t operator()(vast::type const& t) const {
+  size_t operator()(const vast::type& t) const {
     return vast::uhash<vast::xxhash32>{}(t);
   }
 };

--- a/libvast/vast/uuid.hpp
+++ b/libvast/vast/uuid.hpp
@@ -31,7 +31,7 @@ public:
   using reference = value_type&;
   using const_reference = const value_type&;
   using iterator = value_type*;
-  using const_iterator = value_type const*;
+  using const_iterator = const value_type*;
   using size_type = size_t;
 
   static uuid random();

--- a/libvast/vast/uuid.hpp
+++ b/libvast/vast/uuid.hpp
@@ -29,7 +29,7 @@ class uuid : detail::totally_ordered<uuid> {
 public:
   using value_type = uint8_t;
   using reference = value_type&;
-  using const_reference = value_type const&;
+  using const_reference = const value_type&;
   using iterator = value_type*;
   using const_iterator = value_type const*;
   using size_type = size_t;
@@ -50,8 +50,8 @@ public:
 
   void swap(uuid& other);
 
-  friend bool operator==(uuid const& x, uuid const& y);
-  friend bool operator<(uuid const& x, uuid const& y);
+  friend bool operator==(const uuid& x, const uuid& y);
+  friend bool operator<(const uuid& x, const uuid& y);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, uuid& u) {
@@ -70,7 +70,7 @@ namespace std {
 
 template <>
 struct hash<vast::uuid> {
-  size_t operator()(vast::uuid const& u) const {
+  size_t operator()(const vast::uuid& u) const {
     size_t x = 0;
     for (auto& byte : u)
       x ^= static_cast<size_t>(byte) + 0x9e3779b9 + (x << 6) + (x >> 2);

--- a/libvast/vast/value.hpp
+++ b/libvast/vast/value.hpp
@@ -78,22 +78,22 @@ public:
   /// Sets the type of the value.
   /// @param t The new type of the value.
   /// @returns `true` if the value had no data or if the type check succeeded.
-  bool type(vast::type const& t);
+  bool type(const vast::type& t);
 
   /// Retrieves the type of the value.
   /// @returns The type of the value.
-  vast::type const& type() const;
+  const vast::type& type() const;
 
   /// Retrieves the data of the value.
   /// @returns The value data.
-  vast::data const& data() const;
+  const vast::data& data() const;
 
-  friend bool operator==(value const& lhs, value const& rhs);
-  friend bool operator!=(value const& lhs, value const& rhs);
-  friend bool operator<(value const& lhs, value const& rhs);
-  friend bool operator<=(value const& lhs, value const& rhs);
-  friend bool operator>=(value const& lhs, value const& rhs);
-  friend bool operator>(value const& lhs, value const& rhs);
+  friend bool operator==(const value& lhs, const value& rhs);
+  friend bool operator!=(const value& lhs, const value& rhs);
+  friend bool operator<(const value& lhs, const value& rhs);
+  friend bool operator<=(const value& lhs, const value& rhs);
+  friend bool operator>=(const value& lhs, const value& rhs);
+  friend bool operator>(const value& lhs, const value& rhs);
 
   template <class Inspector>
   friend auto inspect(Inspector&f, value& v) {
@@ -110,9 +110,9 @@ private:
 /// Flattens a value if it is a record.
 /// @param v The value to to flatten.
 /// @returns The flattened value or *v* if not a record.
-value flatten(value const& v);
+value flatten(const value& v);
 
-bool convert(value const& v, json& j);
+bool convert(const value& v, json& j);
 
 } // namespace vast
 

--- a/libvast/vast/variant.hpp
+++ b/libvast/vast/variant.hpp
@@ -205,7 +205,7 @@ private:
     }
 
     template <typename T>
-    void operator()(T const&) const
+    void operator()(const T&) const
     noexcept(std::is_nothrow_default_constructible<T>{}) {
       self_.construct(T());
     }
@@ -532,7 +532,7 @@ variant<Ts...>& expose(variant<Ts...>& v) {
 }
 
 template <class T>
-auto& expose(T const& v) {
+auto& expose(const T& v) {
   return expose(const_cast<T&>(v));
 }
 

--- a/libvast/vast/wah_bitmap.hpp
+++ b/libvast/vast/wah_bitmap.hpp
@@ -94,7 +94,7 @@ public:
 
   size_type size() const;
 
-  block_vector const& blocks() const;
+  const block_vector& blocks() const;
 
   // -- modifiers ------------------------------------------------------------
 
@@ -108,7 +108,7 @@ public:
 
   // -- concepts -------------------------------------------------------------
 
-  friend bool operator==(wah_bitmap const& x, wah_bitmap const& y);
+  friend bool operator==(const wah_bitmap& x, const wah_bitmap& y);
 
   template <class Inspector>
   friend auto inspect(Inspector&f, wah_bitmap& bm) {
@@ -130,7 +130,7 @@ public:
 
   wah_bitmap_range() = default;
 
-  explicit wah_bitmap_range(wah_bitmap const& bm);
+  explicit wah_bitmap_range(const wah_bitmap& bm);
 
   void next();
   bool done() const;
@@ -143,7 +143,7 @@ private:
   wah_bitmap::block_vector::const_iterator end_;
 };
 
-wah_bitmap_range bit_range(wah_bitmap const& bm);
+wah_bitmap_range bit_range(const wah_bitmap& bm);
 
 } // namespace vast
 


### PR DESCRIPTION
This pull request related to the github issue #72
I hope nobody else is working on the code ... I'm pretty sure I modified all files.