### PR TITLE
Add `make_ids` utility function

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -24,6 +24,7 @@ set(libvast_sources
   src/error.cpp
   src/event.cpp
   src/ewah_bitmap.cpp
+  src/ids.cpp
   src/filesystem.cpp
   src/key.cpp
   src/http.cpp
@@ -185,6 +186,7 @@ set(tests
   test/filesystem.cpp
   test/hash.cpp
   test/http.cpp
+  test/ids.cpp
   test/iterator.cpp
   test/json.cpp
   test/key.cpp

--- a/libvast/src/ids.cpp
+++ b/libvast/src/ids.cpp
@@ -11,34 +11,25 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#ifndef VAST_IDS_HPP
-#define VAST_IDS_HPP
-
-#include "vast/bitmap.hpp"
-#include "vast/aliases.hpp"
+#include "vast/ids.hpp"
 
 namespace vast {
 
-/// A set of IDs.
-using ids = bitmap;
-
-/// An open interval of IDs.
-struct id_range {
-  id_range(event_id from, event_id to) : first(from), last(to) {
-    // nop
+ids make_ids(std::initializer_list<id_range> ranges) {
+  ids result;
+  for (auto [first, last] : ranges) {
+    VAST_ASSERT(first < last);
+    if (first >= result.size()) {
+      result.append_bits(false, first - result.size());
+      result.append_bits(true, (last - first));
+    } else {
+      ids tmp;
+      tmp.append_bits(false, first);
+      tmp.append_bits(true, (last - first));
+      result |= tmp;
+    }
   }
-  id_range(event_id id) : id_range(id, id + 1) {
-    // nop
-  }
-  event_id first;
-  event_id last;
-};
-
-/// Generates an ID set for the given ranges. For example,
-/// `make_ids({{10, 12}, {20, 22}})` will return an ID set containing the
-/// ranges [10, 12) and [20, 22), i.e., 10, 11, 20, and 21.
-ids make_ids(std::initializer_list<id_range> ranges);
+  return result;
+}
 
 } // namespace vast
-
-#endif

--- a/libvast/test/batch.cpp
+++ b/libvast/test/batch.cpp
@@ -13,6 +13,7 @@
 
 #include "vast/batch.hpp"
 #include "vast/event.hpp"
+#include "vast/ids.hpp"
 #include "vast/load.hpp"
 #include "vast/save.hpp"
 #include "vast/concept/printable/vast/event.hpp"
@@ -51,21 +52,12 @@ TEST(events with IDs) {
   b.ids(666, 666 + 1000);
   MESSAGE("read a batch");
   batch::reader reader{b};
-  bitmap ids;
-  ids.append_bits(false, 666);
-  ids.append_bits(true, 1000);
-  auto xs = reader.read(ids);
+  auto xs = reader.read(make_ids({{666, 1666}}));
   REQUIRE(xs);
   CHECK(*xs == events);
   MESSAGE("read partial batch");
   batch::reader partial{b};
-  ids = bitmap{};
-  ids.append_bits(false, 666);
-  ids.append_bits(true, 1);
-  ids.append_bits(false, 900);
-  ids.append_bits(true, 90);
-  ids.append_bits(false, 9);
-  xs = partial.read(ids);
+  xs = partial.read(make_ids({{666, 667}, {1567, 1657}}));
   REQUIRE(xs);
   REQUIRE_EQUAL(xs->size(), 91u);
   CHECK_EQUAL(xs->front().id(), 666u);

--- a/libvast/test/ids.cpp
+++ b/libvast/test/ids.cpp
@@ -11,34 +11,22 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#ifndef VAST_IDS_HPP
-#define VAST_IDS_HPP
+#include "vast/ids.hpp"
 
-#include "vast/bitmap.hpp"
-#include "vast/aliases.hpp"
+#define SUITE ids
+#include "test.hpp"
 
-namespace vast {
+using namespace vast;
 
-/// A set of IDs.
-using ids = bitmap;
-
-/// An open interval of IDs.
-struct id_range {
-  id_range(event_id from, event_id to) : first(from), last(to) {
-    // nop
-  }
-  id_range(event_id id) : id_range(id, id + 1) {
-    // nop
-  }
-  event_id first;
-  event_id last;
-};
-
-/// Generates an ID set for the given ranges. For example,
-/// `make_ids({{10, 12}, {20, 22}})` will return an ID set containing the
-/// ranges [10, 12) and [20, 22), i.e., 10, 11, 20, and 21.
-ids make_ids(std::initializer_list<id_range> ranges);
-
-} // namespace vast
-
-#endif
+TEST(make ids) {
+  ids xs;
+  xs.append_bit(false);
+  xs.append_bit(true);
+  xs.append_bit(true);
+  xs.append_bits(false, 7);
+  xs.append_bits(true, 10);
+  auto ys = make_ids({1, 2, {10, 20}});
+  CHECK_EQUAL(xs, ys);
+  auto zs = make_ids({{15, 20}, 2, {10, 15}, 1});
+  CHECK_EQUAL(ys, zs);
+}

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -14,6 +14,7 @@
 #include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/vast/event.hpp"
 #include "vast/system/archive.hpp"
+#include "vast/ids.hpp"
 
 #define SUITE archive
 #include "test.hpp"
@@ -32,11 +33,7 @@ TEST(archiving and querying) {
   self->send(a, bro_http_log);
   self->send(a, bgpdump_txt);
   MESSAGE("querying event set {[100,150), [10150,10200)}");
-  bitmap bm;
-  bm.append_bits(false, 100);
-  bm.append_bits(true, 50);
-  bm.append_bits(false, 10000);
-  bm.append_bits(true, 50);
+  auto bm = make_ids({{100, 150}, {10150, 10200}});
   std::vector<event> result;
   self->request(a, infinite, bm).receive(
     [&](std::vector<event>& xs) { result = std::move(xs); },


### PR DESCRIPTION
Building ID sets in unit tests is tedious. This little helper function helps
reducing the noise.