### PR TITLE
Make actor names static where possible

### DIFF
--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -44,7 +44,7 @@ struct value_indexer_state {
   vast::type type;
   std::unique_ptr<value_index> idx;
   value_index::size_type last_flush = 0;
-  const char* name = "value-indexer";
+  static inline const char* name = "value-indexer";
 };
 
 // Wraps a value index into an actor.

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -129,7 +129,7 @@ struct ids_evaluator {
 struct evaluator_state {
   ids hits;
   std::unordered_map<predicate, ids> predicates;
-  const char* name = "evaluator";
+  static inline const char* name = "evaluator";
 };
 
 // Wraps a query expression in an actor. Upon receiving hits from COLLECTORs,

--- a/libvast/vast/system/accountant.hpp
+++ b/libvast/vast/system/accountant.hpp
@@ -30,9 +30,8 @@ namespace vast::system {
 struct accountant_state {
   using stopwatch = std::chrono::steady_clock;
   std::ofstream file;
-  const char* name = "accountant";
+  static inline const char* name = "accountant";
 };
-
 
 using accountant_type =
   caf::typed_actor<

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -71,7 +71,7 @@ struct archive_state {
   detail::cache<uuid, segment> cache;
   segment active;
   accountant_type accountant;
-  const char* name = "archive";
+  static inline const char* name = "archive";
 };
 
 using archive_type = caf::typed_actor<

--- a/libvast/vast/system/consensus.hpp
+++ b/libvast/vast/system/consensus.hpp
@@ -322,7 +322,7 @@ struct server_state {
   path dir;
 
   // Name of this actor (for logging purposes).
-  const char* name = "raft";
+  static inline const char* name = "raft";
 };
 
 /// Spawns a consensus module.

--- a/libvast/vast/system/data_store.hpp
+++ b/libvast/vast/system/data_store.hpp
@@ -25,7 +25,7 @@ namespace vast::system {
 template <class Key, class Value>
 struct data_store_state {
   std::unordered_map<Key, Value> store;
-  const char* name = "data-store";
+  static inline const char* name = "data-store";
 };
 
 /// A key-value store that stores its data in a `std::unordered_map`.

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -44,7 +44,7 @@ struct exporter_state {
   std::chrono::steady_clock::time_point start;
   query_statistics stats;
   uuid id;
-  const char* name = "exporter";
+  static inline const char* name = "exporter";
 };
 
 /// The EXPORTER receives index hits, looks up the corresponding events in the

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -41,7 +41,7 @@ struct importer_state {
   std::chrono::steady_clock::time_point last_replenish;
   std::vector<event> remainder;
   path dir;
-  const char* name = "importer";
+  static inline const char* name = "importer";
 };
 
 /// Spawns an IMPORTER.

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -96,7 +96,7 @@ struct index_state {
   std::unordered_map<uuid, lookup_state> lookups;
   size_t capacity;
   path dir;
-  const char* name = "index";
+  static inline const char* name = "index";
 };
 
 /// Indexes events in horizontal partitions.

--- a/libvast/vast/system/indexer.hpp
+++ b/libvast/vast/system/indexer.hpp
@@ -27,7 +27,7 @@ struct event_indexer_state {
   path dir;
   type event_type;
   std::unordered_map<path, caf::actor> indexers;
-  const char* name = "event-indexer";
+  static inline const char* name = "event-indexer";
 };
 
 /// Indexes an event.

--- a/libvast/vast/system/node.hpp
+++ b/libvast/vast/system/node.hpp
@@ -27,7 +27,7 @@ struct node_state {
   path dir;
   tracker_type tracker;
   std::unordered_map<std::string, int> labels;
-  std::string name = "node";
+  std::string name;
 };
 
 /// Spawns a node.

--- a/libvast/vast/system/partition.hpp
+++ b/libvast/vast/system/partition.hpp
@@ -26,7 +26,7 @@ namespace vast::system {
 
 struct partition_state {
   std::unordered_map<type, caf::actor> indexers;
-  const char* name = "partition";
+  static inline const char* name = "partition";
 };
 
 /// A horizontal partition of the INDEX.

--- a/libvast/vast/system/profiler.hpp
+++ b/libvast/vast/system/profiler.hpp
@@ -25,7 +25,7 @@ class path;
 namespace system {
 
 struct profiler_state {
-  const char* name = "profiler";
+  static inline const char* name = "profiler";
 };
 
 /// Profiles CPU and heap usage via gperftools.

--- a/libvast/vast/system/replicated_store.hpp
+++ b/libvast/vast/system/replicated_store.hpp
@@ -43,7 +43,7 @@ struct replicated_store_state {
   uint64_t request_id = 0;
   std::unordered_map<uint64_t, caf::response_promise> requests;
   std::chrono::steady_clock::time_point last_stats_update;
-  const char* name = "replicated-store";
+  static inline const char* name = "replicated-store";
 };
 
 template <class Inspector, class Key, class Value>

--- a/libvast/vast/system/signal_monitor.hpp
+++ b/libvast/vast/system/signal_monitor.hpp
@@ -23,7 +23,7 @@
 namespace vast::system {
 
 struct signal_monitor_state {
-  const char* name = "signal-monitor";
+  static inline const char* name = "signal-monitor";
 };
 
 using signal_monitor_type = caf::typed_actor<caf::reacts_to<run_atom>>;

--- a/libvast/vast/system/task.hpp
+++ b/libvast/vast/system/task.hpp
@@ -30,7 +30,7 @@ struct task_state {
   std::map<caf::actor_addr, uint64_t> workers;
   detail::flat_set<caf::actor> subscribers;
   detail::flat_set<caf::actor> supervisors;
-  const char* name = "task";
+  static inline const char* name = "task";
 };
 
 namespace detail {

--- a/libvast/vast/system/tracker.hpp
+++ b/libvast/vast/system/tracker.hpp
@@ -66,7 +66,7 @@ auto inspect(Inspector& f, registry& r) {
 
 struct tracker_state {
   vast::system::registry registry;
-  const char* name = "tracker";
+  static inline const char* name = "tracker";
 };
 
 using tracker_type = caf::typed_actor<


### PR DESCRIPTION
Many stateful actors in VAST have a member variable for their name where a
static member variable instead would suffice.