### PR TITLE
Make headers available to generator configuration

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -8,6 +8,10 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/vast/config.hpp.in
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
+# Some CMake generators (e.g., XCode) require header files in
+# addition to the sources.
+file(GLOB_RECURSE libvast_headers "${CMAKE_CURRENT_SOURCE_DIR}/vast/*.hpp")
+
 set(libvast_sources
   src/address.cpp
   src/attribute.cpp
@@ -107,7 +111,7 @@ if (GPERFTOOLS_FOUND AND VAST_USE_PERFTOOLS_HEAP_PROFILER)
   set(libvast_libs ${libvast_libs} ${GPERFTOOLS_TCMALLOC})
 endif ()
 
-add_library(libvast SHARED ${libvast_sources})
+add_library(libvast SHARED ${libvast_sources} ${libvast_headers})
 set_target_properties(libvast
   PROPERTIES
   SOVERSION ${VERSION_MAJOR}


### PR DESCRIPTION
When using CMake to generate a project file that includes links to headers / sources such as an Xcode project the header files did not show up in the editor. With this PR they do! Granted that is not helpful at the moment as Xcode uses the system compiler which does not currently support the C++17 flag. Not sure how other generators behave, but I guess they might have a similar problem.

I had these changes in the continuous query topic branch originally. Here is a separate PR to make it a bit cleaner. 