### PR TITLE
Add function which replaces types with new types if congruent

### DIFF
--- a/libvast/src/format/bgpdump.cpp
+++ b/libvast/src/format/bgpdump.cpp
@@ -60,20 +60,13 @@ bgpdump_parser::bgpdump_parser() {
 }
 
 expected<void> reader::schema(const vast::schema& sch) {
-  auto types = {
+  auto xs = {
     &parser_.announce_type,
     &parser_.route_type,
     &parser_.withdraw_type,
     &parser_.state_change_type,
   };
-  for (auto t : types)
-    if (auto u = sch.find(t->name())) {
-      if (!congruent(*t, *u))
-        return make_error(ec::format_error, "incongruent type:", t->name());
-      else
-        *t = *u;
-    }
-  return {};
+  return replace_if_congruent(xs, sch);
 }
 
 expected<schema> reader::schema() const {

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -276,13 +276,7 @@ expected<event> reader::read() {
 }
 
 expected<void> reader::schema(const vast::schema& sch) {
-  auto t = sch.find(pcap_packet_type.name());
-  if (!t)
-    return make_error(ec::format_error, "did not find packet type in schema");
-  if (!congruent(packet_type_, *t))
-    return make_error(ec::format_error, "incongruent schema provided");
-  packet_type_ = *t;
-  return no_error;
+  return replace_if_congruent({&packet_type_}, sch);
 }
 
 expected<schema> reader::schema() const {

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -22,6 +22,7 @@
 #include "vast/json.hpp"
 #include "vast/pattern.hpp"
 #include "vast/type.hpp"
+#include "vast/schema.hpp"
 
 namespace vast {
 
@@ -620,6 +621,17 @@ bool congruent(const type& x, const data& y) {
 
 bool congruent(const data& x, const type& y) {
   return visit(data_congruence_checker{}, y, x);
+}
+
+expected<void> replace_if_congruent(std::initializer_list<type*> xs,
+                                    const schema& with) {
+  for (auto x : xs)
+    if (auto t = with.find(x->name()); t != nullptr) {
+      if (!congruent(*x, *t))
+        return make_error(ec::type_clash, "incongruent type:", x->name());
+      *x = *t;
+    }
+  return no_error;
 }
 
 bool compatible(const type& lhs, relational_operator op, const type& rhs) {

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -507,6 +507,13 @@ bool congruent(const type& x, const data& y);
 
 bool congruent(const data& x, const type& y);
 
+/// Replaces all types in `xs` that are congruent to a type in `with`.
+/// @param xs Pointers to the types that should get replaced.
+/// @param with Schema containing potentially congruent types.
+/// @returns an error if two types with the same name are not congruent.
+expected<void> replace_if_congruent(std::initializer_list<type*> xs,
+                                    const schema& with);
+
 /// Checks whether the types of two nodes in a predicate are compatible with
 /// each other, i.e., whether operator evaluation for the given types is
 /// semantically correct.


### PR DESCRIPTION
We saw this pattern multiple times in code base.
The function can also be used for the mrt parser and the netflow parser.