### PR TITLE
Replace (con|dis)junction with fold expressions

### DIFF
--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -113,10 +113,10 @@ using disable_if_same = disable_if_t<std::is_same<T, U>::value, R>;
 // -- traits -----------------------------------------------------------------
 
 template <class T, class...Ts>
-struct is_any : std::disjunction<std::is_same<T, Ts>...> {};
+struct is_any : std::bool_constant<(std::is_same_v<T, Ts> || ...)> {};
 
-template <class T, class...Ts>
-struct are_same : std::conjunction<std::is_same<T, Ts>...> {};
+template <class T, class... Ts>
+struct are_same : std::bool_constant<(std::is_same_v<T, Ts> && ...)> {};
 
 // -- tuple ------------------------------------------------------------------
 

--- a/libvast/vast/variant.hpp
+++ b/libvast/vast/variant.hpp
@@ -145,15 +145,13 @@ public:
   }
 
   variant(const variant& other)
-  noexcept(std::conjunction<std::is_nothrow_constructible<Ts>...>::value) {
+  noexcept((std::is_nothrow_constructible_v<Ts> && ...)) {
     other.apply(copy_constructor{*this});
     index_ = other.index_;
   }
 
   variant(variant&& other)
-  noexcept(std::conjunction<
-             std::is_nothrow_move_constructible<Ts>...
-           >::value) {
+  noexcept((std::is_nothrow_move_constructible_v<Ts> && ...)) {
     other.apply(move_constructor{*this});
     index_ = other.index_;
   }
@@ -165,9 +163,7 @@ public:
   }
 
   variant& operator=(variant&& rhs)
-  noexcept(std::conjunction<
-             std::is_nothrow_move_assignable<Ts>...
-           >::value) {
+  noexcept((std::is_nothrow_move_assignable_v<Ts> && ...)) {
     rhs.apply(move_assigner{*this, rhs.index_});
     index_ = rhs.index_;
     return *this;


### PR DESCRIPTION
Use C++17 fold expressions instead of using `std::conjunction` and
`std::disjunction`.