### PR TITLE
Fix expression evaluation

### DIFF
--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -255,7 +255,7 @@ expected<void> validator::operator()(const attribute_extractor& ex,
 }
 
 expected<void> validator::operator()(const type_extractor& ex, const data& d) {
-  if (!type_check(ex.type, d))
+  if (!compatible(ex.type, op_, d))
     return make_error(ec::syntax_error, "type extractor type check failure",
                       ex.type, op_, d);
   return no_error;

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -172,6 +172,9 @@ TEST(validation - type extractor) {
   auto expr = to<expression>(":port == 443/tcp");
   REQUIRE(expr);
   CHECK(visit(validator{}, *expr));
+  expr = to<expression>(":addr in 10.0.0.0/8");
+  REQUIRE(expr);
+  CHECK(visit(validator{}, *expr));
   expr = to<expression>(":port > -42");
   REQUIRE(expr);
   CHECK(!visit(validator{}, *expr));


### PR DESCRIPTION
This PR fixes an issue with the expression validation. The implementation used the wrong internal helper function to compute whether the operands of a predicate are compatible to each other.