### PR TITLE
Pass limit to sink in export command

### DIFF
--- a/libvast/src/system/pcap_writer_command.cpp
+++ b/libvast/src/system/pcap_writer_command.cpp
@@ -41,10 +41,12 @@ pcap_writer_command::pcap_writer_command(command* parent, std::string_view name)
 }
 
 expected<caf::actor> pcap_writer_command::make_sink(caf::scoped_actor& self,
-                                                caf::message args) {
+                                                    option_map& options,
+                                                    caf::message args) {
   CAF_LOG_TRACE(CAF_ARG(args));
+  auto limit = this->get_or<uint64_t>(options, "events", 0u);
   format::pcap::writer writer{output_, flush_};
-  return self->spawn(sink<format::pcap::writer>, std::move(writer));
+  return self->spawn(sink<format::pcap::writer>, std::move(writer), limit);
 }
 
 } // namespace vast::system

--- a/libvast/src/system/spawn_sink.cpp
+++ b/libvast/src/system/spawn_sink.cpp
@@ -63,24 +63,24 @@ expected<actor> spawn_sink(local_actor* self, options& opts) {
     if (!r.error.empty())
       return make_error(ec::syntax_error, r.error);
     format::pcap::writer writer{output, flush};
-    snk = self->spawn(sink<format::pcap::writer>, std::move(writer));
+    snk = self->spawn(sink<format::pcap::writer>, std::move(writer), 0u);
 #endif
   } else if (format == "bro") {
     format::bro::writer writer{output};
-    snk = self->spawn(sink<format::bro::writer>, std::move(writer));
+    snk = self->spawn(sink<format::bro::writer>, std::move(writer), 0u);
   } else {
     auto out = detail::make_output_stream(output, r.opts.count("uds") > 0);
     if (!out)
       return out.error();
     if (format == "csv") {
       format::csv::writer writer{std::move(*out)};
-      snk = self->spawn(sink<format::csv::writer>, std::move(writer));
+      snk = self->spawn(sink<format::csv::writer>, std::move(writer), 0u);
     } else if (format == "ascii") {
       format::ascii::writer writer{std::move(*out)};
-      snk = self->spawn(sink<format::ascii::writer>, std::move(writer));
+      snk = self->spawn(sink<format::ascii::writer>, std::move(writer), 0u);
     } else if (format == "json") {
       format::json::writer writer{std::move(*out)};
-      snk = self->spawn(sink<format::json::writer>, std::move(writer));
+      snk = self->spawn(sink<format::json::writer>, std::move(writer), 0u);
     } else {
       return make_error(ec::syntax_error, "invalid format:", format);
     }

--- a/libvast/src/system/writer_command_base.cpp
+++ b/libvast/src/system/writer_command_base.cpp
@@ -58,7 +58,7 @@ int writer_command_base::run_impl(caf::actor_system& sys, option_map& options,
   });
   // Spawn a sink.
   VAST_DEBUG("spawning sink with parameters:", deep_to_string(options));
-  auto snk_opt = make_sink(self, args);
+  auto snk_opt = make_sink(self, options, args);
   if (!snk_opt) {
     std::cerr << "unable to spawn sink: " << sys.render(snk_opt.error())
               << std::endl;

--- a/libvast/test/system/sink.cpp
+++ b/libvast/test/system/sink.cpp
@@ -28,7 +28,7 @@ FIXTURE_SCOPE(sink_tests, fixtures::actor_system_and_events)
 TEST(Bro sink) {
   MESSAGE("constructing a sink");
   format::bro::writer writer{directory};
-  auto snk = self->spawn(sink<format::bro::writer>, std::move(writer));
+  auto snk = self->spawn(sink<format::bro::writer>, std::move(writer), 0u);
   MESSAGE("sending events");
   self->send(snk, bro_conn_log);
   MESSAGE("shutting down");

--- a/libvast/vast/system/pcap_writer_command.hpp
+++ b/libvast/vast/system/pcap_writer_command.hpp
@@ -51,7 +51,7 @@ public:
   pcap_writer_command(command* parent, std::string_view name);
 
 protected:
-  expected<caf::actor> make_sink(caf::scoped_actor& self,
+  expected<caf::actor> make_sink(caf::scoped_actor& self, option_map& options,
                                  caf::message args) override;
 
 private:

--- a/libvast/vast/system/writer_command.hpp
+++ b/libvast/vast/system/writer_command.hpp
@@ -47,19 +47,20 @@ public:
   }
 
 protected:
-  expected<caf::actor> make_sink(caf::scoped_actor& self,
+  expected<caf::actor> make_sink(caf::scoped_actor& self, option_map& options,
                                  caf::message args) override {
     CAF_LOG_TRACE(CAF_ARG(args));
     using ostream_ptr = std::unique_ptr<std::ostream>;
+    auto limit = this->get_or<uint64_t>(options, "events", 0u);
     if constexpr (std::is_constructible<Writer, ostream_ptr>::value) {
       auto out = detail::make_output_stream(output_, uds_);
       if (!out)
         return out.error();
       Writer writer{std::move(*out)};
-      return self->spawn(sink<Writer>, std::move(writer));
+      return self->spawn(sink<Writer>, std::move(writer), limit);
     } else {
       Writer writer;
-      return self->spawn(sink<Writer>, std::move(writer));
+      return self->spawn(sink<Writer>, std::move(writer), limit);
     }
   }
 

--- a/libvast/vast/system/writer_command_base.hpp
+++ b/libvast/vast/system/writer_command_base.hpp
@@ -49,6 +49,7 @@ protected:
                caf::message args) override;
 
   virtual expected<caf::actor> make_sink(caf::scoped_actor& self,
+                                         option_map& options,
                                          caf::message args) = 0;
 };
 


### PR DESCRIPTION
Fix shutdown issue when using the `export` command with a limit.