### PR TITLE
Setup CI infrastructure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,137 @@
+stages:
+  - dependencies
+  - build
+  - unit-test
+  - coverage
+  - deploy
+
+### Templates
+.build_caf_template: &build_caf_template
+  stage: dependencies
+  script:
+    - scripts/gitlab caf aux/caf caf_install_folder
+  cache:
+    key: "${CI_JOB_NAME}-${CI_PROJECT_DIR}"
+    paths:
+      - aux/caf/
+  artifacts:
+    paths:
+    - caf_install_folder
+
+.build_vast_template: &build_vast_template
+  stage: build
+  script:
+    - scripts/gitlab vast caf_install_folder vast_install_folder
+  cache:
+    key: "${CI_JOB_NAME}-${CI_PROJECT_DIR}"
+    paths:
+      - build/
+  artifacts:
+    paths:
+      - vast_install_folder
+
+.test_template: &test_template
+  stage: unit-test
+  script:
+    - scripts/gitlab test caf_install_folder vast_install_folder
+
+### Code Coverage
+# see: https://tenzir.gitlab.io/vast
+build_vast:osx:clang:gcov:
+  stage: coverage
+  script:
+    - scripts/gitlab vast caf_install_folder vast_install_folder
+  cache:
+    key: "${CI_JOB_NAME}-${CI_PROJECT_DIR}"
+    paths:
+      - build/
+  artifacts:
+    paths:
+      - build/coverage.html
+  variables:
+    BUILD: "gcov"
+    COMPILER: "clang"
+  dependencies:
+    - build_caf:osx:clang:debug
+  tags:
+    - osx
+    - clang
+
+pages:
+  stage: deploy
+  dependencies:
+    - build_vast:osx:clang:gcov
+  script:
+    - mkdir public
+    - mv build/coverage.html public/index.html
+    - ls public/
+  artifacts:
+    paths:
+      - public
+  #only:
+    #- master
+
+####################
+### Matrix Build ###
+####################
+
+### Dependency Stages
+build_caf:osx:clang:release:
+  <<: *build_caf_template
+  variables:
+    BUILD: "release"
+    COMPILER: "clang"
+  tags:
+    - osx
+    - clang
+
+build_caf:osx:clang:debug:
+  <<: *build_caf_template
+  variables:
+    BUILD: "debug"
+    COMPILER: "clang"
+  tags:
+    - osx
+    - clang
+
+### Build Stages
+build_vast:osx:clang:release:
+  <<: *build_vast_template
+  variables:
+    BUILD: "release"
+    COMPILER: "clang"
+  tags:
+    - osx
+    - clang
+  dependencies:
+    - build_caf:osx:clang:release
+
+build_vast:osx:clang:debug:
+  <<: *build_vast_template
+  variables:
+    BUILD: "debug"
+    COMPILER: "clang"
+  tags:
+    - osx
+    - clang
+  dependencies:
+    - build_caf:osx:clang:debug
+
+### Test Stages
+test:osx:clang:release:
+  <<: *test_template
+  dependencies:
+    - build_caf:osx:clang:release
+    - build_vast:osx:clang:release
+  tags:
+    - osx
+    - clang
+
+test:osx:clang:debug:
+  <<: *test_template
+  dependencies:
+    - build_caf:osx:clang:debug
+    - build_vast:osx:clang:debug
+  tags:
+    - osx
+    - clang

--- a/scripts/create-gitlab-ci-script.py
+++ b/scripts/create-gitlab-ci-script.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+import itertools
+
+def get_skeleton():
+    return '''
+stages:
+  - dependencies
+  - build
+  - unit-test
+  - coverage
+  - deploy
+
+### Templates
+.build_caf_template: &build_caf_template
+  stage: dependencies
+  script:
+    - scripts/gitlab caf aux/caf caf_install_folder
+  cache:
+    key: "${CI_JOB_NAME}-${CI_PROJECT_DIR}"
+    paths:
+      - aux/caf/
+  artifacts:
+    paths:
+    - caf_install_folder
+
+.build_vast_template: &build_vast_template
+  stage: build
+  script:
+    - scripts/gitlab vast caf_install_folder vast_install_folder
+  cache:
+    key: "${CI_JOB_NAME}-${CI_PROJECT_DIR}"
+    paths:
+      - build/
+  artifacts:
+    paths:
+      - vast_install_folder
+
+.test_template: &test_template
+  stage: unit-test
+  script:
+    - scripts/gitlab test caf_install_folder vast_install_folder
+
+### Code Coverage
+# see: https://tenzir.gitlab.io/vast
+build_vast:osx:clang:gcov:
+  stage: coverage
+  script:
+    - scripts/gitlab vast caf_install_folder vast_install_folder
+  cache:
+    key: "${CI_JOB_NAME}-${CI_PROJECT_DIR}"
+    paths:
+      - build/
+  artifacts:
+    paths:
+      - build/coverage.html
+  variables:
+    BUILD: "gcov"
+    COMPILER: "clang"
+  dependencies:
+    - build_caf:osx:clang:debug
+  tags:
+    - osx
+    - clang
+
+pages:
+  stage: deploy
+  dependencies:
+    - build_vast:osx:clang:gcov
+  script:
+    - mkdir public
+    - mv build/coverage.html public/index.html
+    - ls public/
+  artifacts:
+    paths:
+      - public
+  #only:
+    #- master
+
+####################
+### Matrix Build ###
+####################
+    '''.strip()
+
+class config:
+    def __init__(self, os, compiler, build):
+        self.os = os
+        self.compiler = compiler
+        self.build = build
+
+def get_env(x):
+    return  \
+'''  variables:
+    BUILD: "{build}"
+    COMPILER: "{compiler}"'''.format(build = x.build, compiler = x.compiler)
+
+def get_tags(x):
+    return \
+'''  tags:
+    - {os}
+    - {compiler}'''.format(os = x.os, compiler = x.compiler)
+
+def get_dependency_job(x):
+    return \
+'''build_caf:{os}:{compiler}:{build}:
+  <<: *build_caf_template
+'''.format(os=x.os, compiler=x.compiler, build=x.build) + \
+    get_env(x) + "\n" + \
+    get_tags(x)
+
+def get_build_job(x):
+    return \
+'''build_vast:{os}:{compiler}:{build}:
+  <<: *build_vast_template'''.format(os=x.os, compiler=x.compiler, build=x.build) + "\n" + \
+    get_env(x) + "\n" + \
+    get_tags(x) + "\n" + \
+'''  dependencies:
+    - build_caf:{os}:{compiler}:{build}'''.format(os=x.os, compiler=x.compiler, build=x.build)
+
+def get_test_job(x):
+    return \
+'''test:{os}:{compiler}:{build}:
+  <<: *test_template
+  dependencies:
+    - build_caf:{os}:{compiler}:{build}
+    - build_vast:{os}:{compiler}:{build}
+'''.format(os=x.os, compiler=x.compiler, build=x.build) + \
+    get_tags(x)
+
+def build_matrix(*params):
+    for x in itertools.product(*params):
+        yield config(*x)
+
+def write_to_file(filename, output):
+    f = open(filename, "w")
+    f.write(output)
+
+def run():
+    filename = ".gitlab-ci.yml"
+    oss = ["osx"]
+    compilers = ["clang"]
+    builds = ["release", "debug"]
+    output = get_skeleton() + "\n\n"
+    output += "### Dependency Stages\n"
+    for x in build_matrix(oss, compilers, builds):
+        output += get_dependency_job(x) + "\n\n"
+    output += "### Build Stages\n"
+    for x in build_matrix(oss, compilers, builds):
+        output += get_build_job(x) + "\n\n"
+    output += "### Test Stages\n"
+    for x in build_matrix(oss, compilers, builds):
+        output += get_test_job(x) + "\n\n"
+    write_to_file(filename, output)
+
+if __name__ == "__main__":
+    run()

--- a/scripts/gitlab
+++ b/scripts/gitlab
@@ -1,0 +1,125 @@
+#!/bin/sh
+#
+# Gitlab script to configure, build, and unit-test VAST on multiple platforms.
+#
+
+set -e # Abort on error.
+
+usage() {
+  printf "usage: %s OPTIONS TARGET \n" $(basename $0)
+  echo
+  echo 'TARGET:'
+  echo '    caf  <clone path> <install path>   clone, build and install caf' 
+  echo '    vast <caf path> <install path>     build and install vast'
+  echo '    test <caf install path> <vast install path>  run vast-test'
+  echo
+  echo 'OPTIONS:'
+  echo '    -h        print this info'
+  echo
+  echo 'environment variables:'
+  echo '    BUILD     build type [relase|debug|asan|gcov]'
+  echo '    COMPILER  compiler type [clang|gcc]'
+  echo
+}
+
+while getopts "h?" opt; do
+  case "$opt" in
+    h|\?)
+      usage
+      exit 0
+    ;;
+  esac
+done
+
+# Command line handling.
+shift $(expr $OPTIND - 1)
+target="$1"; shift # caf or vast
+
+# Configure build environment.
+workspace="$(pwd)"
+os=$(uname)
+
+if [ "$os" = "FreeBSD" ]; then
+  # BSD make in combintation with CMake has trouble with paths that contain
+  # white space, so fall back to GNU make...alas.
+  alias make=gmake
+fi
+
+# Setup compilers.
+if [ "$COMPILER" = "gcc" ]; then
+  export CXX=g++-7
+elif [ "$COMPILER" = "clang" ]; then
+  export CXX=/usr/local/opt/llvm/bin/clang++
+  export LDFLAGS=$(/usr/local/opt/llvm/bin/llvm-config --ldflags)
+fi
+# Make should use all available cores.
+export MAKEFLAGS="-j$(sysctl -n hw.ncpu)"
+
+# Build CAF.
+if [ "$target" = "caf" ]; then
+  caf_clone_folder="$workspace/$1"; shift
+  caf_install_folder="$workspace/$1"; shift
+  if [ -d "$caf_clone_folder" ]; then
+    cd "$caf_clone_folder"
+    git pull
+  else
+    git clone https://github.com/actor-framework/actor-framework.git "$caf_clone_folder"
+    cd "$caf_clone_folder"
+  fi
+  configure="./configure --no-examples --no-unit-tests --no-opencl"
+  configure="$configure --no-openssl --no-tools --no-python"
+  configure="$configure --prefix=$caf_install_folder"
+  if [ "$BUILD" = "release" ]; then
+    configure="$configure --build-type=Release"
+  elif [ "$BUILD" = "debug" ]; then
+    configure="$configure --build-type=Debug --with-runtime-checks"
+  elif [ "$BUILD" = "asan" ]; then
+    configure="$configure --with-address-sanitizer"
+  fi
+  eval $configure
+  cd build
+  make
+  make install
+fi
+
+# Build VAST.
+if [ "$target" = "vast" ]; then
+  caf_install_folder="$workspace/$1"; shift
+  vast_install_folder="$workspace/$1"; shift
+  if [ "$os" = "Darwin" ]; then
+    export DYLD_LIBRARY_PATH="$caf_install_folder/lib"
+  else
+    export LD_LIBRARY_PATH="$caf_install_folder/lib"
+  fi
+  configure="./configure --with-caf=$caf_install_folder"
+  configure="$configure --prefix=$vast_install_folder"
+  if [ "$BUILD" = "release" ]; then
+    configure="$configure --build-type=Release"
+  elif [ "$BUILD" = "debug" ]; then
+    configure="$configure --build-type=Debug"
+  elif [ "$BUILD" = "asan" ]; then
+    configure="$configure --build-type=RelWithDebInfo --enable-asan"
+  elif [ "$BUILD" = "gcov" ]; then
+    configure="$configure --build-type=Debug --enable-gcov"
+  fi
+  eval $configure
+  make
+  if [ "$BUILD" = "gcov" ]; then
+    make coverage
+  else
+    make install
+    cp -r build/bin $vast_install_folder/.
+  fi
+fi
+
+if [ "$target" = "test" ]; then
+  caf_install_folder="$workspace/$1"; shift
+  vast_install_folder="$workspace/$1"; shift
+  lib_paths="$caf_install_folder/lib:$vast_install_folder/lib"
+  if [ "$os" = "Darwin" ]; then
+    export DYLD_LIBRARY_PATH="$lib_paths"
+  else
+    export LD_LIBRARY_PATH="$lib_paths"
+  fi
+  $vast_install_folder/bin/vast-test -v 3 -n -r 600
+fi


### PR DESCRIPTION
<img width="972" alt="screen shot 2018-04-11 at 10 26 51" src="https://user-images.githubusercontent.com/7466955/38605223-fa6e3ca2-3d72-11e8-8fcd-2ca25c0c253a.png">

This is a proposal for a CI setup with GitLab.
As shown in the image above the CI pipeline consists 5 stages: Dependencies, Build, Test, Coverage and Deploy. This pipeline is triggered on each ```git push``` which contains the file ```.gitlab-ci.yml``` in the root directory (it is possible to refine that if necessary). GitLab informs the author when the pipeline fails and integrates the current status in each pull request on GitHub Website. Each stage has access to a local machine cache, which minimizes the build time for VAST and its dependencies.

Each stage can consist of multiple concurrent jobs, which have to be finished successfully before the next stage can be started. We use a job to execute a task for a specific build type (e.g. a debug build with clang or an ASAN build). Each job creates a result (an **artifact**) which can be used by jobs of other stages.

In the fist stage we build CAF and bundle the includes and libs for a specific build type as an artifact. In the second stage we build VAST and bundle the includes, libs and bins as an artifact. In the third stage we run ```vast-test``` for each build type. Afterwards, we create a code coverage report und upload it to the website: [https://tenzir.gitlab.io/vast](https://tenzir.gitlab.io/vast). 

Advantages:
GitLab provides a convenient Web interface and is very easy to configure.

Disadvantages:
GitLab CI is _immature_. It does not provide parallel pipelines and build matrices.
Without parallel pipelines the code coverage report and further independent tasks (like cppcheck or benchmarks) must be awkwardly attached at the end of the _mono_ pipeline. And a failure in one job aborts all future stages regardless of their logical dependencies.
To efficiently map a larger build matrix to the YAML config file it must be auto generated.