### PR TITLE
Switch to new C++17 _v notation

### DIFF
--- a/libvast/src/format/bro.cpp
+++ b/libvast/src/format/bro.cpp
@@ -167,7 +167,7 @@ struct streamer {
 
   template <class T, class U>
   auto operator()(const T&, const U& x) const
-  -> std::enable_if_t<!std::is_same<U, none>::value> {
+  -> std::enable_if_t<!std::is_same_v<U, none>> {
     out_ << to_string(x);
   }
 

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -29,7 +29,7 @@
 using namespace vast;
 
 TEST(vector) {
-  REQUIRE(std::is_same<std::vector<data>, vector>::value);
+  REQUIRE(std::is_same_v<std::vector<data>, vector>);
 }
 
 TEST(set) {

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -78,7 +78,7 @@ TEST(maybe) {
 TEST(container attribute folding) {
   using namespace parsers;
   auto spaces = *' '_p;
-  static_assert(std::is_same<decltype(spaces)::attribute, unused_type>::value,
+  static_assert(std::is_same_v<decltype(spaces)::attribute, unused_type>,
                 "container attribute folding failed");
 }
 

--- a/libvast/test/variant.cpp
+++ b/libvast/test/variant.cpp
@@ -165,7 +165,7 @@ TEST(overload visitation) {
 TEST(reference returning) {
   int i = 42;
   auto& j = visit(referencer{&i}, t0);
-  static_assert(std::is_same<decltype(referencer{nullptr}(42)), int&>::value,
+  static_assert(std::is_same_v<decltype(referencer{nullptr}(42)), int&>,
                 "visitation is not able to return a reference");
   CHECK_EQUAL(i, j); // pro forma
 }

--- a/libvast/vast/access.hpp
+++ b/libvast/vast/access.hpp
@@ -70,17 +70,20 @@ struct has_access_converter {
 } // namespace detail
 
 template <class T>
-struct has_access_state : decltype(detail::has_access_state::test<T>(0)) {};
+inline constexpr bool has_access_state_v
+  = decltype(detail::has_access_state::test<T>(0))::value;
 
 template <class T>
-struct has_access_parser : decltype(detail::has_access_parser::test<T>(0)) {};
+inline constexpr bool has_access_parser_v
+  = decltype(detail::has_access_parser::test<T>(0))::value;
 
 template <class T>
-struct has_access_printer : decltype(detail::has_access_printer::test<T>(0)) {};
+inline constexpr bool has_access_printer_v
+  = decltype(detail::has_access_printer::test<T>(0))::value;
 
 template <class T>
-struct has_access_converter
-  : decltype(detail::has_access_converter::test<T>(0)) {};
+inline constexpr bool has_access_converter_v
+  = decltype(detail::has_access_converter::test<T>(0))::value;
 
 } // namespace vast
 

--- a/libvast/vast/binner.hpp
+++ b/libvast/vast/binner.hpp
@@ -40,12 +40,12 @@ struct decimal_binner {
 
   template <class T>
   static T bin(T x) {
-    if constexpr (std::is_integral<T>::value)
+    if constexpr (std::is_integral_v<T>)
       return x / bucket_size;
-    else if constexpr (std::is_floating_point<T>::value)
+    else if constexpr (std::is_floating_point_v<T>)
       return std::round(x / bucket_size);
     else
-      static_assert(!std::is_same<T, T>::value,
+      static_assert(!std::is_same_v<T, T>,
                     "T is neither integral nor a float");
   }
 };
@@ -73,9 +73,9 @@ struct precision_binner {
 
   template <class T>
   static T bin(T x) {
-    if constexpr (std::is_integral<T>::value) {
+    if constexpr (std::is_integral_v<T>) {
       return std::min(x, integral_max);
-    } else if constexpr (std::is_floating_point<T>::value) {
+    } else if constexpr (std::is_floating_point_v<T>) {
       T i;
       auto f = std::modf(x, &i);
       auto negative = std::signbit(x);

--- a/libvast/vast/bitmap_algorithms.hpp
+++ b/libvast/vast/bitmap_algorithms.hpp
@@ -33,7 +33,7 @@ namespace detail {
 
 template <class T, class U>
 struct eval_result_type {
-  using type = std::conditional_t<std::is_same<T, U>::value, T, bitmap>;
+  using type = std::conditional_t<std::is_same_v<T, U>, T, bitmap>;
 };
 
 template <class T, class U>
@@ -64,11 +64,11 @@ binary_eval(const LHS& lhs, const RHS& rhs, Operation op) {
   using result_type = detail::eval_result_type_t<LHS, RHS>;
   using word_type = typename result_type::word_type;
   static_assert(
-    detail::are_same<
+    detail::are_same_v<
       typename LHS::word_type::value_type,
       typename RHS::word_type::value_type,
       typename result_type::word_type::value_type
-    >::value,
+    >,
     "LHS, RHS, and result bitmaps must have same block type");
   // TODO: figure out whether we still need the notion of a "fill," i.e., a
   // homogeneous sequence greater-than-or-equal to the word size, or whether

--- a/libvast/vast/bitvector.hpp
+++ b/libvast/vast/bitvector.hpp
@@ -39,9 +39,9 @@ class bitvector_iterator;
 /// of the interface defined in §23.3.12.
 template <class Block = size_t, class Allocator = std::allocator<Block>>
 class bitvector : detail::equality_comparable<bitvector<Block, Allocator>> {
-  static_assert(std::is_unsigned<Block>::value,
+  static_assert(std::is_unsigned_v<Block>,
                 "Block must be unsigned for well-defined bit operations");
-  static_assert(!std::is_same<Block, bool>::value,
+  static_assert(!std::is_same_v<Block, bool>,
                 "Block cannot be bool; you may want std::vector<bool> instead");
 
 public:
@@ -335,7 +335,7 @@ class bitvector_iterator
       typename Bitvector::value_type,
       std::random_access_iterator_tag,
       std::conditional_t<
-        std::is_const<Bitvector>::value,
+        std::is_const_v<Bitvector>,
         typename Bitvector::const_reference,
         typename Bitvector::reference
       >,
@@ -704,8 +704,8 @@ rank(const bitvector<Block, Allocator>& bv) {
   auto n = bv.size();
   auto p = bv.blocks().data();
   for (; n >= word_type::width; ++p, n -= word_type::width)
-    result += Bit 
-      ? word_type::popcount(*p) 
+    result += Bit
+      ? word_type::popcount(*p)
       : word_type::width - word_type::popcount(*p);
   if (n > 0) {
     auto last = word_type::popcount(*p & word_type::lsb_mask(n));

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -117,10 +117,10 @@ public:
     // Map T to the clostest type in config_value.
     using cfg_type =
       typename std::conditional<
-        std::is_integral<T>::value && !std::is_same<bool, T>::value,
+        std::is_integral_v<T> && !std::is_same_v<bool, T>,
         int64_t,
         typename std::conditional<
-          std::is_floating_point<T>::value,
+          std::is_floating_point_v<T>,
           double,
           T
           >::type
@@ -162,10 +162,10 @@ protected:
       // Map T to the clostest type in config_value.
       using cfg_type =
         typename std::conditional<
-          std::is_integral<T>::value && !std::is_same<bool, T>::value,
+          std::is_integral_v<T> && !std::is_same_v<bool, T>,
           int64_t,
           typename std::conditional<
-            std::is_floating_point<T>::value,
+            std::is_floating_point_v<T>,
             double,
             T
             >::type

--- a/libvast/vast/concept/hashable/hash_append.hpp
+++ b/libvast/vast/concept/hashable/hash_append.hpp
@@ -79,7 +79,7 @@ template <class ...T>
 struct is_uniquely_represented<std::tuple<T...>>
   : std::integral_constant<
       bool,
-      std::conjunction<is_uniquely_represented<T>...>::value
+      std::conjunction_v<is_uniquely_represented<T>...>
         && detail::sum<sizeof(T)...>{} == sizeof(std::tuple<T...>)
     > {};
 
@@ -182,7 +182,7 @@ void hash_append(Hasher& h, std::chrono::time_point<Clock, Duration> t) {
 // -- empty types -------------------------------------------------------------
 
 template <class Hasher, class T>
-std::enable_if_t<std::is_empty<T>::value>
+std::enable_if_t<std::is_empty_v<T>>
 hash_append(Hasher& h, T) noexcept {
   hash_append(h, 0);
 }

--- a/libvast/vast/concept/parseable/core/as.hpp
+++ b/libvast/vast/concept/parseable/core/as.hpp
@@ -42,7 +42,7 @@ private:
 template <class Attribute, class Parser>
 auto as(Parser&& p)
 -> std::enable_if_t<
-     is_parser<std::decay_t<Parser>>::value,
+     is_parser_v<std::decay_t<Parser>>,
      as_parser<std::decay_t<Parser>, Attribute>
    > {
   return as_parser<std::decay_t<Parser>, Attribute>{std::forward<Parser>(p)};

--- a/libvast/vast/concept/parseable/core/choice.hpp
+++ b/libvast/vast/concept/parseable/core/choice.hpp
@@ -33,6 +33,9 @@ struct is_choice_parser : std::false_type {};
 template <class Lhs, class Rhs>
 struct is_choice_parser<choice_parser<Lhs, Rhs>> : std::true_type {};
 
+template <class T>
+inline constexpr bool is_choice_parser_v = is_choice_parser<T>::value;
+
 /// Attempts to parse either LHS or RHS.
 template <class Lhs, class Rhs>
 class choice_parser : public parser<choice_parser<Lhs, Rhs>> {
@@ -90,13 +93,13 @@ private:
 
   template <class Left, class Iterator>
   auto parse_left(Iterator& f, const Iterator& l, unused_type) const
-  -> std::enable_if_t<!is_choice_parser<Left>::value, bool> {
+  -> std::enable_if_t<!is_choice_parser_v<Left>, bool> {
     return lhs_(f, l, unused);
   }
 
   template <class Left, class Iterator, class Attribute>
   auto parse_left(Iterator& f, const Iterator& l, Attribute& a) const
-  -> std::enable_if_t<!is_choice_parser<Left>::value, bool> {
+  -> std::enable_if_t<!is_choice_parser_v<Left>, bool> {
     lhs_attribute al;
     if (!lhs_(f, l, al))
       return false;

--- a/libvast/vast/concept/parseable/core/ignore.hpp
+++ b/libvast/vast/concept/parseable/core/ignore.hpp
@@ -40,7 +40,7 @@ private:
 template <class Parser>
 auto ignore(Parser&& p)
 -> std::enable_if_t<
-     is_parser<std::decay_t<Parser>>::value,
+     is_parser_v<std::decay_t<Parser>>,
      ignore_parser<std::decay_t<Parser>>
    > {
   return ignore_parser<std::decay_t<Parser>>{std::move(p)};

--- a/libvast/vast/concept/parseable/core/operators.hpp
+++ b/libvast/vast/concept/parseable/core/operators.hpp
@@ -56,7 +56,7 @@ class choice_parser;
 template <class T>
 auto operator&(T&& x)
   -> std::enable_if_t<
-       is_parser<std::decay_t<T>>{},
+       is_parser_v<std::decay_t<T>>,
        and_parser<std::decay_t<T>>
      > {
   return and_parser<std::decay_t<T>>{std::forward<T>(x)};
@@ -65,7 +65,7 @@ auto operator&(T&& x)
 template <class T>
 auto operator!(T&& x)
   -> std::enable_if_t<
-       is_parser<std::decay_t<T>>{},
+       is_parser_v<std::decay_t<T>>,
        not_parser<std::decay_t<T>>
      > {
   return not_parser<std::decay_t<T>>{std::forward<T>(x)};
@@ -74,7 +74,7 @@ auto operator!(T&& x)
 template <class T>
 auto operator-(T&& x)
   -> std::enable_if_t<
-       is_parser<std::decay_t<T>>{},
+       is_parser_v<std::decay_t<T>>,
        optional_parser<std::decay_t<T>>
      > {
   return optional_parser<std::decay_t<T>>{std::forward<T>(x)};
@@ -83,7 +83,7 @@ auto operator-(T&& x)
 template <class T>
 auto operator*(T&& x)
   -> std::enable_if_t<
-       is_parser<std::decay_t<T>>{},
+       is_parser_v<std::decay_t<T>>,
        kleene_parser<std::decay_t<T>>
      > {
   return kleene_parser<std::decay_t<T>>{std::forward<T>(x)};
@@ -92,7 +92,7 @@ auto operator*(T&& x)
 template <class T>
 auto operator+(T&& x)
   -> std::enable_if_t<
-       is_parser<std::decay_t<T>>{},
+       is_parser_v<std::decay_t<T>>,
        plus_parser<std::decay_t<T>>
      > {
   return plus_parser<std::decay_t<T>>{std::forward<T>(x)};
@@ -101,7 +101,7 @@ auto operator+(T&& x)
 template <class T>
 auto operator~(T&& x)
   -> std::enable_if_t<
-       is_parser<std::decay_t<T>>{},
+       is_parser_v<std::decay_t<T>>,
        maybe_parser<std::decay_t<T>>
      > {
   return maybe_parser<std::decay_t<T>>{std::forward<T>(x)};

--- a/libvast/vast/concept/parseable/core/parser.hpp
+++ b/libvast/vast/concept/parseable/core/parser.hpp
@@ -116,11 +116,12 @@ struct has_parser {
 
 /// Checks whether the parser registry has a given type registered.
 template <class T>
-struct has_parser : decltype(detail::has_parser::test<T>(0)) {};
+inline constexpr bool has_parser_v
+  = decltype(detail::has_parser::test<T>(0))::value;
 
 /// Checks whether a given type is-a parser, i.e., derived from ::vast::parser.
 template <class T>
-using is_parser = std::is_base_of<parser<T>, T>;
+inline constexpr bool is_parser_v = std::is_base_of<parser<T>, T>::value;
 
 } // namespace vast
 

--- a/libvast/vast/concept/parseable/core/repeat.hpp
+++ b/libvast/vast/concept/parseable/core/repeat.hpp
@@ -66,7 +66,7 @@ private:
 
 template <class Parser, class T>
 class dynamic_repeat_parser : public parser<dynamic_repeat_parser<Parser, T>> {
-  static_assert(std::is_integral<T>::value, "T must be an an integral type");
+  static_assert(std::is_integral_v<T>, "T must be an an integral type");
 
 public:
   using container = detail::container<typename Parser::attribute>;

--- a/libvast/vast/concept/parseable/core/rule.hpp
+++ b/libvast/vast/concept/parseable/core/rule.hpp
@@ -74,7 +74,7 @@ public:
   template <
     class RHS,
     class = std::enable_if_t<
-      is_parser<std::decay_t<RHS>>{} && !detail::is_same_or_derived<rule, RHS>::value
+      is_parser_v<std::decay_t<RHS>> && !detail::is_same_or_derived_v<rule, RHS>
     >
   >
   rule(RHS&& rhs)
@@ -84,8 +84,8 @@ public:
 
   template <class RHS>
   auto operator=(RHS&& rhs)
-    -> std::enable_if_t<is_parser<std::decay_t<RHS>>{}
-                        && !detail::is_same_or_derived<rule, RHS>::value> {
+    -> std::enable_if_t<is_parser_v<std::decay_t<RHS>>
+                        && !detail::is_same_or_derived_v<rule, RHS>> {
     make_parser<RHS>(std::forward<RHS>(rhs));
   }
 

--- a/libvast/vast/concept/parseable/core/sequence.hpp
+++ b/libvast/vast/concept/parseable/core/sequence.hpp
@@ -31,6 +31,9 @@ struct is_sequence_parser : std::false_type {};
 template <class... Ts>
 struct is_sequence_parser<sequence_parser<Ts...>> : std::true_type {};
 
+template <class T>
+inline constexpr bool is_sequence_parser_v = is_sequence_parser<T>::value;
+
 template <class Lhs, class Rhs>
 class sequence_parser : public parser<sequence_parser<Lhs, Rhs>> {
 public:
@@ -78,16 +81,16 @@ public:
 private:
   template <class T>
   static constexpr auto depth_helper()
-    -> std::enable_if_t<!is_sequence_parser<T>::value, size_t> {
+    -> std::enable_if_t<!is_sequence_parser_v<T>, size_t> {
     return 0;
   }
 
   template <class T>
   static constexpr auto depth_helper()
     -> std::enable_if_t<
-         is_sequence_parser<T>::value
-          && (std::is_same<typename T::lhs_attribute, unused_type>::value
-              || std::is_same<typename T::rhs_attribute, unused_type>::value),
+         is_sequence_parser_v<T>
+          && (std::is_same_v<typename T::lhs_attribute, unused_type>
+              || std::is_same_v<typename T::rhs_attribute, unused_type>),
          size_t
        >
   { return depth_helper<typename T::lhs_type>();
@@ -96,9 +99,9 @@ private:
   template <class T>
   static constexpr auto depth_helper()
     -> std::enable_if_t<
-         is_sequence_parser<T>::value
-          && !std::is_same<typename T::lhs_attribute, unused_type>::value
-          && !std::is_same<typename T::rhs_attribute, unused_type>::value,
+         is_sequence_parser_v<T>
+          && !std::is_same_v<typename T::lhs_attribute, unused_type>
+          && !std::is_same_v<typename T::rhs_attribute, unused_type>,
          size_t
        > {
     return 1 + depth_helper<typename T::lhs_type>();
@@ -117,7 +120,7 @@ private:
   template <class L, class T>
   static auto get_helper(T& x)
     -> std::enable_if_t<
-         !is_sequence_parser<L>::value,
+         !is_sequence_parser_v<L>,
          decltype(std::get<0>(x))
        > {
     return std::get<0>(x);

--- a/libvast/vast/concept/parseable/detail/container.hpp
+++ b/libvast/vast/concept/parseable/detail/container.hpp
@@ -27,6 +27,9 @@ struct is_pair : std::false_type {};
 template <class T, class U>
 struct is_pair<std::pair<T, U>> : std::true_type {};
 
+template <class T>
+inline constexpr bool is_pair_v = is_pair<T>::value;
+
 template <class Elem>
 struct container {
   using vector_type = std::vector<Elem>;
@@ -44,7 +47,7 @@ struct container {
       attribute
     >::value_type;
 
-  static constexpr bool modified = std::is_same<vector_type, attribute>::value;
+  static constexpr bool modified = std::is_same_v<vector_type, attribute>;
 
   template <class Container, class T>
   static void push_back(Container& c, T&& x) {
@@ -70,7 +73,7 @@ struct container {
   template <class Parser, class Iterator, class Attribute>
   static bool parse(const Parser& p, Iterator& f, const Iterator& l,
                     Attribute& a) {
-    if constexpr (!is_pair<typename Attribute::value_type>::value) {
+    if constexpr (!is_pair_v<typename Attribute::value_type>) {
       value_type x;
       if (!p(f, l, x))
         return false;

--- a/libvast/vast/concept/parseable/from_string.hpp
+++ b/libvast/vast/concept/parseable/from_string.hpp
@@ -28,7 +28,7 @@ template <
   class... Args
 >
 auto from_string(Iterator begin, Iterator end, Args&&... args)
-  -> std::enable_if_t<is_parseable<Iterator, To>::value, optional<To>> {
+  -> std::enable_if_t<is_parseable_v<Iterator, To>, optional<To>> {
   optional<To> t{To{}};
   if (Parser{std::forward<Args>(args)...}(begin, end, *t))
     return t;

--- a/libvast/vast/concept/parseable/numeric/integral.hpp
+++ b/libvast/vast/concept/parseable/numeric/integral.hpp
@@ -122,7 +122,7 @@ struct integral_parser
 };
 
 template <class T>
-struct parser_registry<T, std::enable_if_t<std::is_integral<T>::value>> {
+struct parser_registry<T, std::enable_if_t<std::is_integral_v<T>>> {
   using type = integral_parser<T>;
 };
 

--- a/libvast/vast/concept/parseable/numeric/real.hpp
+++ b/libvast/vast/concept/parseable/numeric/real.hpp
@@ -114,7 +114,7 @@ struct real_parser : parser<real_parser<T, Policies...>> {
 };
 
 template <class T>
-struct parser_registry<T, std::enable_if_t<std::is_floating_point<T>::value>> {
+struct parser_registry<T, std::enable_if_t<std::is_floating_point_v<T>>> {
   using type = real_parser<T, policy::require_dot>;
 };
 

--- a/libvast/vast/concept/parseable/parse.hpp
+++ b/libvast/vast/concept/parseable/parse.hpp
@@ -22,13 +22,13 @@ namespace vast {
 
 template <class Iterator, class T, class... Args>
 auto parse(Iterator& f, const Iterator& l, T& x, Args&&... args)
-  -> std::enable_if_t<has_parser<T>::value, bool> {
+  -> std::enable_if_t<has_parser_v<T>, bool> {
   return make_parser<T>{std::forward<Args>(args)...}(f, l, x);
 }
 
 template <class Iterator, class T, class... Args>
 auto parse(Iterator& f, const Iterator& l, T& x, Args&&... args)
-  -> std::enable_if_t<!has_parser<T>::value && has_access_parser<T>::value,
+  -> std::enable_if_t<!has_parser_v<T> && has_access_parser_v<T>,
                       bool> {
   return access::parser<T>{std::forward<Args>(args)...}(f, l, x);
 }
@@ -49,8 +49,7 @@ bool conjunctive_parse(Iterator& f, const Iterator& l, T& x, Ts&... xs) {
 
 template <class Iterator, class T>
 auto parse(Iterator& f, const Iterator& l, T& x)
-  -> std::enable_if_t<!has_parser<T>::value && has_access_state<T>::value,
-                      bool> {
+  -> std::enable_if_t<!has_parser_v<T> && has_access_state_v<T>, bool> {
   bool r;
   auto fun = [&](auto&... xs) { r = detail::conjunctive_parse(f, l, xs...); };
   access::state<T>::call(x, fun);
@@ -71,7 +70,8 @@ struct is_parseable {
 } // namespace detail
 
 template <class I, class T>
-struct is_parseable : decltype(detail::is_parseable::test<I, T>(0, 0, 0)) {};
+inline constexpr bool is_parseable_v
+  = decltype(detail::is_parseable::test<I, T>(0, 0, 0))::value;
 
 } // namespace vast
 

--- a/libvast/vast/concept/parseable/stream.hpp
+++ b/libvast/vast/concept/parseable/stream.hpp
@@ -22,7 +22,7 @@ namespace vast {
 
 template <class CharT, class Traits, class T>
 auto operator>>(std::basic_istream<CharT, Traits>& in, T& x)
-  -> std::enable_if_t<is_parseable<std::istreambuf_iterator<CharT>, T>::value,
+  -> std::enable_if_t<is_parseable_v<std::istreambuf_iterator<CharT>, T>,
                       decltype(in)> {
   using vast::parse; // enable ADL
   std::istreambuf_iterator<CharT> begin{in}, end;

--- a/libvast/vast/concept/parseable/to.hpp
+++ b/libvast/vast/concept/parseable/to.hpp
@@ -24,7 +24,7 @@ namespace vast {
 
 template <class To, class Iterator>
 auto to(Iterator& f, const Iterator& l)
-  -> std::enable_if_t<is_parseable<Iterator, To>{}, expected<To>> {
+  -> std::enable_if_t<is_parseable_v<Iterator, To>, expected<To>> {
   expected<To> t{To{}};
   if (!parse(f, l, *t))
     return make_error(ec::parse_error);
@@ -34,7 +34,7 @@ auto to(Iterator& f, const Iterator& l)
 template <class To, class Range>
 auto to(Range&& rng)
   -> std::enable_if_t<
-       is_parseable<decltype(std::begin(rng)), To>{}, expected<To>
+       is_parseable_v<decltype(std::begin(rng)), To>, expected<To>
      > {
   using std::begin;
   using std::end;

--- a/libvast/vast/concept/printable/core/choice.hpp
+++ b/libvast/vast/concept/printable/core/choice.hpp
@@ -30,6 +30,9 @@ struct is_choice_printer : std::false_type {};
 template <class Lhs, class Rhs>
 struct is_choice_printer<choice_printer<Lhs, Rhs>> : std::true_type {};
 
+template <class T>
+inline constexpr bool is_choice_printer_v = is_choice_printer<T>::value;
+
 /// Attempts to print either LHS or RHS.
 template <class Lhs, class Rhs>
 class choice_printer : public printer<choice_printer<Lhs, Rhs>> {
@@ -80,13 +83,13 @@ private:
 
   template <class Left, class Iterator>
   auto print_left(Iterator& out, unused_type) const
-  -> std::enable_if_t<!is_choice_printer<Left>::value, bool> {
+  -> std::enable_if_t<!is_choice_printer_v<Left>, bool> {
     return lhs_.print(out, unused);
   }
 
   template <class Left, class Iterator, class Attribute>
   auto print_left(Iterator& out, const Attribute& a) const
-  -> std::enable_if_t<!is_choice_printer<Left>::value, bool> {
+  -> std::enable_if_t<!is_choice_printer_v<Left>, bool> {
     auto x = get_if<lhs_attribute>(a);
     return x && lhs_.print(out, *x);
   }

--- a/libvast/vast/concept/printable/core/ignore.hpp
+++ b/libvast/vast/concept/printable/core/ignore.hpp
@@ -40,7 +40,7 @@ private:
 template <class Printer>
 auto ignore(Printer&& p)
 -> std::enable_if_t<
-     is_printer<std::decay_t<Printer>>::value,
+     is_printer_v<std::decay_t<Printer>>,
      ignore_printer<std::decay_t<Printer>>
    > {
   return ignore_printer<std::decay_t<Printer>>{std::forward<Printer>(p)};

--- a/libvast/vast/concept/printable/core/operators.hpp
+++ b/libvast/vast/concept/printable/core/operators.hpp
@@ -51,7 +51,7 @@ class choice_printer;
 template <class T>
 auto operator&(T&& x)
 -> std::enable_if_t<
-     is_printer<std::decay_t<T>>{},
+     is_printer_v<std::decay_t<T>>,
      and_printer<std::decay_t<T>>
    > {
   return and_printer<std::decay_t<T>>{std::forward<T>(x)};
@@ -60,7 +60,7 @@ auto operator&(T&& x)
 template <class T>
 auto operator!(T&& x)
 -> std::enable_if_t<
-     is_printer<std::decay_t<T>>{},
+     is_printer_v<std::decay_t<T>>,
      not_printer<std::decay_t<T>>
    > {
   return not_printer<std::decay_t<T>>{std::forward<T>(x)};
@@ -69,7 +69,7 @@ auto operator!(T&& x)
 template <class T>
 auto operator-(T&& x)
 -> std::enable_if_t<
-     is_printer<std::decay_t<T>>{},
+     is_printer_v<std::decay_t<T>>,
      optional_printer<std::decay_t<T>>
    > {
   return optional_printer<std::decay_t<T>>{std::forward<T>(x)};
@@ -78,7 +78,7 @@ auto operator-(T&& x)
 template <class T>
 auto operator*(T&& x)
 -> std::enable_if_t<
-     is_printer<std::decay_t<T>>{},
+     is_printer_v<std::decay_t<T>>,
      kleene_printer<std::decay_t<T>>
    > {
   return kleene_printer<std::decay_t<T>>{std::forward<T>(x)};
@@ -87,7 +87,7 @@ auto operator*(T&& x)
 template <class T>
 auto operator+(T&& x)
 -> std::enable_if_t<
-     is_printer<std::decay_t<T>>{},
+     is_printer_v<std::decay_t<T>>,
      plus_printer<std::decay_t<T>>
    > {
   return plus_printer<std::decay_t<T>>{std::forward<T>(x)};
@@ -96,7 +96,7 @@ auto operator+(T&& x)
 template <class T>
 auto operator~(T&& x)
 -> std::enable_if_t<
-     is_printer<std::decay_t<T>>{},
+     is_printer_v<std::decay_t<T>>,
      maybe_printer<std::decay_t<T>>
    > {
   return maybe_printer<std::decay_t<T>>{std::forward<T>(x)};

--- a/libvast/vast/concept/printable/core/printer.hpp
+++ b/libvast/vast/concept/printable/core/printer.hpp
@@ -103,12 +103,13 @@ struct has_printer {
 
 /// Checks whether the printer registry has a given type registered.
 template <class T>
-struct has_printer : decltype(detail::has_printer::test<T>(0)) {};
+inline constexpr bool has_printer_v
+  = decltype(detail::has_printer::test<T>(0))::value;
 
 /// Checks whether a given type is-a printer, i.e., derived from
 /// ::vast::printer.
 template <class T>
-using is_printer = std::is_base_of<printer<T>, T>;
+inline constexpr bool is_printer_v = std::is_base_of_v<printer<T>, T>;
 
 } // namespace vast
 

--- a/libvast/vast/concept/printable/core/sequence.hpp
+++ b/libvast/vast/concept/printable/core/sequence.hpp
@@ -32,6 +32,9 @@ struct is_sequence_printer : std::false_type {};
 template <class... Ts>
 struct is_sequence_printer<sequence_printer<Ts...>> : std::true_type {};
 
+template <class T>
+inline constexpr bool is_sequence_printer_v = is_sequence_printer<T>::value;
+
 // TODO: factor helper functions shared among sequence printer and parser.
 
 template <class Lhs, class Rhs>
@@ -77,16 +80,16 @@ public:
 private:
   template <class T>
   static constexpr auto depth_helper()
-  -> std::enable_if_t<!is_sequence_printer<T>::value, size_t> {
+  -> std::enable_if_t<!is_sequence_printer_v<T>, size_t> {
     return 0;
   }
 
   template <class T>
   static constexpr auto depth_helper()
   -> std::enable_if_t<
-       is_sequence_printer<T>::value
-        && (std::is_same<typename T::lhs_attribute, unused_type>::value
-            || std::is_same<typename T::rhs_attribute, unused_type>::value),
+       is_sequence_printer_v<T>
+        && (std::is_same_v<typename T::lhs_attribute, unused_type>
+            || std::is_same_v<typename T::rhs_attribute, unused_type>),
        size_t
      > {
     return depth_helper<typename T::lhs_type>();
@@ -95,9 +98,9 @@ private:
   template <class T>
   static constexpr auto depth_helper()
   -> std::enable_if_t<
-       is_sequence_printer<T>::value
-        && !std::is_same<typename T::lhs_attribute, unused_type>::value
-        && !std::is_same<typename T::rhs_attribute, unused_type>::value,
+       is_sequence_printer_v<T>
+        && !std::is_same_v<typename T::lhs_attribute, unused_type>
+        && !std::is_same_v<typename T::rhs_attribute, unused_type>,
        size_t
      > {
     return 1 + depth_helper<typename T::lhs_type>();
@@ -116,7 +119,7 @@ private:
   template <class L, class T>
   static auto get_helper(const T& x)
   -> std::enable_if_t<
-       ! is_sequence_printer<L>::value,
+       !is_sequence_printer_v<L>,
        decltype(std::get<0>(x))
      > {
     return std::get<0>(x);

--- a/libvast/vast/concept/printable/detail/as_printer.hpp
+++ b/libvast/vast/concept/printable/detail/as_printer.hpp
@@ -41,35 +41,36 @@ inline auto as_printer(std::string str) {
 template <class T>
 auto as_printer(T x)
 -> std::enable_if_t<
-     std::is_arithmetic<T>{} && !std::is_same<T, bool>::value,
+     std::is_arithmetic_v<T> && !std::is_same_v<T, bool>,
      literal_printer
    > {
   return literal_printer{x};
 }
 
 template <class T>
-auto as_printer(T x) -> std::enable_if_t<is_printer<T>{}, T> {
+auto as_printer(T x) -> std::enable_if_t<is_printer_v<T>, T> {
   return x; // A good compiler will elide the copy.
 }
 
 // -- binary ------------------------------------------------------------------
 
 template <class T>
-using is_convertible_to_unary_printer =
-  std::integral_constant<
-    bool,
-    std::is_convertible<T, std::string>{}
-    || (std::is_arithmetic<T>{} && !std::is_same<T, bool>::value)
-  >;
+inline constexpr bool is_convertible_to_unary_printer_v =
+  std::is_convertible_v<T, std::string>
+  || (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>);
 
 template <class T, class U>
 using is_convertible_to_binary_printer =
   std::integral_constant<
     bool,
-    (is_printer<T>{} && is_printer<U>{})
-    || (is_printer<T>{} && is_convertible_to_unary_printer<U>{})
-    || (is_convertible_to_unary_printer<T>{} && is_printer<U>{})
+    (is_printer_v<T> && is_printer_v<U>)
+    || (is_printer_v<T> && is_convertible_to_unary_printer_v<U>)
+    || (is_convertible_to_unary_printer_v<T> && is_printer_v<U>)
   >;
+
+template <class T, class U>
+inline constexpr bool is_convertible_to_binary_printer_v
+  = is_convertible_to_binary_printer<T, U>::value;
 
 template <
   template <class, class> class Binaryprinter,
@@ -78,13 +79,13 @@ template <
 >
 using make_binary_printer =
   std::conditional_t<
-    is_printer<T>{} && is_printer<U>{},
+    is_printer_v<T> && is_printer_v<U>,
     Binaryprinter<T, U>,
     std::conditional_t<
-      is_printer<T>{} && is_convertible_to_unary_printer<U>{},
+      is_printer_v<T> && is_convertible_to_unary_printer_v<U>,
       Binaryprinter<T, decltype(as_printer(std::declval<U>()))>,
       std::conditional_t<
-        is_convertible_to_unary_printer<T>{} && is_printer<U>{},
+        is_convertible_to_unary_printer_v<T> && is_printer_v<U>,
         Binaryprinter<decltype(as_printer(std::declval<T>())), U>,
         std::false_type
       >
@@ -98,7 +99,7 @@ template <
 >
 auto as_printer(T&& x, U&& y)
   -> std::enable_if_t<
-       is_convertible_to_binary_printer<std::decay_t<T>, std::decay_t<U>>{},
+       is_convertible_to_binary_printer_v<std::decay_t<T>, std::decay_t<U>>,
        make_binary_printer<
          Binaryprinter,
          decltype(as_printer(std::forward<T>(x))),

--- a/libvast/vast/concept/printable/numeric/integral.hpp
+++ b/libvast/vast/concept/printable/numeric/integral.hpp
@@ -64,7 +64,7 @@ struct integral_printer : printer<integral_printer<T, Policy, MinDigits>> {
     if (x < 0) {
       *out++ = '-';
       x = -x;
-    } else if (std::is_same<Policy, policy::force_sign>::value) {
+    } else if (std::is_same_v<Policy, policy::force_sign>) {
       *out++ = '+';
     }
     pad(out, x);
@@ -73,7 +73,7 @@ struct integral_printer : printer<integral_printer<T, Policy, MinDigits>> {
 };
 
 template <class T>
-struct printer_registry<T, std::enable_if_t<std::is_integral<T>::value>> {
+struct printer_registry<T, std::enable_if_t<std::is_integral_v<T>>> {
   using type = integral_printer<T>;
 };
 

--- a/libvast/vast/concept/printable/numeric/real.hpp
+++ b/libvast/vast/concept/printable/numeric/real.hpp
@@ -55,7 +55,7 @@ struct real_printer : printer<real_printer<T, MaxDigits>> {
 };
 
 template <class T>
-struct printer_registry<T, std::enable_if_t<std::is_floating_point<T>::value>> {
+struct printer_registry<T, std::enable_if_t<std::is_floating_point_v<T>>> {
   using type = real_printer<T>;
 };
 

--- a/libvast/vast/concept/printable/print.hpp
+++ b/libvast/vast/concept/printable/print.hpp
@@ -22,13 +22,13 @@ namespace vast {
 
 template <class Iterator, class T, class... Args>
 auto print(Iterator&& out, const T& x, Args&&... args)
-  -> std::enable_if_t<has_printer<T>::value, bool> {
+  -> std::enable_if_t<has_printer_v<T>, bool> {
   return make_printer<T>{std::forward<Args>(args)...}.print(out, x);
 }
 
 template <class Iterator, class T, class... Args>
 auto print(Iterator&& out, const T& x, Args&&... args)
-  -> std::enable_if_t<!has_printer<T>::value && has_access_printer<T>::value,
+  -> std::enable_if_t<!has_printer_v<T> && has_access_printer_v<T>,
                       bool> {
   return access::printer<T>{std::forward<Args>(args)...}.print(out, x);
 }
@@ -70,7 +70,8 @@ struct is_printable {
 } // namespace detail
 
 template <class I, class T>
-struct is_printable : decltype(detail::is_printable::test<I, T>(0, 0)) {};
+inline constexpr bool is_printable_v
+  = decltype(detail::is_printable::test<I, T>(0, 0))::value;
 
 } // namespace vast
 

--- a/libvast/vast/concept/printable/std/chrono.hpp
+++ b/libvast/vast/concept/printable/std/chrono.hpp
@@ -58,7 +58,7 @@ struct duration_printer : printer<duration_printer<Rep, Period, Policy>> {
 
   template <class Iterator, class P = Policy>
   auto print(Iterator& out, std::chrono::duration<Rep, Period> d) const
-  -> std::enable_if_t<std::is_same<P, policy::adaptive>::value, bool> {
+  -> std::enable_if_t<std::is_same_v<P, policy::adaptive>, bool> {
     using namespace std::chrono;
     using namespace date;
     auto num = printers::real2;
@@ -79,7 +79,7 @@ struct duration_printer : printer<duration_printer<Rep, Period, Policy>> {
 
   template <class Iterator, class P = Policy>
   auto print(Iterator& out, std::chrono::duration<Rep, Period> d) const
-  -> std::enable_if_t<std::is_same<P, policy::fixed>::value, bool> {
+  -> std::enable_if_t<std::is_same_v<P, policy::fixed>, bool> {
     return (make_printer<Rep>{} << units(d))(out, d.count());
   }
 };

--- a/libvast/vast/concept/printable/stream.hpp
+++ b/libvast/vast/concept/printable/stream.hpp
@@ -23,7 +23,7 @@ namespace vast {
 template <class Char, class Traits, class T>
 auto operator<<(std::basic_ostream<Char, Traits>& out, const T& x)
   -> std::enable_if_t<
-       is_printable<std::ostreambuf_iterator<Char>, T>::value, decltype(out)
+       is_printable_v<std::ostreambuf_iterator<Char>, T>, decltype(out)
      > {
   using vast::print; // enable ADL
   if (!print(std::ostreambuf_iterator<Char>{out}, x))

--- a/libvast/vast/concept/printable/to.hpp
+++ b/libvast/vast/concept/printable/to.hpp
@@ -25,7 +25,7 @@ namespace vast {
 template <class To, class From, class... Opts>
 auto to(From&& from, Opts&&... opts)
 -> std::enable_if_t<
-     std::is_same<std::string, To>{} && has_printer<std::decay_t<From>>{},
+     std::is_same<std::string, To>{} && has_printer_v<std::decay_t<From>>,
      expected<std::string>
    > {
   std::string str;

--- a/libvast/vast/concept/printable/to_string.hpp
+++ b/libvast/vast/concept/printable/to_string.hpp
@@ -23,9 +23,9 @@ namespace vast {
 template <class From, class... Opts>
 auto to_string(From&& from, Opts&&... opts)
   -> std::enable_if_t<
-       is_printable<
+       is_printable_v<
           std::back_insert_iterator<std::string>, std::decay_t<From>
-        >{},
+        >,
        std::string
      > {
   std::string str;

--- a/libvast/vast/concept/printable/vast/bitmap.hpp
+++ b/libvast/vast/concept/printable/vast/bitmap.hpp
@@ -33,7 +33,7 @@ struct bitmap_printer : printer<bitmap_printer<Bitmap, Policy>> {
 template <class Bitmap>
 struct printer_registry<
   Bitmap,
-  std::enable_if_t<std::is_base_of<bitmap_base<Bitmap>, Bitmap>::value>
+  std::enable_if_t<std::is_base_of_v<bitmap_base<Bitmap>, Bitmap>>
 > {
   using type = bitmap_printer<Bitmap, policy::expanded>;
 };

--- a/libvast/vast/concept/printable/vast/bits.hpp
+++ b/libvast/vast/concept/printable/vast/bits.hpp
@@ -33,7 +33,7 @@ struct bits_printer : printer<bits_printer<T , Policy>> {
 
   template <class Iterator, class P = Policy>
   auto print(Iterator& out, const bits<T>& b) const
-  -> std::enable_if_t<std::is_same<P, policy::rle>::value, bool> {
+  -> std::enable_if_t<std::is_same_v<P, policy::rle>, bool> {
     auto print_run = [&](auto bit, auto length) {
       using size_type = typename word_type::size_type;
       return printers::integral<size_type>(out, length) &&
@@ -64,7 +64,7 @@ struct bits_printer : printer<bits_printer<T , Policy>> {
 
   template <class Iterator, class P = Policy>
   auto print(Iterator& out, const bits<T>& b) const
-  -> std::enable_if_t<std::is_same<P, policy::expanded>::value, bool> {
+  -> std::enable_if_t<std::is_same_v<P, policy::expanded>, bool> {
     if (b.size() > word_type::width) {
       auto c = b.data() ? '1' : '0';
       for (auto i = 0u; i < b.size(); ++i)

--- a/libvast/vast/concept/printable/vast/bitvector.hpp
+++ b/libvast/vast/concept/printable/vast/bitvector.hpp
@@ -32,7 +32,7 @@ struct bitvector_printer : printer<bitvector_printer<Bitvector, Order>> {
   using attribute = Bitvector;
 
   static constexpr bool msb_to_lsb =
-    std::is_same<Order, policy::msb_to_lsb>::value;
+    std::is_same_v<Order, policy::msb_to_lsb>;
 
   template <class Iterator>
   bool print(Iterator& out, const Bitvector& bv) const {

--- a/libvast/vast/concept/printable/vast/coder.hpp
+++ b/libvast/vast/concept/printable/vast/coder.hpp
@@ -41,7 +41,7 @@ template <class Coder>
 struct printer_registry<
   Coder,
   std::enable_if_t<
-    std::is_base_of<vector_coder<typename Coder::bitmap_type>, Coder>::value
+    std::is_base_of_v<vector_coder<typename Coder::bitmap_type>, Coder>
   >
 > {
   using type = vector_coder_printer<

--- a/libvast/vast/concept/printable/vast/expression.hpp
+++ b/libvast/vast/concept/printable/vast/expression.hpp
@@ -87,13 +87,13 @@ struct expression_printer : printer<expression_printer> {
   template <class Iterator, class T>
   auto print(Iterator& out, const T& x) const
     -> std::enable_if_t<
-         std::is_same<T, attribute_extractor>::value
-         || std::is_same<T, key_extractor>::value
-         || std::is_same<T, data_extractor>::value
-         || std::is_same<T, predicate>::value
-         || std::is_same<T, conjunction>::value
-         || std::is_same<T, disjunction>::value
-         || std::is_same<T, negation>::value,
+         std::is_same_v<T, attribute_extractor>
+         || std::is_same_v<T, key_extractor>
+         || std::is_same_v<T, data_extractor>
+         || std::is_same_v<T, predicate>
+         || std::is_same_v<T, conjunction>
+         || std::is_same_v<T, disjunction>
+         || std::is_same_v<T, negation>,
          bool
        >
   {
@@ -111,14 +111,14 @@ template <class T>
 struct printer_registry<
   T,
   std::enable_if_t<
-    std::is_same<T, attribute_extractor>::value
-    || std::is_same<T, key_extractor>::value
-    || std::is_same<T, data_extractor>::value
-    || std::is_same<T, predicate>::value
-    || std::is_same<T, conjunction>::value
-    || std::is_same<T, disjunction>::value
-    || std::is_same<T, negation>::value
-    || std::is_same<T, expression>::value
+    std::is_same_v<T, attribute_extractor>
+    || std::is_same_v<T, key_extractor>
+    || std::is_same_v<T, data_extractor>
+    || std::is_same_v<T, predicate>
+    || std::is_same_v<T, conjunction>
+    || std::is_same_v<T, disjunction>
+    || std::is_same_v<T, negation>
+    || std::is_same_v<T, expression>
   >
 >
 {

--- a/libvast/vast/concept/printable/vast/json.hpp
+++ b/libvast/vast/concept/printable/vast/json.hpp
@@ -57,7 +57,7 @@ template <class TreePolicy, int Indent = 2, int Padding = 0>
 struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
   using attribute = json;
 
-  static constexpr bool tree = std::is_same<TreePolicy, policy::tree>::value;
+  static constexpr bool tree = std::is_same_v<TreePolicy, policy::tree>;
 
   static_assert(Padding >= 0, "padding must not be negative");
 
@@ -184,7 +184,7 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
   template <class Iterator, class T>
   auto print(Iterator& out, const T& x) const
   -> std::enable_if_t<
-    !std::is_same<json::jsonize<T>, std::false_type>::value,
+    !std::is_same_v<json::jsonize<T>, std::false_type>,
     bool
   > {
     return print_visitor<Iterator>{out}(x);

--- a/libvast/vast/concept/support/detail/action_traits.hpp
+++ b/libvast/vast/concept/support/detail/action_traits.hpp
@@ -31,7 +31,7 @@ struct action_traits {
   using result_type = typename traits::result_type;
 
   static constexpr auto arity = traits::num_args;
-  static constexpr bool returns_void = std::is_void<result_type>::value;
+  static constexpr bool returns_void = std::is_void_v<result_type>;
   static constexpr bool no_args_returns_void = arity == 0 && returns_void;
   static constexpr bool one_arg_returns_void = arity == 1 && returns_void;
   static constexpr bool no_args_returns_non_void = arity == 0 && !returns_void;

--- a/libvast/vast/concept/support/detail/guard_traits.hpp
+++ b/libvast/vast/concept/support/detail/guard_traits.hpp
@@ -25,7 +25,7 @@ struct guard_traits {
   using result_type = typename traits::result_type;
 
   static constexpr auto arity = traits::num_args;
-  static constexpr bool returns_bool = std::is_same<result_type, bool>::value;
+  static constexpr bool returns_bool = std::is_same_v<result_type, bool>;
   static constexpr bool no_args_returns_bool = arity == 0 && returns_bool;
   static constexpr bool one_arg_returns_bool = arity == 1 && returns_bool;
 };

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -48,32 +48,32 @@ namespace detail {
 
 template <class T>
 using make_data_type = std::conditional_t<
-    std::is_floating_point<T>::value,
+    std::is_floating_point_v<T>,
     real,
     std::conditional_t<
-      std::is_same<T, boolean>::value,
+      std::is_same_v<T, boolean>,
       boolean,
       std::conditional_t<
-        std::is_unsigned<T>::value,
+        std::is_unsigned_v<T>,
         count,
         std::conditional_t<
-          std::is_signed<T>::value,
+          std::is_signed_v<T>,
           integer,
           std::conditional_t<
-            std::is_convertible<T, std::string>::value,
+            std::is_convertible_v<T, std::string>,
             std::string,
             std::conditional_t<
-                 std::is_same<T, none>::value
-              || std::is_same<T, timespan>::value
-              || std::is_same<T, timestamp>::value
-              || std::is_same<T, pattern>::value
-              || std::is_same<T, address>::value
-              || std::is_same<T, subnet>::value
-              || std::is_same<T, port>::value
-              || std::is_same<T, enumeration>::value
-              || std::is_same<T, vector>::value
-              || std::is_same<T, set>::value
-              || std::is_same<T, table>::value,
+                 std::is_same_v<T, none>
+              || std::is_same_v<T, timespan>
+              || std::is_same_v<T, timestamp>
+              || std::is_same_v<T, pattern>
+              || std::is_same_v<T, address>
+              || std::is_same_v<T, subnet>
+              || std::is_same_v<T, port>
+              || std::is_same_v<T, enumeration>
+              || std::is_same_v<T, vector>
+              || std::is_same_v<T, set>
+              || std::is_same_v<T, table>,
               T,
               std::false_type
             >
@@ -134,8 +134,8 @@ public:
   template <
     class T,
     class = detail::disable_if_t<
-      detail::is_same_or_derived<data, T>::value
-      || std::is_same<data_type<T>, std::false_type>::value
+      detail::is_same_or_derived_v<data, T>
+      || std::is_same_v<data_type<T>, std::false_type>
     >
   >
   data(T&& x)

--- a/libvast/vast/detail/cache.hpp
+++ b/libvast/vast/detail/cache.hpp
@@ -165,7 +165,7 @@ public:
   template <class T>
   auto insert(T&& x)
   -> std::enable_if_t<
-    std::is_same<std::decay_t<T>, value_type>::value,
+    std::is_same_v<std::decay_t<T>, value_type>,
     std::pair<iterator, bool>
   > {
     auto i = tracker_.find(x.first);

--- a/libvast/vast/detail/coded_deserializer.hpp
+++ b/libvast/vast/detail/coded_deserializer.hpp
@@ -39,7 +39,7 @@ public:
 protected:
   template <class T>
   error zig_zag_varbyte_decode(T& x) {
-    static_assert(std::is_signed<T>::value, "T must be an signed type");
+    static_assert(std::is_signed_v<T>, "T must be an signed type");
     auto u = std::make_unsigned_t<T>{0};
     if (auto e = this->varbyte_decode(u))
       return e;

--- a/libvast/vast/detail/coded_serializer.hpp
+++ b/libvast/vast/detail/coded_serializer.hpp
@@ -39,7 +39,7 @@ public:
 protected:
   template <class T>
   error zig_zag_varbyte_encode(T x) {
-    static_assert(std::is_signed<T>::value, "T must be an signed type");
+    static_assert(std::is_signed_v<T>, "T must be an signed type");
     return this->varbyte_encode(zigzag::encode(x));
   }
 

--- a/libvast/vast/detail/coding.hpp
+++ b/libvast/vast/detail/coding.hpp
@@ -24,7 +24,7 @@ namespace vast::detail {
 /// @relates byte_to_hex hex_to_byte
 template <
   class T,
-  class = std::enable_if_t<std::is_integral<T>::value>
+  class = std::enable_if_t<std::is_integral_v<T>>
 >
 char byte_to_char(T b) {
   return b < 10 ? '0' + b : 'a' + b - 10;
@@ -36,7 +36,7 @@ char byte_to_char(T b) {
 /// @relates byte_to_char hex_to_byte
 template <
   class T,
-  class = std::enable_if_t<std::is_integral<T>::value>
+  class = std::enable_if_t<std::is_integral_v<T>>
 >
 std::pair<char, char> byte_to_hex(T b) {
   static constexpr char hex[] = "0123456789ABCDEF";
@@ -49,7 +49,7 @@ std::pair<char, char> byte_to_hex(T b) {
 /// @relates byte_to_hex byte_to_char
 template <
   class T,
-  class = std::enable_if_t<std::is_integral<T>::value>
+  class = std::enable_if_t<std::is_integral_v<T>>
 >
 char hex_to_byte(T hex) {
   if (hex >= '0' && hex <= '9')
@@ -67,7 +67,7 @@ char hex_to_byte(T hex) {
 /// @relates byte_to_hex byte_to_char
 template <
   class T,
-  class = std::enable_if_t<std::is_integral<T>::value>
+  class = std::enable_if_t<std::is_integral_v<T>>
 >
 char hex_to_byte(T hi, T lo) {
   auto byte = hex_to_byte(hi) << 4;

--- a/libvast/vast/detail/iterator.hpp
+++ b/libvast/vast/detail/iterator.hpp
@@ -123,7 +123,7 @@ public:
       reference,
       std::add_pointer_t<
         std::conditional_t<
-          std::is_const<Value>::value,
+          std::is_const_v<Value>,
           value_type const,
           value_type
         >
@@ -143,10 +143,8 @@ public:
 
   using postfix_increment_result =
     std::conditional_t<
-      std::is_convertible<
-        reference,
-        std::add_lvalue_reference_t<Value const>
-      >::value,
+      std::is_convertible_v<reference,
+                            std::add_lvalue_reference_t<Value const>>,
       postfix_increment_proxy,
       Derived
     >;

--- a/libvast/vast/detail/range_map.hpp
+++ b/libvast/vast/detail/range_map.hpp
@@ -25,7 +25,7 @@ namespace vast::detail {
 /// values.
 template <class Point, class Value>
 class range_map {
-  static_assert(std::is_arithmetic<Point>::value,
+  static_assert(std::is_arithmetic_v<Point>,
                 "Point must be an arithmetic type");
 
   using map_type = std::map<Point, std::pair<Point, Value>>;

--- a/libvast/vast/detail/stack_vector.hpp
+++ b/libvast/vast/detail/stack_vector.hpp
@@ -67,7 +67,7 @@ struct stack_vector : private stack_container<T, N>, short_vector<T, N> {
   }
 
   stack_vector(stack_vector&& other)
-  noexcept(std::is_nothrow_move_constructible<vector_type>::value)
+  noexcept(std::is_nothrow_move_constructible_v<vector_type>)
     : vector_type(std::move(other), this->arena_) {
   }
 
@@ -77,7 +77,7 @@ struct stack_vector : private stack_container<T, N>, short_vector<T, N> {
   }
 
   stack_vector& operator=(stack_vector&& other)
-  noexcept(std::is_nothrow_move_assignable<vector_type>::value) {
+  noexcept(std::is_nothrow_move_assignable_v<vector_type>) {
     static_cast<vector_type&>(*this) = std::move(other);
     return *this;
   }

--- a/libvast/vast/detail/string.hpp
+++ b/libvast/vast/detail/string.hpp
@@ -544,7 +544,7 @@ private:
 
 template <class Key, class Value>
 class array_skip_table {
-  static_assert(std::is_integral<Key>::value,
+  static_assert(std::is_integral_v<Key>,
                 "array skip table key must be integral");
 
   static_assert(sizeof(Key) == 1, "array skip table key must occupy one byte");
@@ -656,7 +656,7 @@ private:
 
   using skip_table =
     std::conditional_t<
-      std::is_integral<pat_char_type>::value && sizeof(pat_char_type) == 1,
+      std::is_integral_v<pat_char_type> && sizeof(pat_char_type) == 1,
       array_skip_table<pat_char_type, pat_difference_type>,
       unordered_skip_table<pat_char_type, pat_difference_type>
     >;

--- a/libvast/vast/detail/zigzag.hpp
+++ b/libvast/vast/detail/zigzag.hpp
@@ -33,7 +33,7 @@ namespace vast::detail::zigzag {
 template <class T>
 auto encode(T x)
 -> std::enable_if_t<
-  std::is_integral<T>::value && std::is_signed<T>{},
+  std::is_integral_v<T> && std::is_signed_v<T>,
   std::make_unsigned_t<T>
 > {
   static constexpr auto width = std::numeric_limits<T>::digits;
@@ -46,7 +46,7 @@ auto encode(T x)
 template <class T>
 auto decode(T x)
 -> std::enable_if_t<
-  std::is_integral<T>::value && std::is_unsigned<T>{},
+  std::is_integral_v<T> && std::is_unsigned_v<T>,
   std::make_signed_t<T>
 > {
   return (x >> 1) ^ -static_cast<std::make_signed_t<T>>(x & 1);

--- a/libvast/vast/format/csv.hpp
+++ b/libvast/vast/format/csv.hpp
@@ -45,7 +45,7 @@ struct value_printer : printer<value_printer> {
 
     template <class T, class U>
     auto operator()(const T&, const U& x)
-    -> std::enable_if_t<!std::is_same<U, none>::value, bool> {
+    -> std::enable_if_t<!std::is_same_v<U, none>, bool> {
       return make_printer<U>{}.print(out_, x);
     }
 

--- a/libvast/vast/json.hpp
+++ b/libvast/vast/json.hpp
@@ -49,22 +49,22 @@ public:
   /// If conversion is impossible it returns `std::false_type`.
   template <class T>
   using json_value = std::conditional_t<
-    std::is_same<T, none>::value,
+    std::is_same_v<T, none>,
     null,
     std::conditional_t<
-      std::is_same<T, bool>::value,
+      std::is_same_v<T, bool>,
       boolean,
       std::conditional_t<
-        std::is_convertible<T, number>::value,
+        std::is_convertible_v<T, number>,
         number,
         std::conditional_t<
-          std::is_convertible<T, std::string>::value,
+          std::is_convertible_v<T, std::string>,
           string,
           std::conditional_t<
-            std::is_same<T, array>::value,
+            std::is_same_v<T, array>,
             array,
             std::conditional_t<
-              std::is_same<T, object>::value,
+              std::is_same_v<T, object>,
               object,
               std::false_type
             >
@@ -115,7 +115,7 @@ public:
   template <
     class T,
     class =
-      std::enable_if_t<!std::is_same<std::false_type, jsonize<T>>::value>
+      std::enable_if_t<!std::is_same_v<std::false_type, jsonize<T>>>
   >
   json(T&& x)
     : value_(jsonize<T>(std::forward<T>(x))) {
@@ -181,7 +181,7 @@ inline bool convert(bool b, json& j) {
 
 template <class T>
 bool convert(T x, json& j) {
-  if constexpr (std::is_arithmetic<T>::value) {
+  if constexpr (std::is_arithmetic_v<T>) {
     j = json::number(x);
     return true;
   } else if constexpr (std::is_convertible_v<T, std::string>) {

--- a/libvast/vast/load.hpp
+++ b/libvast/vast/load.hpp
@@ -37,7 +37,7 @@ template <compression Method = compression::null, class Source, class... Ts>
 expected<void> load(Source&& in, Ts&&... xs) {
   static_assert(sizeof...(Ts) > 0);
   using source_type = std::decay_t<Source>;
-  if constexpr (detail::is_streambuf<source_type>::value) {
+  if constexpr (detail::is_streambuf_v<source_type>) {
     try {
       if (Method == compression::null) {
         caf::stream_deserializer<source_type&> s{in};

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -40,13 +40,17 @@ struct formatter {
     static constexpr auto value = type::value;
   };
 
+  template <class Stream, class T>
+  static inline constexpr bool is_streamable_v
+    = is_streamable<Stream, T>::value;
+
   template <class T>
   formatter& operator<<(const T& x) {
-    if constexpr (is_streamable<std::ostringstream, T>::value) {
+    if constexpr (is_streamable_v<std::ostringstream, T>) {
       message << x;
       return *this;
-    } else if constexpr (vast::is_printable<std::ostreambuf_iterator<char>,
-                                            T>::value) {
+    } else if constexpr (vast::is_printable_v<std::ostreambuf_iterator<char>,
+                                              T>) {
       using vast::print;
       if (!print(std::ostreambuf_iterator<char>{message}, x))
         message.setstate(std::ios_base::failbit);

--- a/libvast/vast/save.hpp
+++ b/libvast/vast/save.hpp
@@ -36,7 +36,7 @@ template <compression Method = compression::null, class Sink, class... Ts>
 expected<void> save(Sink&& out, Ts&&... xs) {
   static_assert(sizeof...(Ts) > 0);
   using sink_type = std::decay_t<Sink>;
-  if constexpr (detail::is_streambuf<sink_type>::value) {
+  if constexpr (detail::is_streambuf_v<sink_type>) {
     try {
       if (Method == compression::null) {
         caf::stream_serializer<sink_type&> s{out};

--- a/libvast/vast/system/writer_command.hpp
+++ b/libvast/vast/system/writer_command.hpp
@@ -51,7 +51,7 @@ protected:
     CAF_LOG_TRACE(CAF_ARG(args));
     using ostream_ptr = std::unique_ptr<std::ostream>;
     auto limit = this->get_or<uint64_t>(options, "events", 0u);
-    if constexpr (std::is_constructible<Writer, ostream_ptr>::value) {
+    if constexpr (std::is_constructible_v<Writer, ostream_ptr>) {
       auto out = detail::make_output_stream(output_, uds_);
       if (!out)
         return out.error();

--- a/libvast/vast/value.hpp
+++ b/libvast/vast/value.hpp
@@ -45,8 +45,8 @@ public:
   template <
     class T,
     class = detail::disable_if_t<
-      detail::is_same_or_derived<value, T>::value
-      || std::is_same<data_type<T>, std::false_type>::value
+      detail::is_same_or_derived_v<value, T>
+      || std::is_same_v<data_type<T>, std::false_type>
     >
   >
   value(T&& x)

--- a/libvast/vast/variant.hpp
+++ b/libvast/vast/variant.hpp
@@ -126,7 +126,7 @@ public:
   }
 
   /// Default-construct a variant with the first type.
-  variant() noexcept(std::is_nothrow_default_constructible<first_type>::value) {
+  variant() noexcept(std::is_nothrow_default_constructible_v<first_type>) {
     construct(first_type{});
     index_ = 0;
   }
@@ -325,7 +325,7 @@ private:
   template <class T, class Storage>
   using const_type =
     typename std::conditional<
-      std::is_const<std::remove_reference_t<Storage>>::value, T const, T
+      std::is_const_v<std::remove_reference_t<Storage>>, T const, T
     >::type;
 
   template <class T, class Storage, class Visitor, class... Args>

--- a/libvast/vast/word.hpp
+++ b/libvast/vast/word.hpp
@@ -23,9 +23,8 @@
 namespace vast::detail {
 
 template <class T>
-using is_unsigned_integral = bool_constant<
-  std::is_unsigned<T>::value && std::is_integral<T>::value
->;
+inline constexpr bool is_unsigned_integral_v
+  = std::is_unsigned_v<T> && std::is_integral_v<T>;
 
 // Type alias used for SFINAE of free functions below. If we would simply use
 // typename word<T>::size_type, the static_assert would fire. With this work
@@ -33,7 +32,7 @@ using is_unsigned_integral = bool_constant<
 // proceed.
 template <class T>
 using word_size_type = std::conditional_t<
-  is_unsigned_integral<T>::value,
+  is_unsigned_integral_v<T>,
   uint64_t,
   void
 >;
@@ -46,7 +45,7 @@ namespace vast {
 /// operations.
 template <class T>
 struct word {
-  static_assert(detail::is_unsigned_integral<T>::value,
+  static_assert(detail::is_unsigned_integral_v<T>,
                 "bitwise operations require unsigned integral, types");
 
   // -- general ---------------------------------------------------------------
@@ -305,7 +304,7 @@ constexpr typename word<T>::value_type word<T>::lsb1;
 template <bool Bit = true, class T>
 static constexpr auto rank(T x)
 -> std::enable_if_t<
-  detail::is_unsigned_integral<T>::value,
+  detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
 > {
   if constexpr (Bit)
@@ -323,7 +322,7 @@ static constexpr auto rank(T x)
 template <bool Bit = true, class T>
 static constexpr auto rank(T x, detail::word_size_type<T> i)
 -> std::enable_if_t<
-  Bit && detail::is_unsigned_integral<T>::value,
+  Bit && detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
 > {
   T masked = x & word<T>::lsb_fill(i + 1);
@@ -333,7 +332,7 @@ static constexpr auto rank(T x, detail::word_size_type<T> i)
 template <bool Bit, class T>
 static constexpr auto rank(T x, detail::word_size_type<T> i)
 -> std::enable_if_t<
-  !Bit && detail::is_unsigned_integral<T>::value,
+  !Bit && detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
 > {
   return rank<1>(static_cast<T>(~x), i);
@@ -347,7 +346,7 @@ static constexpr auto rank(T x, detail::word_size_type<T> i)
 template <bool Bit = true, class T>
 static constexpr auto find_first(T x)
 -> std::enable_if_t<
-  Bit && detail::is_unsigned_integral<T>::value,
+  Bit && detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
 > {
   auto tzs = word<T>::count_trailing_zeros(x);
@@ -357,7 +356,7 @@ static constexpr auto find_first(T x)
 template <bool Bit, class T>
 static constexpr auto find_first(T x)
 -> std::enable_if_t<
-  !Bit && detail::is_unsigned_integral<T>::value,
+  !Bit && detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
 > {
   return find_first<1>(static_cast<T>(~x));
@@ -366,7 +365,7 @@ static constexpr auto find_first(T x)
 template <bool Bit = true, class T>
 static constexpr auto find_last(T x)
 -> std::enable_if_t<
-  Bit && detail::is_unsigned_integral<T>::value,
+  Bit && detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
 > {
   auto lzs = word<T>::count_leading_zeros(x);
@@ -376,7 +375,7 @@ static constexpr auto find_last(T x)
 template <bool Bit, class T>
 static constexpr auto find_last(T x)
 -> std::enable_if_t<
-  !Bit && detail::is_unsigned_integral<T>::value,
+  !Bit && detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
 > {
   return find_last<1>(static_cast<T>(~x));
@@ -388,7 +387,7 @@ static constexpr auto find_last(T x)
 template <class T>
 static constexpr auto find_next(T x, detail::word_size_type<T> i)
 -> std::enable_if_t<
-  detail::is_unsigned_integral<T>::value,
+  detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
   > {
   if (i == word<T>::width - 1)
@@ -404,7 +403,7 @@ static constexpr auto find_next(T x, detail::word_size_type<T> i)
 template <class T>
 static constexpr auto find_prev(T x, detail::word_size_type<T> i)
 -> std::enable_if_t<
-  detail::is_unsigned_integral<T>::value,
+  detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
 > {
   if (i == 0)
@@ -423,7 +422,7 @@ static constexpr auto find_prev(T x, detail::word_size_type<T> i)
 template <bool Bit = true, class T>
 static constexpr auto select(T x, detail::word_size_type<T> i)
 -> std::enable_if_t<
-  Bit && detail::is_unsigned_integral<T>::value,
+  Bit && detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
 > {
   // TODO: make this efficient and branch-free. There is one implementation
@@ -440,7 +439,7 @@ static constexpr auto select(T x, detail::word_size_type<T> i)
 template <bool Bit, class T>
 static constexpr auto select(T x, detail::word_size_type<T> i)
 -> std::enable_if_t<
-  !Bit && detail::is_unsigned_integral<T>::value,
+  !Bit && detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
 > {
   // TODO: see note above.


### PR DESCRIPTION
Switch to C++17-style `_v` notation for VAST's own type traits and uses the new STL goodness.

We could also think about adding `_v` `constexpr` variables for all atoms to get even more consistency. However, we can't get rid of all `::value` uses since CAF is still at C++11.