### PR TITLE
Replace caf::message in command by a range over args of strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build*/
 Makefile
 vast.ini
+compile_commands.json

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,1 @@
+./build/compile_commands.json

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,1 +1,0 @@
-./build/compile_commands.json

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -36,9 +36,8 @@ int command::run(caf::actor_system& sys, option_map& options,
   CAF_LOG_TRACE(CAF_ARG(options));
   // Split the arguments.
   auto args = caf::message_builder{args_begin, args_end}.move_to_message();
-  auto [local_args, subcmd, subcmd_args, consumed_args] = separate_args(args);
-  // Note: ???????Consumed arguments 
-  args_begin += consumed_args;
+  auto [local_args, subcmd, subcmd_args] = separate_args(args);
+  args_begin += local_args.size();
   // Parse arguments for this command.
   auto res = local_args.extract_opts(opts_);
   if (res.opts.count("help") != 0) {
@@ -130,7 +129,7 @@ int command::run_impl(caf::actor_system&, option_map& options,
   return EXIT_FAILURE;
 }
 
-std::tuple<caf::message, std::string, caf::message, size_t>
+std::tuple<caf::message, std::string, caf::message>
 command::separate_args(const caf::message& args) {
   auto arg = [&](size_t i) -> const std::string& {
     VAST_ASSERT(args.match_element<std::string>(i));
@@ -148,11 +147,10 @@ command::separate_args(const caf::message& args) {
       pos += 2;
     } else {
       // Found the end of the options list.
-      return std::make_tuple(args.take(pos), arg(pos), args.drop(pos+ 1),
-                             pos);
+      return std::make_tuple(args.take(pos), arg(pos), args.drop(pos+ 1));
     }
   }
-  return std::make_tuple(args, "", caf::none, args.size());
+  return std::make_tuple(args, "", caf::none);
 }
 
 } // namespace vast

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -85,11 +85,10 @@ application::root_command::root_command()
 
 command::proceed_result
 application::root_command::proceed(caf::actor_system& sys, option_map& options,
-                                   caf::message args) {
-  CAF_LOG_TRACE(CAF_ARG(options) << CAF_ARG(args));
+                                   const_iterator, const_iterator) {
+  CAF_LOG_TRACE(CAF_ARG(options));
   CAF_IGNORE_UNUSED(sys);
   CAF_IGNORE_UNUSED(options);
-  CAF_IGNORE_UNUSED(args);
   if (print_version) {
     std::cout << VAST_VERSION << std::endl;
     return stop_successful;
@@ -105,9 +104,10 @@ application::application() {
   detail::adjust_resource_consumption();
 }
 
-int application::run(caf::actor_system& sys, message args) {
+int application::run(caf::actor_system& sys, command::const_iterator args_begin,
+                     command::const_iterator args_end) {
   CAF_LOG_TRACE(CAF_ARG(args));
-  return root_.run(sys, std::move(args));
+  return root_.run(sys, args_begin, args_end);
 }
 
 //  // TODO: replace this manual parsing by a proper interface in the program

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -85,7 +85,7 @@ application::root_command::root_command()
 
 command::proceed_result
 application::root_command::proceed(caf::actor_system& sys, option_map& options,
-                                   const_iterator, const_iterator) {
+                                   argument_iterator, argument_iterator) {
   CAF_LOG_TRACE(CAF_ARG(options));
   CAF_IGNORE_UNUSED(sys);
   CAF_IGNORE_UNUSED(options);
@@ -104,10 +104,10 @@ application::application() {
   detail::adjust_resource_consumption();
 }
 
-int application::run(caf::actor_system& sys, command::const_iterator args_begin,
-                     command::const_iterator args_end) {
+int application::run(caf::actor_system& sys, command::argument_iterator begin,
+                     command::argument_iterator end) {
   CAF_LOG_TRACE(CAF_ARG(args));
-  return root_.run(sys, args_begin, args_end);
+  return root_.run(sys, begin, end);
 }
 
 //  // TODO: replace this manual parsing by a proper interface in the program

--- a/libvast/src/system/export_command.cpp
+++ b/libvast/src/system/export_command.cpp
@@ -43,8 +43,8 @@ export_command::export_command(command* parent, std::string_view name)
   add_opt("events,e", "maximum number of results", max_events_);
 }
 
-int export_command::run_impl(actor_system&, option_map&, const_iterator,
-                             const_iterator) {
+int export_command::run_impl(actor_system&, option_map&, argument_iterator,
+                             argument_iterator) {
   VAST_ERROR("export_command::run_impl called");
   return EXIT_FAILURE;
 }

--- a/libvast/src/system/export_command.cpp
+++ b/libvast/src/system/export_command.cpp
@@ -43,7 +43,8 @@ export_command::export_command(command* parent, std::string_view name)
   add_opt("events,e", "maximum number of results", max_events_);
 }
 
-int export_command::run_impl(actor_system&, option_map&, caf::message) {
+int export_command::run_impl(actor_system&, option_map&, const_iterator,
+                             const_iterator) {
   VAST_ERROR("export_command::run_impl called");
   return EXIT_FAILURE;
 }

--- a/libvast/src/system/import_command.cpp
+++ b/libvast/src/system/import_command.cpp
@@ -36,8 +36,8 @@ import_command::import_command(command* parent, std::string_view name)
   // nop
 }
 
-int import_command::run_impl(actor_system&, option_map&, const_iterator,
-                             const_iterator) {
+int import_command::run_impl(actor_system&, option_map&, argument_iterator,
+                             argument_iterator) {
   VAST_ERROR("import_command::run_impl called");
   return EXIT_FAILURE;
 }

--- a/libvast/src/system/import_command.cpp
+++ b/libvast/src/system/import_command.cpp
@@ -36,7 +36,8 @@ import_command::import_command(command* parent, std::string_view name)
   // nop
 }
 
-int import_command::run_impl(actor_system&, option_map&, caf::message) {
+int import_command::run_impl(actor_system&, option_map&, const_iterator,
+                             const_iterator) {
   VAST_ERROR("import_command::run_impl called");
   return EXIT_FAILURE;
 }

--- a/libvast/src/system/pcap_reader_command.cpp
+++ b/libvast/src/system/pcap_reader_command.cpp
@@ -62,8 +62,8 @@ pcap_reader_command::pcap_reader_command(command* parent, std::string_view name)
 }
 
 expected<caf::actor> pcap_reader_command::make_source(caf::scoped_actor& self,
-                                                      const_iterator,
-                                                      const_iterator) {
+                                                      argument_iterator,
+                                                      argument_iterator) {
   CAF_LOG_TRACE();
   format::pcap::reader reader{input,    cutoff,      flow_max,
                               flow_age, flow_expiry, pseudo_realtime};

--- a/libvast/src/system/pcap_reader_command.cpp
+++ b/libvast/src/system/pcap_reader_command.cpp
@@ -62,9 +62,9 @@ pcap_reader_command::pcap_reader_command(command* parent, std::string_view name)
 }
 
 expected<caf::actor> pcap_reader_command::make_source(caf::scoped_actor& self,
-                                                  caf::message args) {
-  CAF_IGNORE_UNUSED(args);
-  CAF_LOG_TRACE(CAF_ARG(args));
+                                                      const_iterator,
+                                                      const_iterator) {
+  CAF_LOG_TRACE();
   format::pcap::reader reader{input,    cutoff,      flow_max,
                               flow_age, flow_expiry, pseudo_realtime};
   return self->spawn(source<format::pcap::reader>, std::move(reader));

--- a/libvast/src/system/pcap_writer_command.cpp
+++ b/libvast/src/system/pcap_writer_command.cpp
@@ -42,9 +42,9 @@ pcap_writer_command::pcap_writer_command(command* parent, std::string_view name)
 
 expected<caf::actor> pcap_writer_command::make_sink(caf::scoped_actor& self,
                                                     option_map& options,
-                                                    caf::message args) {
-  CAF_IGNORE_UNUSED(args);
-  CAF_LOG_TRACE(CAF_ARG(args));
+                                                    const_iterator,
+                                                    const_iterator) {
+  CAF_LOG_TRACE();
   auto limit = this->get_or<uint64_t>(options, "events", 0u);
   format::pcap::writer writer{output_, flush_};
   return self->spawn(sink<format::pcap::writer>, std::move(writer), limit);

--- a/libvast/src/system/pcap_writer_command.cpp
+++ b/libvast/src/system/pcap_writer_command.cpp
@@ -42,8 +42,8 @@ pcap_writer_command::pcap_writer_command(command* parent, std::string_view name)
 
 expected<caf::actor> pcap_writer_command::make_sink(caf::scoped_actor& self,
                                                     option_map& options,
-                                                    const_iterator,
-                                                    const_iterator) {
+                                                    argument_iterator,
+                                                    argument_iterator) {
   CAF_LOG_TRACE();
   auto limit = this->get_or<uint64_t>(options, "events", 0u);
   format::pcap::writer writer{output_, flush_};

--- a/libvast/src/system/reader_command_base.cpp
+++ b/libvast/src/system/reader_command_base.cpp
@@ -40,14 +40,14 @@
 namespace vast::system {
 
 int reader_command_base::run_impl(caf::actor_system& sys, option_map& options,
-                                  const_iterator args_begin,
-                                  const_iterator args_end) {
+                                  argument_iterator begin,
+                                  argument_iterator end) {
   using namespace caf;
   using namespace std::chrono_literals;
   // Helper for blocking actor communication.
   scoped_actor self{sys};
   // Spawn the source.
-  auto src_opt = make_source(self, args_begin, args_end);
+  auto src_opt = make_source(self, begin, end);
   if (!src_opt) {
     std::cerr << "unable to spawn source: " << sys.render(src_opt.error())
               << std::endl;

--- a/libvast/src/system/reader_command_base.cpp
+++ b/libvast/src/system/reader_command_base.cpp
@@ -40,13 +40,14 @@
 namespace vast::system {
 
 int reader_command_base::run_impl(caf::actor_system& sys, option_map& options,
-                                  caf::message args) {
+                                  const_iterator args_begin,
+                                  const_iterator args_end) {
   using namespace caf;
   using namespace std::chrono_literals;
   // Helper for blocking actor communication.
   scoped_actor self{sys};
   // Spawn the source.
-  auto src_opt = make_source(self, std::move(args));
+  auto src_opt = make_source(self, args_begin, args_end);
   if (!src_opt) {
     std::cerr << "unable to spawn source: " << sys.render(src_opt.error())
               << std::endl;

--- a/libvast/src/system/remote_command.cpp
+++ b/libvast/src/system/remote_command.cpp
@@ -36,8 +36,10 @@ remote_command::remote_command(command* parent, std::string_view name)
   // nop
 }
 
-int remote_command::run_impl(actor_system& sys, option_map& options, message args) {
-  CAF_LOG_TRACE(CAF_ARG2("name", name()) << CAF_ARG(options) << CAF_ARG(args));
+int remote_command::run_impl(actor_system& sys, option_map& options,
+                             const_iterator args_begin,
+                             const_iterator args_end) {
+  CAF_LOG_TRACE(CAF_ARG2("name", name()) << CAF_ARG(options));
   // Get a convenient and blocking way to interact with actors.
   scoped_actor self{sys};
   // Get VAST node.
@@ -49,6 +51,7 @@ int remote_command::run_impl(actor_system& sys, option_map& options, message arg
   }
   auto node = std::move(*node_opt);
   // Build command to remote node.
+  auto args = caf::message_builder{args_begin, args_end}.move_to_message();
   auto cmd = make_message(std::string{name()}, std::move(args));
   // Delegate command to node.
   auto result = true;

--- a/libvast/src/system/remote_command.cpp
+++ b/libvast/src/system/remote_command.cpp
@@ -37,8 +37,8 @@ remote_command::remote_command(command* parent, std::string_view name)
 }
 
 int remote_command::run_impl(actor_system& sys, option_map& options,
-                             const_iterator args_begin,
-                             const_iterator args_end) {
+                             argument_iterator begin,
+                             argument_iterator end) {
   CAF_LOG_TRACE(CAF_ARG2("name", name()) << CAF_ARG(options));
   // Get a convenient and blocking way to interact with actors.
   scoped_actor self{sys};
@@ -51,7 +51,7 @@ int remote_command::run_impl(actor_system& sys, option_map& options,
   }
   auto node = std::move(*node_opt);
   // Build command to remote node.
-  auto args = caf::message_builder{args_begin, args_end}.move_to_message();
+  auto args = caf::message_builder{begin, end}.move_to_message();
   auto cmd = make_message(std::string{name()}, std::move(args));
   // Delegate command to node.
   auto result = true;

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -42,9 +42,8 @@ start_command::start_command(command* parent, std::string_view name)
 }
 
 int start_command::run_impl(actor_system& sys, option_map& options,
-                        caf::message args) {
-  CAF_IGNORE_UNUSED(args);
-  CAF_LOG_TRACE(CAF_ARG(options) << CAF_ARG(args));
+                        const_iterator, const_iterator) {
+  CAF_LOG_TRACE(CAF_ARG(options));
   // Fetch SSL settings from config.
   auto& sys_cfg = sys.config();
   auto use_encryption = !sys_cfg.openssl_certificate.empty()

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -42,7 +42,7 @@ start_command::start_command(command* parent, std::string_view name)
 }
 
 int start_command::run_impl(actor_system& sys, option_map& options,
-                        const_iterator, const_iterator) {
+                        argument_iterator, argument_iterator) {
   CAF_LOG_TRACE(CAF_ARG(options));
   // Fetch SSL settings from config.
   auto& sys_cfg = sys.config();

--- a/libvast/src/system/writer_command_base.cpp
+++ b/libvast/src/system/writer_command_base.cpp
@@ -43,8 +43,8 @@ using namespace caf;
 namespace vast::system {
 
 int writer_command_base::run_impl(caf::actor_system& sys, option_map& options,
-                                  const_iterator args_begin,
-                                  const_iterator args_end) {
+                                  argument_iterator begin,
+                                  argument_iterator end) {
   // Get a convenient and blocking way to interact with actors.
   scoped_actor self{sys};
   // Get VAST node.
@@ -59,7 +59,7 @@ int writer_command_base::run_impl(caf::actor_system& sys, option_map& options,
   });
   // Spawn a sink.
   VAST_DEBUG("spawning sink with parameters:", deep_to_string(options));
-  auto snk_opt = make_sink(self, options, args_begin, args_end);
+  auto snk_opt = make_sink(self, options, begin, end);
   if (!snk_opt) {
     std::cerr << "unable to spawn sink: " << sys.render(snk_opt.error())
               << std::endl;
@@ -71,7 +71,7 @@ int writer_command_base::run_impl(caf::actor_system& sys, option_map& options,
   // TODO: we need to also include arguments in CLI format from the export
   //       command; we really should forward `options` to the node actor
   //       instead to clean this up
-  auto args = caf::message_builder{args_begin, args_end}.move_to_message();
+  auto args = caf::message_builder{begin, end}.move_to_message();
   args = make_message("exporter") + args;
   if (get_or<bool>(options, "continuous", false))
     args += make_message("--continuous");

--- a/libvast/src/system/writer_command_base.cpp
+++ b/libvast/src/system/writer_command_base.cpp
@@ -43,7 +43,8 @@ using namespace caf;
 namespace vast::system {
 
 int writer_command_base::run_impl(caf::actor_system& sys, option_map& options,
-                              caf::message args) {
+                                  const_iterator args_begin,
+                                  const_iterator args_end) {
   // Get a convenient and blocking way to interact with actors.
   scoped_actor self{sys};
   // Get VAST node.
@@ -58,7 +59,7 @@ int writer_command_base::run_impl(caf::actor_system& sys, option_map& options,
   });
   // Spawn a sink.
   VAST_DEBUG("spawning sink with parameters:", deep_to_string(options));
-  auto snk_opt = make_sink(self, options, args);
+  auto snk_opt = make_sink(self, options, args_begin, args_end);
   if (!snk_opt) {
     std::cerr << "unable to spawn sink: " << sys.render(snk_opt.error())
               << std::endl;
@@ -70,6 +71,7 @@ int writer_command_base::run_impl(caf::actor_system& sys, option_map& options,
   // TODO: we need to also include arguments in CLI format from the export
   //       command; we really should forward `options` to the node actor
   //       instead to clean this up
+  auto args = caf::message_builder{args_begin, args_end}.move_to_message();
   args = make_message("exporter") + args;
   if (get_or<bool>(options, "continuous", false))
     args += make_message("--continuous");

--- a/libvast/test/command.cpp
+++ b/libvast/test/command.cpp
@@ -31,19 +31,19 @@ public:
   }
 
   proceed_result proceed(caf::actor_system&, option_map&,
-                         const_iterator args_begin,
-                         const_iterator args_end) override {
+                         argument_iterator begin,
+                         argument_iterator end) override {
     tested_proceed = true;
-    proceed_begin = args_begin;
-    proceed_end = args_end;
+    proceed_begin = begin;
+    proceed_end = end;
     return proceed_ok;
   }
 
-  int run_impl(caf::actor_system&, option_map&, const_iterator args_begin,
-               const_iterator args_end) override {
+  int run_impl(caf::actor_system&, option_map&, argument_iterator begin,
+               argument_iterator end) override {
     was_executed = true;
-    run_begin = args_begin;
-    run_end = args_end;
+    run_begin = begin;
+    run_end = end;
     return EXIT_SUCCESS;
   }
 
@@ -51,10 +51,10 @@ public:
   bool flag = false;
   bool tested_proceed = false;
   bool was_executed = false;
-  const_iterator proceed_begin;
-  const_iterator proceed_end;
-  const_iterator run_begin;
-  const_iterator run_end;
+  argument_iterator proceed_begin;
+  argument_iterator proceed_end;
+  argument_iterator run_begin;
+  argument_iterator run_end;
 };
 
 class bar : public command {
@@ -64,29 +64,29 @@ public:
   }
 
   proceed_result proceed(caf::actor_system&, option_map&,
-                         const_iterator args_begin,
-                         const_iterator args_end) override {
+                         argument_iterator begin,
+                         argument_iterator end) override {
     tested_proceed = true;
-    proceed_begin = args_begin;
-    proceed_end = args_end;
+    proceed_begin = begin;
+    proceed_end = end;
     return proceed_ok;
   }
 
-  int run_impl(caf::actor_system&, option_map&, const_iterator args_begin,
-               const_iterator args_end) override {
+  int run_impl(caf::actor_system&, option_map&, argument_iterator begin,
+               argument_iterator end) override {
     was_executed = true;
-    run_begin = args_begin;
-    run_end = args_end;
+    run_begin = begin;
+    run_end = end;
     return EXIT_SUCCESS;
   }
 
   int other_value = 0;
   bool tested_proceed = false;
   bool was_executed = false;
-  const_iterator proceed_begin;
-  const_iterator proceed_end;
-  const_iterator run_begin;
-  const_iterator run_end;
+  argument_iterator proceed_begin;
+  argument_iterator proceed_end;
+  argument_iterator run_begin;
+  argument_iterator run_end;
 };
 
 struct fixture {

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -42,6 +42,9 @@ public:
   /// Maps names of config parameters to their value.
   using option_map = std::map<std::string, caf::config_value>;
 
+  /// Iterates over CLI arguments.
+  using const_iterator = std::vector<std::string>::const_iterator;
+
   /// Wraps the result of proceed.
   enum proceed_result {
     proceed_ok,
@@ -59,11 +62,13 @@ public:
 
   /// Runs the command and blocks until execution completes.
   /// @returns An exit code suitable for returning from main.
-  int run(caf::actor_system& sys, caf::message args);
+  int run(caf::actor_system& sys, const_iterator args_begin,
+          const_iterator args_end);
 
   /// Runs the command and blocks until execution completes.
   /// @returns An exit code suitable for returning from main.
-  int run(caf::actor_system& sys, option_map& options, caf::message args);
+  int run(caf::actor_system& sys, option_map& options,
+          const_iterator args_begin, const_iterator args_end);
 
   /// Prints usage to `std::cerr`.
   void usage();
@@ -134,7 +139,8 @@ protected:
   /// Checks whether a command is ready to proceed, i.e., whether the
   /// configuration allows for calling `run_impl` or `run` on a nested command.
   virtual proceed_result proceed(caf::actor_system& sys, option_map& options,
-                                 caf::message args);
+                                 const_iterator args_begin,
+                                 const_iterator args_end);
 
   virtual int run_impl(caf::actor_system& sys, option_map& options,
                        caf::message args);
@@ -166,7 +172,7 @@ protected:
 private:
   /// Separates arguments into the arguments for the current command, the name
   /// of the subcommand, and the arguments for the subcommand.
-  std::tuple<caf::message, std::string, caf::message>
+  std::tuple<caf::message, std::string, caf::message, size_t>
   separate_args(const caf::message& args);
 
   std::map<std::string_view, std::unique_ptr<command>> nested_;

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -43,7 +43,7 @@ public:
   using option_map = std::map<std::string, caf::config_value>;
 
   /// Iterates over CLI arguments.
-  using const_iterator = std::vector<std::string>::const_iterator;
+  using argument_iterator = std::vector<std::string>::const_iterator;
 
   /// Wraps the result of proceed.
   enum proceed_result {
@@ -62,13 +62,13 @@ public:
 
   /// Runs the command and blocks until execution completes.
   /// @returns An exit code suitable for returning from main.
-  int run(caf::actor_system& sys, const_iterator args_begin,
-          const_iterator args_end);
+  int run(caf::actor_system& sys, argument_iterator begin,
+          argument_iterator end);
 
   /// Runs the command and blocks until execution completes.
   /// @returns An exit code suitable for returning from main.
   int run(caf::actor_system& sys, option_map& options,
-          const_iterator args_begin, const_iterator args_end);
+          argument_iterator begin, argument_iterator end);
 
   /// Prints usage to `std::cerr`.
   void usage();
@@ -139,11 +139,11 @@ protected:
   /// Checks whether a command is ready to proceed, i.e., whether the
   /// configuration allows for calling `run_impl` or `run` on a nested command.
   virtual proceed_result proceed(caf::actor_system& sys, option_map& options,
-                                 const_iterator args_begin,
-                                 const_iterator args_end);
+                                 argument_iterator begin,
+                                 argument_iterator end);
 
   virtual int run_impl(caf::actor_system& sys, option_map& options,
-                       const_iterator args_begin, const_iterator args_end);
+                       argument_iterator begin, argument_iterator end);
 
   template <class T>
   void add_opt(std::string name, std::string descr, T& ref) {

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -172,7 +172,7 @@ protected:
 private:
   /// Separates arguments into the arguments for the current command, the name
   /// of the subcommand, and the arguments for the subcommand.
-  std::tuple<caf::message, std::string, caf::message, size_t>
+  std::tuple<caf::message, std::string, caf::message>
   separate_args(const caf::message& args);
 
   std::map<std::string_view, std::unique_ptr<command>> nested_;

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -143,7 +143,7 @@ protected:
                                  const_iterator args_end);
 
   virtual int run_impl(caf::actor_system& sys, option_map& options,
-                       caf::message args);
+                       const_iterator args_begin, const_iterator args_end);
 
   template <class T>
   void add_opt(std::string name, std::string descr, T& ref) {

--- a/libvast/vast/system/application.hpp
+++ b/libvast/vast/system/application.hpp
@@ -32,7 +32,7 @@ public:
 
   protected:
     proceed_result proceed(caf::actor_system& sys, option_map& options,
-                           caf::message) override;
+                           const_iterator, const_iterator) override;
 
   private:
     /// Directory for persistent state.
@@ -63,7 +63,8 @@ public:
 
   /// Starts the application and blocks until execution completes.
   /// @returns An exit code suitable for returning from main.
-  int run(caf::actor_system& sys, caf::message args);
+  int run(caf::actor_system& sys, command::const_iterator args_begin,
+          command::const_iterator args_end);
 
 private:
   root_command root_;

--- a/libvast/vast/system/application.hpp
+++ b/libvast/vast/system/application.hpp
@@ -32,7 +32,7 @@ public:
 
   protected:
     proceed_result proceed(caf::actor_system& sys, option_map& options,
-                           const_iterator, const_iterator) override;
+                           argument_iterator, argument_iterator) override;
 
   private:
     /// Directory for persistent state.
@@ -63,8 +63,8 @@ public:
 
   /// Starts the application and blocks until execution completes.
   /// @returns An exit code suitable for returning from main.
-  int run(caf::actor_system& sys, command::const_iterator args_begin,
-          command::const_iterator args_end);
+  int run(caf::actor_system& sys, command::argument_iterator begin,
+          command::argument_iterator end);
 
 private:
   root_command root_;

--- a/libvast/vast/system/export_command.hpp
+++ b/libvast/vast/system/export_command.hpp
@@ -28,8 +28,8 @@ public:
   export_command(command* parent, std::string_view name);
 
 protected:
-  int run_impl(caf::actor_system& sys, option_map& options, const_iterator,
-               const_iterator) override;
+  int run_impl(caf::actor_system& sys, option_map& options,
+               argument_iterator begin, argument_iterator end) override;
 
 private:
   bool continuous_;

--- a/libvast/vast/system/export_command.hpp
+++ b/libvast/vast/system/export_command.hpp
@@ -28,8 +28,8 @@ public:
   export_command(command* parent, std::string_view name);
 
 protected:
-  int run_impl(caf::actor_system& sys, option_map& options,
-               caf::message args) override;
+  int run_impl(caf::actor_system& sys, option_map& options, const_iterator,
+               const_iterator) override;
 
 private:
   bool continuous_;

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -28,8 +28,8 @@ public:
   import_command(command* parent, std::string_view name);
 
 protected:
-  int run_impl(caf::actor_system& sys, option_map& options, const_iterator,
-               const_iterator) override;
+  int run_impl(caf::actor_system& sys, option_map& options,
+               argument_iterator begin, argument_iterator end) override;
 };
 
 } // namespace vast::system

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -28,8 +28,8 @@ public:
   import_command(command* parent, std::string_view name);
 
 protected:
-  int run_impl(caf::actor_system& sys, option_map& options,
-               caf::message args) override;
+  int run_impl(caf::actor_system& sys, option_map& options, const_iterator,
+               const_iterator) override;
 };
 
 } // namespace vast::system

--- a/libvast/vast/system/pcap_reader_command.hpp
+++ b/libvast/vast/system/pcap_reader_command.hpp
@@ -51,7 +51,8 @@ public:
 
 protected:
   expected<caf::actor> make_source(caf::scoped_actor& self,
-                                   caf::message args) override;
+                                   const_iterator args_begin,
+                                   const_iterator args_end) override;
 
 private:
   std::string input;

--- a/libvast/vast/system/pcap_reader_command.hpp
+++ b/libvast/vast/system/pcap_reader_command.hpp
@@ -51,8 +51,8 @@ public:
 
 protected:
   expected<caf::actor> make_source(caf::scoped_actor& self,
-                                   const_iterator args_begin,
-                                   const_iterator args_end) override;
+                                   argument_iterator begin,
+                                   argument_iterator end) override;
 
 private:
   std::string input;

--- a/libvast/vast/system/pcap_writer_command.hpp
+++ b/libvast/vast/system/pcap_writer_command.hpp
@@ -51,7 +51,8 @@ public:
 
 protected:
   expected<caf::actor> make_sink(caf::scoped_actor& self, option_map& options,
-                                 caf::message args) override;
+                                 const_iterator args_begin,
+                                 const_iterator args_end) override;
 
 private:
   std::string output_;

--- a/libvast/vast/system/pcap_writer_command.hpp
+++ b/libvast/vast/system/pcap_writer_command.hpp
@@ -51,8 +51,8 @@ public:
 
 protected:
   expected<caf::actor> make_sink(caf::scoped_actor& self, option_map& options,
-                                 const_iterator args_begin,
-                                 const_iterator args_end) override;
+                                 argument_iterator begin,
+                                 argument_iterator end) override;
 
 private:
   std::string output_;

--- a/libvast/vast/system/reader_command.hpp
+++ b/libvast/vast/system/reader_command.hpp
@@ -56,8 +56,8 @@ public:
 
 protected:
   expected<caf::actor> make_source(caf::scoped_actor& self,
-                                   const_iterator args_begin,
-                                   const_iterator args_end) override {
+                                   argument_iterator begin,
+                                   argument_iterator end) override {
     CAF_LOG_TRACE();
     auto in = detail::make_input_stream(input_, uds_);
     if (!in)
@@ -76,9 +76,9 @@ protected:
       anon_send(src, put_atom::value, std::move(*sch));
     }
     // Attempt to parse the remainder as an expression.
-    if (args_begin != args_end) {
+    if (begin != end) {
       auto str = std::accumulate(
-        std::next(args_begin), args_end, *args_begin,
+        std::next(begin), end, *begin,
         [](std::string a, const std::string& b) { return a += ' ' + b; });
       auto expr = to<expression>(str);
       if (!expr)

--- a/libvast/vast/system/reader_command_base.hpp
+++ b/libvast/vast/system/reader_command_base.hpp
@@ -44,11 +44,12 @@ public:
   using node_command::node_command;
 
 protected:
-  int run_impl(caf::actor_system& sys, option_map& options,
-               caf::message args) override;
+  int run_impl(caf::actor_system& sys, option_map& options, const_iterator,
+               const_iterator) override;
 
   virtual expected<caf::actor> make_source(caf::scoped_actor& self,
-                                           caf::message args) = 0;
+                                           const_iterator args_begin,
+                                           const_iterator args_end) = 0;
 };
 
 } // namespace vast::system

--- a/libvast/vast/system/reader_command_base.hpp
+++ b/libvast/vast/system/reader_command_base.hpp
@@ -44,12 +44,12 @@ public:
   using node_command::node_command;
 
 protected:
-  int run_impl(caf::actor_system& sys, option_map& options, const_iterator,
-               const_iterator) override;
+  int run_impl(caf::actor_system& sys, option_map& options,
+               argument_iterator begin, argument_iterator end) override;
 
   virtual expected<caf::actor> make_source(caf::scoped_actor& self,
-                                           const_iterator args_begin,
-                                           const_iterator args_end) = 0;
+                                           argument_iterator begin,
+                                           argument_iterator end) = 0;
 };
 
 } // namespace vast::system

--- a/libvast/vast/system/remote_command.hpp
+++ b/libvast/vast/system/remote_command.hpp
@@ -29,7 +29,7 @@ public:
 
 protected:
   int run_impl(caf::actor_system& sys, option_map& options,
-               const_iterator args_begin, const_iterator args_end) override;
+               argument_iterator begin, argument_iterator end) override;
 };
 
 } // namespace vast::system

--- a/libvast/vast/system/remote_command.hpp
+++ b/libvast/vast/system/remote_command.hpp
@@ -29,7 +29,7 @@ public:
 
 protected:
   int run_impl(caf::actor_system& sys, option_map& options,
-               caf::message args) override;
+               const_iterator args_begin, const_iterator args_end) override;
 };
 
 } // namespace vast::system

--- a/libvast/vast/system/start_command.hpp
+++ b/libvast/vast/system/start_command.hpp
@@ -29,7 +29,7 @@ public:
 
 protected:
   int run_impl(caf::actor_system& sys, option_map& options,
-               const_iterator args_begin, const_iterator args_end) override;
+               argument_iterator begin, argument_iterator end) override;
 
 private:
   /// Spawn empty node without components if set.

--- a/libvast/vast/system/start_command.hpp
+++ b/libvast/vast/system/start_command.hpp
@@ -29,7 +29,7 @@ public:
 
 protected:
   int run_impl(caf::actor_system& sys, option_map& options,
-               caf::message args) override;
+               const_iterator args_begin, const_iterator args_end) override;
 
 private:
   /// Spawn empty node without components if set.

--- a/libvast/vast/system/writer_command.hpp
+++ b/libvast/vast/system/writer_command.hpp
@@ -47,8 +47,8 @@ public:
 
 protected:
   expected<caf::actor> make_sink(caf::scoped_actor& self, option_map& options,
-                                 caf::message args) override {
-    CAF_LOG_TRACE(CAF_ARG(args));
+                                 const_iterator, const_iterator) override {
+    CAF_LOG_TRACE();
     using ostream_ptr = std::unique_ptr<std::ostream>;
     auto limit = this->get_or<uint64_t>(options, "events", 0u);
     if constexpr (std::is_constructible_v<Writer, ostream_ptr>) {

--- a/libvast/vast/system/writer_command.hpp
+++ b/libvast/vast/system/writer_command.hpp
@@ -47,7 +47,8 @@ public:
 
 protected:
   expected<caf::actor> make_sink(caf::scoped_actor& self, option_map& options,
-                                 const_iterator, const_iterator) override {
+                                 argument_iterator,
+                                 argument_iterator) override {
     CAF_LOG_TRACE();
     using ostream_ptr = std::unique_ptr<std::ostream>;
     auto limit = this->get_or<uint64_t>(options, "events", 0u);

--- a/libvast/vast/system/writer_command_base.hpp
+++ b/libvast/vast/system/writer_command_base.hpp
@@ -45,11 +45,11 @@ public:
 
 protected:
   int run_impl(caf::actor_system& sys, option_map& options,
-               const_iterator args_begin, const_iterator args_end) override;
+               argument_iterator begin, argument_iterator end) override;
 
   virtual expected<caf::actor>
   make_sink(caf::scoped_actor& self, option_map& options,
-            const_iterator args_begin, const_iterator args_end) = 0;
+            argument_iterator begin, argument_iterator end) = 0;
 };
 
 } // namespace vast::system

--- a/libvast/vast/system/writer_command_base.hpp
+++ b/libvast/vast/system/writer_command_base.hpp
@@ -45,11 +45,11 @@ public:
 
 protected:
   int run_impl(caf::actor_system& sys, option_map& options,
-               caf::message args) override;
+               const_iterator args_begin, const_iterator args_end) override;
 
-  virtual expected<caf::actor> make_sink(caf::scoped_actor& self,
-                                         option_map& options,
-                                         caf::message args) = 0;
+  virtual expected<caf::actor>
+  make_sink(caf::scoped_actor& self, option_map& options,
+            const_iterator args_begin, const_iterator args_end) = 0;
 };
 
 } // namespace vast::system

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -26,9 +26,6 @@ int main(int argc, char** argv) {
   caf::actor_system sys{cfg};
   default_application app;
   // Dispatch to root command.
-  auto result = app.run(sys,
-                        caf::message_builder{cfg.command_line.begin(),
-                                             cfg.command_line.end()}
-                        .move_to_message());
+  auto result = app.run(sys, cfg.command_line.begin(), cfg.command_line.end());
   return result;
 }


### PR DESCRIPTION
This is the first of a series of commits to redesign command.

In this step, we replace the caf::message in the command API by light weight iterators.