### PR TITLE
Consolidate logging API

### DIFF
--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -33,7 +33,7 @@ command::~command() {
 
 int command::run(caf::actor_system& sys, option_map& options,
                  argument_iterator begin, argument_iterator end) {
-  CAF_LOG_TRACE(CAF_ARG(options));
+  VAST_TRACE(VAST_ARG(options), VAST_ARG("args", begin, end));
   // Split the arguments.
   auto args = caf::message_builder{begin, end}.move_to_message();
   auto [local_args, subcmd, subcmd_args] = separate_args(args);
@@ -114,17 +114,18 @@ bool command::is_root() const noexcept {
 }
 
 command::proceed_result command::proceed(caf::actor_system&,
-                                         option_map& options, argument_iterator,
-                                         argument_iterator) {
-  CAF_LOG_TRACE(CAF_ARG(options));
-  CAF_IGNORE_UNUSED(options);
+                                         option_map& options,
+                                         argument_iterator begin,
+                                         argument_iterator end) {
+  VAST_UNUSED(options, begin, end);
+  VAST_TRACE(VAST_ARG(options), VAST_ARG("args", begin, end));
   return proceed_ok;
 }
 
 int command::run_impl(caf::actor_system&, option_map& options,
-                      argument_iterator, argument_iterator) {
-  CAF_LOG_TRACE(CAF_ARG(options));
-  CAF_IGNORE_UNUSED(options);
+                      argument_iterator begin, argument_iterator end) {
+  VAST_UNUSED(options, begin, end);
+  VAST_TRACE(VAST_ARG(options), VAST_ARG("args", begin, end));
   usage();
   return EXIT_FAILURE;
 }

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -85,8 +85,10 @@ application::root_command::root_command()
 
 command::proceed_result
 application::root_command::proceed(caf::actor_system& sys, option_map& options,
-                                   argument_iterator, argument_iterator) {
-  CAF_LOG_TRACE(CAF_ARG(options));
+                                   argument_iterator begin,
+                                   argument_iterator end) {
+  VAST_UNUSED(begin, end);
+  VAST_TRACE(VAST_ARG(options), VAST_ARG("args", begin, end));
   CAF_IGNORE_UNUSED(sys);
   CAF_IGNORE_UNUSED(options);
   if (print_version) {
@@ -106,7 +108,7 @@ application::application() {
 
 int application::run(caf::actor_system& sys, command::argument_iterator begin,
                      command::argument_iterator end) {
-  CAF_LOG_TRACE(CAF_ARG(args));
+  VAST_TRACE(VAST_ARG("args", begin, end));
   return root_.run(sys, begin, end);
 }
 

--- a/libvast/src/system/pcap_reader_command.cpp
+++ b/libvast/src/system/pcap_reader_command.cpp
@@ -62,9 +62,10 @@ pcap_reader_command::pcap_reader_command(command* parent, std::string_view name)
 }
 
 expected<caf::actor> pcap_reader_command::make_source(caf::scoped_actor& self,
-                                                      argument_iterator,
-                                                      argument_iterator) {
-  CAF_LOG_TRACE();
+                                                      argument_iterator begin,
+                                                      argument_iterator end) {
+  VAST_UNUSED(begin, end);
+  VAST_TRACE(VAST_ARG("args", begin, end));
   format::pcap::reader reader{input,    cutoff,      flow_max,
                               flow_age, flow_expiry, pseudo_realtime};
   return self->spawn(source<format::pcap::reader>, std::move(reader));

--- a/libvast/src/system/pcap_writer_command.cpp
+++ b/libvast/src/system/pcap_writer_command.cpp
@@ -42,9 +42,10 @@ pcap_writer_command::pcap_writer_command(command* parent, std::string_view name)
 
 expected<caf::actor> pcap_writer_command::make_sink(caf::scoped_actor& self,
                                                     option_map& options,
-                                                    argument_iterator,
-                                                    argument_iterator) {
-  CAF_LOG_TRACE();
+                                                    argument_iterator begin,
+                                                    argument_iterator end) {
+  VAST_UNUSED(begin, end);
+  VAST_TRACE(VAST_ARG("args", begin, end));
   auto limit = this->get_or<uint64_t>(options, "events", 0u);
   format::pcap::writer writer{output_, flush_};
   return self->spawn(sink<format::pcap::writer>, std::move(writer), limit);

--- a/libvast/src/system/remote_command.cpp
+++ b/libvast/src/system/remote_command.cpp
@@ -39,7 +39,8 @@ remote_command::remote_command(command* parent, std::string_view name)
 int remote_command::run_impl(actor_system& sys, option_map& options,
                              argument_iterator begin,
                              argument_iterator end) {
-  CAF_LOG_TRACE(CAF_ARG2("name", name()) << CAF_ARG(options));
+  VAST_TRACE(VAST_ARG("name", name()), VAST_ARG(options),
+             VAST_ARG("args", begin, end));
   // Get a convenient and blocking way to interact with actors.
   scoped_actor self{sys};
   // Get VAST node.

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -42,8 +42,9 @@ start_command::start_command(command* parent, std::string_view name)
 }
 
 int start_command::run_impl(actor_system& sys, option_map& options,
-                        argument_iterator, argument_iterator) {
-  CAF_LOG_TRACE(CAF_ARG(options));
+                        argument_iterator begin, argument_iterator end) {
+  VAST_UNUSED(begin, end);
+  VAST_TRACE(VAST_ARG(options), VAST_ARG("args", begin, end));
   // Fetch SSL settings from config.
   auto& sys_cfg = sys.config();
   auto use_encryption = !sys_cfg.openssl_certificate.empty()

--- a/libvast/vast/system/reader_command.hpp
+++ b/libvast/vast/system/reader_command.hpp
@@ -58,7 +58,7 @@ protected:
   expected<caf::actor> make_source(caf::scoped_actor& self,
                                    argument_iterator begin,
                                    argument_iterator end) override {
-    CAF_LOG_TRACE();
+    VAST_TRACE(VAST_ARG("args", begin, end));
     auto in = detail::make_input_stream(input_, uds_);
     if (!in)
       return in.error();

--- a/libvast/vast/system/sink.hpp
+++ b/libvast/vast/system/sink.hpp
@@ -19,6 +19,7 @@
 
 #include "vast/logger.hpp"
 
+#include <caf/behavior.hpp>
 #include <caf/stateful_actor.hpp>
 
 #include "vast/concept/printable/stream.hpp"

--- a/libvast/vast/system/writer_command.hpp
+++ b/libvast/vast/system/writer_command.hpp
@@ -47,9 +47,10 @@ public:
 
 protected:
   expected<caf::actor> make_sink(caf::scoped_actor& self, option_map& options,
-                                 argument_iterator,
-                                 argument_iterator) override {
-    CAF_LOG_TRACE();
+                                 argument_iterator begin,
+                                 argument_iterator end) override {
+    VAST_UNUSED(begin, end);
+    VAST_TRACE(VAST_ARG(options), VAST_ARG("args", begin, end));
     using ostream_ptr = std::unique_ptr<std::ostream>;
     auto limit = this->get_or<uint64_t>(options, "events", 0u);
     if constexpr (std::is_constructible_v<Writer, ostream_ptr>) {


### PR DESCRIPTION
Lift CAF logging primitives and avoid unnecessary complexity for features we get for free from CAF.