### PR TITLE
Add non-owning view infrastructure

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -19,6 +19,7 @@ set(libvast_sources
   src/base.cpp
   src/batch.cpp
   src/bitmap.cpp
+  src/buffer.cpp
   src/chunk.cpp
   src/command.cpp
   src/compression.cpp
@@ -91,6 +92,7 @@ set(libvast_sources
   src/uuid.cpp
   src/value.cpp
   src/value_index.cpp
+  src/view.cpp
   src/wah_bitmap.cpp
 )
 
@@ -201,6 +203,7 @@ set(tests
   test/bitmap_index.cpp
   test/bits.cpp
   test/bitvector.cpp
+  test/buffer.cpp
   test/cache.cpp
   test/chunk.cpp
   test/coder.cpp
@@ -258,6 +261,7 @@ set(tests
   test/variant.cpp
   test/vector_map.cpp
   test/vector_set.cpp
+  test/view.cpp
   test/word.cpp
 )
 

--- a/libvast/src/view.cpp
+++ b/libvast/src/view.cpp
@@ -1,0 +1,34 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/view.hpp"
+
+namespace vast {
+
+concrete_vector_view::concrete_vector_view(const vector& xs) : xs_{xs} {
+  // nop
+}
+
+abstract_vector_view::value_type concrete_vector_view::at(size_type i) const {
+  return make_view(xs_[i]);
+}
+
+abstract_vector_view::size_type concrete_vector_view::size() const {
+  return xs_.size();
+}
+
+view_t<data> make_view(const data& x) {
+  return visit([](const auto& z) { return make_view(z); }, x);
+}
+
+} // namespace vast

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -1,0 +1,43 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/view.hpp"
+
+#define SUITE view
+#include "test.hpp"
+
+using namespace vast;
+using namespace std::string_literals;
+
+TEST(arithmetic view) {
+  CHECK_EQUAL(view_t<boolean>{true}, true);
+  CHECK_EQUAL(view_t<integer>{42}, 42);
+  CHECK_EQUAL(view_t<std::string>{"foo"}, "foo");
+}
+
+TEST(make_view) {
+  auto x = make_view(true);
+  CHECK(std::holds_alternative<boolean>(x));
+  auto str = "foo"s;
+  x = make_view(str);
+  CHECK(std::holds_alternative<view_t<std::string>>(x));
+  CHECK(std::holds_alternative<std::string_view>(x));
+  auto xs = vector{42, true, "foo"};
+  x = make_view(xs);
+  REQUIRE(std::holds_alternative<view_t<vector>>(x));
+  auto v = get<view_t<vector>>(x);
+  REQUIRE_EQUAL(v->size(), 3u);
+  CHECK_EQUAL(v->at(0), 42);
+  CHECK_EQUAL(v->at(1), true);
+  CHECK_EQUAL(v->at(2), "foo");
+}

--- a/libvast/vast/view.hpp
+++ b/libvast/vast/view.hpp
@@ -1,0 +1,182 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <variant>
+
+#include <caf/intrusive_ptr.hpp>
+#include <caf/ref_counted.hpp>
+
+#include "vast/aliases.hpp"
+#include "vast/data.hpp"
+#include "vast/none.hpp"
+#include "vast/time.hpp"
+
+#include "vast/detail/type_traits.hpp"
+
+namespace vast {
+
+/// A type-safe overlay over an immutable sequence of bytes.
+template <class>
+struct view;
+
+template <class T>
+using view_t = typename view<T>::type;
+
+/// @relates view
+template <>
+struct view<none> {
+  using type = none;
+};
+
+/// @relates view
+template <>
+struct view<boolean> {
+  using type = boolean;
+};
+
+/// @relates view
+template <>
+struct view<integer> {
+  using type = integer;
+};
+
+/// @relates view
+template <>
+struct view<count> {
+  using type = count;
+};
+
+/// @relates view
+template <>
+struct view<real> {
+  using type = real;
+};
+
+/// @relates view
+template <>
+struct view<timespan> {
+  using type = timespan;
+};
+
+/// @relates view
+template <>
+struct view<timestamp> {
+  using type = timestamp;
+};
+
+/// @relates view
+template <>
+struct view<std::string> {
+  using type = std::string_view;
+};
+
+//// @relates view
+template <>
+struct view<pattern> {
+  using type = std::string_view;
+};
+
+// @relates view
+struct abstract_vector_view;
+
+/// @relates view
+using abstract_vector_view_ptr = caf::intrusive_ptr<abstract_vector_view>;
+
+/// @relates view
+template <>
+struct view<vector> {
+  using type = abstract_vector_view_ptr;
+};
+
+/// A type-erased view over variout types of data.
+/// @relates view
+using data_view_variant = std::variant<
+  none,
+  view_t<boolean>,
+  view_t<integer>,
+  view_t<count>,
+  view_t<real>,
+  view_t<timespan>,
+  view_t<timestamp>,
+  view_t<std::string>,
+  view_t<vector>
+>;
+
+/// @relates view
+template <>
+struct view<data> {
+  using type = data_view_variant;
+};
+
+/// @relates view
+struct abstract_vector_view : public caf::ref_counted {
+  using value_type = view_t<data>;
+  using size_type = size_t;
+
+  virtual ~abstract_vector_view() = default;
+
+  /// Retrieves a specific element.
+  /// @param i The position of the element to retrieve.
+  virtual value_type at(size_type i) const = 0;
+
+  /// @returns The number of elements in the container.
+  virtual size_type size() const = 0;
+};
+
+/// A view over a @ref vector.
+/// @relates view
+class concrete_vector_view : public abstract_vector_view {
+public:
+  concrete_vector_view(const vector& xs);
+
+  value_type at(size_type i) const override;
+
+  size_type size() const override;
+
+private:
+  const vector& xs_;
+};
+
+/// @relates view
+template <class T>
+view_t<data> make_view(const T& x) {
+  constexpr auto directly_constructible
+    = detail::is_any_v<T, none, boolean, integer, count, real, timespan,
+                       timestamp, std::string>;
+  if constexpr (directly_constructible) {
+    return view_t<data>{x};
+  } else if constexpr (std::is_same_v<T, pattern>) {
+    return {}; // TODO
+  } else if constexpr (std::is_same_v<T, address>) {
+    return {}; // TODO
+  } else if constexpr (std::is_same_v<T, subnet>) {
+    return {}; // TODO
+  } else if constexpr (std::is_same_v<T, port>) {
+    return {}; // TODO
+  } else if constexpr (std::is_same_v<T, vector>) {
+    return abstract_vector_view_ptr{new concrete_vector_view{x}};
+  } else if constexpr (std::is_same_v<T, set>) {
+    return {}; // TODO
+  } else if constexpr (std::is_same_v<T, table>) {
+    return {}; // TODO
+  } else {
+    return {};
+  }
+}
+
+view_t<data> make_view(const data& x);
+
+} // namespace vast


### PR DESCRIPTION
This PR adds new functionality to create *views*, i.e., non-owning light-weight overlay structures that point to immutable data.