### PR TITLE
Add missing unit-test to cmake build

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -234,6 +234,7 @@ set(tests
   test/offset.cpp
   test/option_declaration_set.cpp
   test/option_map.cpp
+  test/parse_data.cpp
   test/parseable.cpp
   test/pattern.cpp
   test/port.cpp

--- a/libvast/test/parse_data.cpp
+++ b/libvast/test/parse_data.cpp
@@ -14,7 +14,7 @@
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/data.hpp"
 
-#define SUITE parse_data 
+#define SUITE parseable
 #include "test.hpp"
 
 using namespace vast;

--- a/libvast/test/parse_data.cpp
+++ b/libvast/test/parse_data.cpp
@@ -14,7 +14,7 @@
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/data.hpp"
 
-#define SUITE parseable
+#define SUITE parse_data 
 #include "test.hpp"
 
 using namespace vast;


### PR DESCRIPTION
It seems like the unit_test `parse_data.cpp`was overlooked and not added to the cmake build.
Here is the fix.