### PR TITLE
Add global get() and get_or() for option_map

### DIFF
--- a/libvast/src/option_map.cpp
+++ b/libvast/src/option_map.cpp
@@ -18,25 +18,13 @@
 
 namespace vast {
 
-optional<option_map::mapped_type> option_map::get(std::string_view name) const {
+optional<const option_map::mapped_type&> 
+option_map::operator[](std::string_view name) const {
   // TODO: Remove explicit conversion to a string.
   // This requires to override *find* to support equivalent keys.
   if (auto x = xs_.find(std::string{name}); x != xs_.end())
     return x->second;
   return {};
-}
-
-option_map::mapped_type
-option_map::get_or(std::string_view name,
-                   const mapped_type& default_value) const {
-  if(auto x = get(name); x)
-    return *x;
-  return default_value;
-}
-
-optional<option_map::mapped_type> 
-option_map::operator[](std::string_view name) const {
-  return get(name);
 }
 
 void option_map::set(const key_type& name, const mapped_type& x) {

--- a/libvast/test/option_map.cpp
+++ b/libvast/test/option_map.cpp
@@ -46,7 +46,7 @@ struct fixture {
 
 FIXTURE_SCOPE(command_tests, fixture)
 
-TEST(retrieving data) {
+TEST(retrieving arguments) {
   auto num = 42;
   opts.add("true", true);
   opts.add("false", false);
@@ -60,8 +60,13 @@ TEST(retrieving data) {
   CHECK(!i);
   i = get<integer>(opts, "number");
   CHECK(!i);
-  auto j = get_or<integer>(opts, "number", num);
+  auto j = get_or(opts, "number", num);
   CHECK_EQUAL(j, num);
+  opts.add("number", 42);
+  check_option<integer>(opts, "number", 42);
+  CHECK_EQUAL(get_or<integer>(opts, "number", 0), 42);
+  CHECK_EQUAL(get_or<boolean>(opts, "number", 0), 0);
+  CHECK_EQUAL(get_or(opts, "number", 0), 42);
 }
 
 TEST(cli parsing) {

--- a/libvast/test/option_map.cpp
+++ b/libvast/test/option_map.cpp
@@ -23,6 +23,20 @@ using namespace vast;
 
 namespace {
 
+template <class T>
+void check_option(const option_map& opts, const std::string& name,
+                  const T& value) {
+  auto d = get<T>(opts, name);
+  REQUIRE(d);
+  CHECK_EQUAL(*d, value);
+};
+
+template <class T>
+void check_fail_option(const option_map& opts, const std::string& name) {
+  auto d = get<T>(opts, name);
+  CHECK(!d);
+};
+
 struct fixture {
   option_declaration_set decl;
   option_map opts;
@@ -38,20 +52,16 @@ TEST(retrieving data) {
   opts.add("false", false);
   CHECK(!opts.add("true", true));
   CHECK_EQUAL(opts.size(), 2u);
-  auto x = opts.get("true");
-  REQUIRE(x);
-  CHECK_EQUAL(get<boolean>(*x), true);
-  x = opts.get("false");
-  REQUIRE(x);
-  CHECK_EQUAL(get<boolean>(*x), false);
+  check_option<boolean>(opts, "true", true);
+  check_option<boolean>(opts, "false", false);
   opts.set("true", false);
-  x = opts.get("true");
-  REQUIRE(x);
-  CHECK_EQUAL(get<boolean>(*x), false);
-  x = opts.get("number");
-  CHECK(!x);
-  auto y = opts.get_or("number", num);
-  CHECK_EQUAL(y, num);
+  check_option<boolean>(opts, "true", false);
+  auto i = get<integer>(opts, "true");
+  CHECK(!i);
+  i = get<integer>(opts, "number");
+  CHECK(!i);
+  auto j = get_or<integer>(opts, "number", num);
+  CHECK_EQUAL(j, num);
 }
 
 TEST(cli parsing) {
@@ -63,23 +73,14 @@ TEST(cli parsing) {
     }
     return result;
   };
-  auto check_option = [&](const std::string& name, auto value) {
-    auto d = opts.get(name);
-    REQUIRE(d);
-    CHECK_EQUAL(*d, value);
-  };
-  auto check_fail_option = [&](const std::string& name) {
-    auto d = opts.get(name);
-    CHECK(!d);
-  };
   auto check_all_options = [&](const auto& args) {
     opts.clear();
     auto [state, it] = decl.parse(opts, args.begin(), args.end());
     CHECK_EQUAL(state, option_declaration_set::parse_state::successful);
     CHECK_EQUAL(it, args.end());
-    check_option("boolean", true);
-    check_option("integer", 42);
-    check_option("string", "test");
+    check_option<boolean>(opts, "boolean", true);
+    check_option<integer>(opts, "integer", 42);
+    check_option<std::string>(opts, "string", "test");
   };
   CHECK(decl.add("boolean,b", "", false));  
   CHECK(decl.add("integer,i", "", 1));  
@@ -89,10 +90,10 @@ TEST(cli parsing) {
   auto [state, it] = decl.parse(opts, args.begin(), args.end());
   CHECK_EQUAL(state, option_declaration_set::parse_state::successful);
   CHECK_EQUAL(it, args.end());
-  check_option("boolean", false);
-  check_option("integer", 1);
-  check_option("string", "foo");
-  check_fail_option("not-contained");
+  check_option<boolean>(opts, "boolean", false);
+  check_option<integer>(opts, "integer", 1);
+  check_option<std::string>(opts, "string", "foo");
+  check_fail_option<std::string>(opts, "not-contained");
   MESSAGE("Test long names");
   args = split("--boolean --integer=42 --string=\"test\"");
   check_all_options(args);
@@ -116,12 +117,12 @@ TEST(cli parsing) {
   std::tie(state, it) = decl2.parse(opts, args.begin(), args.end());
   CHECK_EQUAL(state, option_declaration_set::parse_state::successful);
   CHECK_EQUAL(it, args.end());
-  check_option("boolean", true);
-  check_option("boolean2", false);
-  check_option("integer", 42);
-  check_option("integer2", 1337);
-  check_option("string", "test");
-  check_option("string2", "test2");
+  check_option<boolean>(opts, "boolean", true);
+  check_option<boolean>(opts, "boolean2", false);
+  check_option<integer>(opts, "integer", 42);
+  check_option<integer>(opts, "integer2", 1337);
+  check_option<std::string>(opts, "string", "test");
+  check_option<std::string>(opts, "string2", "test2");
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/vast/option_map.hpp
+++ b/libvast/vast/option_map.hpp
@@ -90,19 +90,17 @@ optional<const T&> get(const option_map& xs, std::string_view name) {
   auto x = xs[name];
   if (!x)
     return {};
-  auto result = get_if<T>(*x);
-  if (!result)
-    return {};
-  return *result;
+  if (auto result = get_if<T>(*x); result)
+    return *result;
+  return {};
 }
 
 template <class T>
 T get_or(const option_map& xs, std::string_view name,
          const T& default_value) {
-  auto x = get<detail::make_data_type<T>>(xs, name);
-  if (!x)
-    return default_value;
-  return *x;
+  if (auto x = get<detail::make_data_type<T>>(xs, name); x)
+    return *x;
+  return default_value;
 }
 
 } // namespace vast

--- a/libvast/vast/option_map.hpp
+++ b/libvast/vast/option_map.hpp
@@ -99,7 +99,7 @@ optional<const T&> get(const option_map& xs, std::string_view name) {
 template <class T>
 T get_or(const option_map& xs, std::string_view name,
          const T& default_value) {
-  auto x = get<T>(xs, name);
+  auto x = get<detail::make_data_type<T>>(xs, name);
   if (!x)
     return default_value;
   return *x;

--- a/libvast/vast/option_map.hpp
+++ b/libvast/vast/option_map.hpp
@@ -47,12 +47,7 @@ public:
 
   // -- lookup ---------------------------------------------------------------
 
-  optional<mapped_type> get(std::string_view name) const;
-
-  mapped_type get_or(std::string_view name,
-                     const mapped_type& default_value) const;
-
-  optional<mapped_type> operator[](std::string_view name) const;
+  optional<const mapped_type&> operator[](std::string_view name) const;
 
   // -- modifiers ------------------------------------------------------------
 
@@ -89,6 +84,26 @@ public:
 private:
   map_type xs_;
 };
+
+template <class T>
+optional<const T&> get(const option_map& xs, std::string_view name) {
+  auto x = xs[name];
+  if (!x)
+    return {};
+  auto result = get_if<T>(*x);
+  if (!result)
+    return {};
+  return *result;
+}
+
+template <class T>
+T get_or(const option_map& xs, std::string_view name,
+         const T& default_value) {
+  auto x = get<T>(xs, name);
+  if (!x)
+    return default_value;
+  return *x;
+}
 
 } // namespace vast
 


### PR DESCRIPTION
This PR changes the `option_map` API.
The function `get()`and `get_or()` expose the `option_map` internal data structure`data` which complicates its usage.

The new API returns the actual types.