### PR TITLE
Consolidate variant implementations

### DIFF
--- a/libvast/src/bitmap.cpp
+++ b/libvast/src/bitmap.cpp
@@ -46,6 +46,14 @@ void bitmap::flip() {
   caf::visit([](auto& bm) { bm.flip(); }, bitmap_);
 }
 
+bitmap::variant& bitmap::data() {
+  return bitmap_;
+}
+
+const bitmap::variant& bitmap::data() const {
+  return bitmap_;
+}
+
 bool operator==(const bitmap& x, const bitmap& y) {
   return x.bitmap_ == y.bitmap_;
 }
@@ -57,7 +65,7 @@ bitmap_bit_range::bitmap_bit_range(const bitmap& bm) {
       bits_ = r.get();
     range_ = std::move(r);
   };
-  caf::visit(visitor, bm.bitmap_);
+  caf::visit(visitor, bm);
 }
 
 void bitmap_bit_range::next() {

--- a/libvast/src/bitmap.cpp
+++ b/libvast/src/bitmap.cpp
@@ -23,27 +23,27 @@ bitmap::bitmap(size_type n, bool bit) : bitmap{} {
 }
 
 bool bitmap::empty() const {
-  return visit([](auto& bm) { return bm.empty(); }, bitmap_);
+  return caf::visit([](auto& bm) { return bm.empty(); }, bitmap_);
 }
 
 bitmap::size_type bitmap::size() const {
-  return visit([](auto& bm) { return bm.size(); }, bitmap_);
+  return caf::visit([](auto& bm) { return bm.size(); }, bitmap_);
 }
 
 void bitmap::append_bit(bool bit) {
-  visit([=](auto& bm) { bm.append_bit(bit); }, bitmap_);
+  caf::visit([=](auto& bm) { bm.append_bit(bit); }, bitmap_);
 }
 
 void bitmap::append_bits(bool bit, size_type n) {
-  visit([=](auto& bm) { bm.append_bits(bit, n); }, bitmap_);
+  caf::visit([=](auto& bm) { bm.append_bits(bit, n); }, bitmap_);
 }
 
 void bitmap::append_block(block_type value, size_type n) {
-  visit([=](auto& bm) { bm.append_block(value, n); }, bitmap_);
+  caf::visit([=](auto& bm) { bm.append_block(value, n); }, bitmap_);
 }
 
 void bitmap::flip() {
-  visit([](auto& bm) { bm.flip(); }, bitmap_);
+  caf::visit([](auto& bm) { bm.flip(); }, bitmap_);
 }
 
 bool operator==(const bitmap& x, const bitmap& y) {
@@ -57,7 +57,7 @@ bitmap_bit_range::bitmap_bit_range(const bitmap& bm) {
       bits_ = r.get();
     range_ = std::move(r);
   };
-  visit(visitor, bm);
+  caf::visit(visitor, bm.bitmap_);
 }
 
 void bitmap_bit_range::next() {
@@ -65,11 +65,11 @@ void bitmap_bit_range::next() {
     rng.next();
     bits_ = rng.get();
   };
-  visit(visitor, range_);
+  caf::visit(visitor, range_);
 }
 
 bool bitmap_bit_range::done() const {
-  return visit([](auto& rng) { return rng.done(); }, range_);
+  return caf::visit([](auto& rng) { return rng.done(); }, range_);
 }
 
 bitmap_bit_range bit_range(const bitmap& bm) {

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -37,27 +37,27 @@ expression hoister::operator()(none) const {
 expression hoister::operator()(const conjunction& c) const {
   conjunction hoisted;
   for (auto& op : c)
-    if (auto inner = get_if<conjunction>(op))
+    if (auto inner = caf::get_if<conjunction>(&op))
       for (auto& inner_op : *inner)
-        hoisted.push_back(visit(*this, inner_op));
+        hoisted.push_back(caf::visit(*this, inner_op));
     else
-      hoisted.push_back(visit(*this, op));
+      hoisted.push_back(caf::visit(*this, op));
   return hoisted.size() == 1 ? hoisted[0] : hoisted;
 }
 
 expression hoister::operator()(const disjunction& d) const {
   disjunction hoisted;
   for (auto& op : d)
-    if (auto inner = get_if<disjunction>(op))
+    if (auto inner = caf::get_if<disjunction>(&op))
       for (auto& inner_op : *inner)
-        hoisted.push_back(visit(*this, inner_op));
+        hoisted.push_back(caf::visit(*this, inner_op));
     else
-      hoisted.push_back(visit(*this, op));
+      hoisted.push_back(caf::visit(*this, op));
   return hoisted.size() == 1 ? hoisted[0] : hoisted;
 }
 
 expression hoister::operator()(const negation& n) const {
-  return {negation{visit(*this, n.expr())}};
+  return {negation{caf::visit(*this, n.expr())}};
 }
 
 expression hoister::operator()(const predicate& p) const {
@@ -72,23 +72,25 @@ expression aligner::operator()(none) const {
 expression aligner::operator()(const conjunction& c) const {
   conjunction result;
   for (auto& op : c)
-    result.push_back(visit(*this, op));
+    result.push_back(caf::visit(*this, op));
   return result;
 }
 
 expression aligner::operator()(const disjunction& d) const {
   disjunction result;
   for (auto& op : d)
-    result.push_back(visit(*this, op));
+    result.push_back(caf::visit(*this, op));
   return result;
 }
 
 expression aligner::operator()(const negation& n) const {
-  return {negation{visit(*this, n.expr())}};
+  return {negation{caf::visit(*this, n.expr())}};
 }
 
 expression aligner::operator()(const predicate& p) const {
-  auto is_extractor = [](auto& operand) { return !is<data>(operand); };
+  auto is_extractor = [](auto& operand) {
+    return !caf::holds_alternative<data>(operand);
+  };
   // Already aligned if LHS is an extractor or no extractor present.
   if (is_extractor(p.lhs) || !is_extractor(p.rhs))
     return p;
@@ -106,7 +108,7 @@ expression denegator::operator()(none) const {
 expression denegator::operator()(const conjunction& c) const {
   auto add = [&](auto x) -> expression {
     for (auto& op : c)
-      x.push_back(visit(*this, op));
+      x.push_back(caf::visit(*this, op));
     return x;
   };
   return negate_ ? add(disjunction{}) : add(conjunction{});
@@ -115,7 +117,7 @@ expression denegator::operator()(const conjunction& c) const {
 expression denegator::operator()(const disjunction& d) const {
   auto add = [&](auto x) -> expression {
     for (auto& op : d)
-      x.push_back(visit(*this, op));
+      x.push_back(caf::visit(*this, op));
     return x;
   };
   return negate_ ? add(conjunction{}) : add(disjunction{});
@@ -123,10 +125,10 @@ expression denegator::operator()(const disjunction& d) const {
 
 expression denegator::operator()(const negation& n) const {
   // Step through double negations.
-  if (auto inner = get_if<negation>(n.expr()))
-    return visit(*this, inner->expr());
+  if (auto inner = caf::get_if<negation>(&n.expr()))
+    return caf::visit(*this, inner->expr());
   // Apply De Morgan from here downward.
-  return visit(denegator{!negate_}, n.expr());
+  return caf::visit(denegator{!negate_}, n.expr());
 }
 
 expression denegator::operator()(const predicate& p) const {
@@ -141,7 +143,7 @@ expression deduplicator::operator()(none) const {
 expression deduplicator::operator()(const conjunction& c) const {
   conjunction result;
   for (auto& op : c) {
-    auto p = visit(*this, op);
+    auto p = caf::visit(*this, op);
     if (std::count(result.begin(), result.end(), p) == 0)
       result.push_back(p);
   }
@@ -151,7 +153,7 @@ expression deduplicator::operator()(const conjunction& c) const {
 expression deduplicator::operator()(const disjunction& d) const {
   disjunction result;
   for (auto& op : d) {
-    auto p = visit(*this, op);
+    auto p = caf::visit(*this, op);
     if (std::count(result.begin(), result.end(), p) == 0)
       result.push_back(p);
   }
@@ -159,7 +161,7 @@ expression deduplicator::operator()(const disjunction& d) const {
 }
 
 expression deduplicator::operator()(const negation& n) const {
-  return visit(*this, n.expr());
+  return caf::visit(*this, n.expr());
 }
 
 expression deduplicator::operator()(const predicate& p) const {
@@ -186,7 +188,7 @@ std::vector<predicate> predicatizer::operator()(none) const {
 std::vector<predicate> predicatizer::operator()(const conjunction& con) const {
   std::vector<predicate> result;
   for (auto& op : con) {
-    auto ps = visit(*this, op);
+    auto ps = caf::visit(*this, op);
     inplace_union(result, ps);
   }
   return result;
@@ -195,14 +197,14 @@ std::vector<predicate> predicatizer::operator()(const conjunction& con) const {
 std::vector<predicate> predicatizer::operator()(const disjunction& dis) const {
   std::vector<predicate> result;
   for (auto& op : dis) {
-    auto ps = visit(*this, op);
+    auto ps = caf::visit(*this, op);
     inplace_union(result, ps);
   }
   return result;
 }
 
 std::vector<predicate> predicatizer::operator()(const negation& n) const {
-  return visit(*this, n.expr());
+  return caf::visit(*this, n.expr());
 }
 
 std::vector<predicate> predicatizer::operator()(const predicate& pred) const {
@@ -216,7 +218,7 @@ expected<void> validator::operator()(none) {
 
 expected<void> validator::operator()(const conjunction& c) {
   for (auto& op : c) {
-    auto m = visit(*this, op);
+    auto m = caf::visit(*this, op);
     if (!m)
       return m;
   }
@@ -225,7 +227,7 @@ expected<void> validator::operator()(const conjunction& c) {
 
 expected<void> validator::operator()(const disjunction& d) {
   for (auto& op : d) {
-    auto m = visit(*this, op);
+    auto m = caf::visit(*this, op);
     if (!m)
       return m;
   }
@@ -233,12 +235,12 @@ expected<void> validator::operator()(const disjunction& d) {
 }
 
 expected<void> validator::operator()(const negation& n) {
-  return visit(*this, n.expr());
+  return caf::visit(*this, n.expr());
 }
 
 expected<void> validator::operator()(const predicate& p) {
   op_ = p.op;
-  return visit(*this, p.lhs, p.rhs);
+  return caf::visit(*this, p.lhs, p.rhs);
 }
 
 expected<void> validator::operator()(const attribute_extractor& ex,
@@ -278,14 +280,14 @@ bool time_restrictor::operator()(none) const {
 
 bool time_restrictor::operator()(const conjunction& con) const {
   for (auto& op : con)
-    if (!visit(*this, op))
+    if (!caf::visit(*this, op))
       return false;
   return true;
 }
 
 bool time_restrictor::operator()(const disjunction& dis) const {
   for (auto& op : dis)
-    if (visit(*this, op))
+    if (caf::visit(*this, op))
       return true;
   return false;
 }
@@ -294,19 +296,19 @@ bool time_restrictor::operator()(const negation& n) const {
   // We can only apply a negation if it sits directly on top of a time
   // extractor, because only then we can negate the meaning of the temporal
   // constraint.
-  auto r = visit(*this, n.expr());
-  if (auto p = get_if<predicate>(n.expr()))
-    if (auto a = get_if<attribute_extractor>(p->lhs))
+  auto r = caf::visit(*this, n.expr());
+  if (auto p = caf::get_if<predicate>(&n.expr()))
+    if (auto a = caf::get_if<attribute_extractor>(&p->lhs))
       if (a->attr == "time")
         return !r;
   return r;
 }
 
 bool time_restrictor::operator()(const predicate& p) const {
-  if (auto a = get_if<attribute_extractor>(p.lhs)) {
+  if (auto a = caf::get_if<attribute_extractor>(&p.lhs)) {
     if (a->attr == "time") {
-      auto d = get_if<data>(p.rhs);
-      VAST_ASSERT(d && is<timestamp>(*d)); // require validation
+      auto d = caf::get_if<data>(&p.rhs);
+      VAST_ASSERT(d && is<timestamp>(*d));
       return evaluate(first_, p.op, *d) || evaluate(last_, p.op, *d);
     }
   }
@@ -324,10 +326,10 @@ expected<expression> type_resolver::operator()(none) {
 expected<expression> type_resolver::operator()(const conjunction& c) {
   conjunction result;
   for (auto& op : c) {
-    auto r = visit(*this, op);
+    auto r = caf::visit(*this, op);
     if (!r)
       return r;
-    else if (is<none>(*r))
+    else if (caf::holds_alternative<none>(*r))
       return expression{};
     else
       result.push_back(std::move(*r));
@@ -344,10 +346,10 @@ expected<expression> type_resolver::operator()(const conjunction& c) {
 expected<expression> type_resolver::operator()(const disjunction& d) {
   disjunction result;
   for (auto& op : d) {
-    auto r = visit(*this, op);
+    auto r = caf::visit(*this, op);
     if (!r)
       return r;
-    else if (!is<none>(*r))
+    else if (!caf::holds_alternative<none>(*r))
       result.push_back(std::move(*r));
   }
   if (result.empty())
@@ -360,10 +362,10 @@ expected<expression> type_resolver::operator()(const disjunction& d) {
 
 
 expected<expression> type_resolver::operator()(const negation& n) {
-  auto r = visit(*this, n.expr());
+  auto r = caf::visit(*this, n.expr());
   if (!r)
     return r;
-  else if (!is<none>(*r))
+  else if (!caf::holds_alternative<none>(*r))
     return {negation{std::move(*r)}};
   else
     return expression{};
@@ -371,7 +373,7 @@ expected<expression> type_resolver::operator()(const negation& n) {
 
 expected<expression> type_resolver::operator()(const predicate& p) {
   op_ = p.op;
-  return visit(*this, p.lhs, p.rhs);
+  return caf::visit(*this, p.lhs, p.rhs);
 }
 
 expected<expression> type_resolver::operator()(const type_extractor& ex,
@@ -452,8 +454,8 @@ expression type_pruner::operator()(none) {
 expression type_pruner::operator()(const conjunction& c) {
   conjunction result;
   for (auto& op : c) {
-    auto e = visit(*this, op);
-    if (is<none>(e))
+    auto e = caf::visit(*this, op);
+    if (caf::holds_alternative<none>(e))
       // If any operand of the conjunction is not a viable type resolver, the
       // entire conjunction is not viable. For example, if we have an event
       // consisting only of numeric types and the conjunction (int == +42 &&
@@ -472,8 +474,8 @@ expression type_pruner::operator()(const conjunction& c) {
 expression type_pruner::operator()(const disjunction& d) {
   disjunction result;
   for (auto& op : d) {
-    auto e = visit(*this, op);
-    if (!is<none>(e))
+    auto e = caf::visit(*this, op);
+    if (!caf::holds_alternative<none>(e))
       result.push_back(std::move(e));
   }
   if (result.empty())
@@ -484,14 +486,14 @@ expression type_pruner::operator()(const disjunction& d) {
 }
 
 expression type_pruner::operator()(const negation& n) {
-  auto e = visit(*this, n.expr());
-  if (is<none>(e))
+  auto e = caf::visit(*this, n.expr());
+  if (caf::holds_alternative<none>(e))
     return e;
   return negation{std::move(e)};
 }
 
 expression type_pruner::operator()(const predicate& p) {
-  if (auto lhs = get_if<type_extractor>(p.lhs)) {
+  if (auto lhs = caf::get_if<type_extractor>(&p.lhs)) {
     if (auto r = get_if<record_type>(type_)) {
       disjunction result;
       for (auto& e : record_type::each{*r})
@@ -507,7 +509,7 @@ expression type_pruner::operator()(const predicate& p) {
     } else if (congruent(type_, lhs->type)) {
       return predicate{data_extractor{type_, {}}, p.op, p.rhs};
     }
-  } else if (auto lhs = get_if<data_extractor>(p.lhs)) {
+  } else if (auto lhs = caf::get_if<data_extractor>(&p.lhs)) {
     if (lhs->type != type_)
       return {};
   }
@@ -523,25 +525,25 @@ bool event_evaluator::operator()(none) {
 
 bool event_evaluator::operator()(const conjunction& c) {
   for (auto& op : c)
-    if (!visit(*this, op))
+    if (!caf::visit(*this, op))
       return false;
   return true;
 }
 
 bool event_evaluator::operator()(const disjunction& d) {
   for (auto& op : d)
-    if (visit(*this, op))
+    if (caf::visit(*this, op))
       return true;
   return false;
 }
 
 bool event_evaluator::operator()(const negation& n) {
-  return !visit(*this, n.expr());
+  return !caf::visit(*this, n.expr());
 }
 
 bool event_evaluator::operator()(const predicate& p) {
   op_ = p.op;
-  return visit(*this, p.lhs, p.rhs);
+  return caf::visit(*this, p.lhs, p.rhs);
 }
 
 bool event_evaluator::operator()(const attribute_extractor& e, const data& d) {
@@ -585,25 +587,25 @@ bool matcher::operator()(none) {
 
 bool matcher::operator()(const conjunction& c) {
   for (auto& op : c)
-    if (!visit(*this, op))
+    if (!caf::visit(*this, op))
       return false;
   return true;
 }
 
 bool matcher::operator()(const disjunction& d) {
   for (auto& op : d)
-    if (visit(*this, op))
+    if (caf::visit(*this, op))
       return true;
   return false;
 }
 
 bool matcher::operator()(const negation& n) {
-  return visit(*this, n.expr());
+  return caf::visit(*this, n.expr());
 }
 
 bool matcher::operator()(const predicate& p) {
   op_ = p.op;
-  return visit(*this, p.lhs, p.rhs);
+  return caf::visit(*this, p.lhs, p.rhs);
 }
 
 bool matcher::operator()(const attribute_extractor& e, const data& d) {

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -194,7 +194,7 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
           VAST_DEBUG(self, "tailored AST to", candidate.type() << ':', checker);
         }
         // Perform candidate check and keep event as result on success.
-        if (visit(event_evaluator{candidate}, checker))
+        if (caf::visit(event_evaluator{candidate}, checker))
           self->state.results.push_back(std::move(candidate));
         else
           VAST_DEBUG(self, "ignores false positive:", candidate);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -60,7 +60,7 @@ void partition_index::add(const std::vector<event> xs, const uuid& partition) {
 std::vector<uuid> partition_index::lookup(const expression& expr) const {
   std::vector<uuid> result;
   for (auto& x : partitions_)
-    if (visit(time_restrictor{x.second.range.from, x.second.range.to}, expr))
+    if (caf::visit(time_restrictor{x.second.range.from, x.second.range.to}, expr))
       result.push_back(x.first);
   return result;
 }

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -196,7 +196,7 @@ struct loader {
   result_type operator()(const disjunction& d) {
     result_type result;
     for (auto& op : d) {
-      auto x = visit(*this, op);
+      auto x = caf::visit(*this, op);
       result.insert(result.end(),
                     std::make_move_iterator(x.begin()),
                     std::make_move_iterator(x.end()));
@@ -205,7 +205,7 @@ struct loader {
   }
 
   result_type operator()(const predicate& p) {
-    return visit(*this, p.lhs, p.rhs);
+    return caf::visit(*this, p.lhs, p.rhs);
   }
 
   result_type operator()(const attribute_extractor& ex, const data& x) {
@@ -337,7 +337,7 @@ behavior event_indexer(stateful_actor<event_indexer_state>* self,
       auto rp = self->make_response_promise<bitmap>();
       // For now, we require that the predicate is part of a normalized
       // expression, i.e., LHS an extractor type and RHS of type data.
-      auto rhs = get_if<data>(pred.rhs);
+      auto rhs = caf::get_if<data>(&pred.rhs);
       VAST_ASSERT(rhs);
       auto resolved = type_resolver{self->state.event_type}(pred);
       if (!resolved) {
@@ -347,7 +347,7 @@ behavior event_indexer(stateful_actor<event_indexer_state>* self,
         return;
       }
 
-      auto indexers = visit(loader{self}, *resolved);
+      auto indexers = caf::visit(loader{self}, *resolved);
       // Forward predicate to all available indexers.
       if (indexers.empty()) {
         VAST_DEBUG(self, "did not find matching indexers for", pred);

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -48,17 +48,17 @@ struct fixture {
 FIXTURE_SCOPE(expr_tests, fixture)
 
 TEST(construction) {
-  auto n = get_if<negation>(expr0);
+  auto n = caf::get_if<negation>(&expr0);
   REQUIRE(n);
-  auto c = get_if<conjunction>(n->expr());
+  auto c = caf::get_if<conjunction>(&n->expr());
   REQUIRE(c);
   REQUIRE(c->size() == 2);
-  auto p0 = get_if<predicate>(c->at(0));
+  auto p0 = caf::get_if<predicate>(&c->at(0));
   REQUIRE(p0);
   CHECK(get<key_extractor>(p0->lhs).key == key{"x", "y", "z"});
   CHECK_EQUAL(p0->op, less_equal);
   CHECK(get<data>(p0->rhs) == data{42});
-  auto p1 = get_if<predicate>(c->at(1));
+  auto p1 = caf::get_if<predicate>(&c->at(1));
   REQUIRE(p1);
   CHECK(get<attribute_extractor>(p1->lhs).attr == attribute{"foo"});
   CHECK_EQUAL(p1->op, equal);
@@ -70,15 +70,15 @@ TEST(serialization) {
   std::vector<char> buf;
   save(buf, expr0, expr1);
   load(buf, ex0, ex1);
-  auto d = get_if<disjunction>(ex1);
+  auto d = caf::get_if<disjunction>(&ex1);
   REQUIRE(d);
   REQUIRE(!d->empty());
-  auto n = get_if<negation>(d->at(0));
+  auto n = caf::get_if<negation>(&d->at(0));
   REQUIRE(n);
-  auto c = get_if<conjunction>(n->expr());
+  auto c = caf::get_if<conjunction>(&n->expr());
   REQUIRE(c);
   REQUIRE_EQUAL(c->size(), 2u);
-  auto p = get_if<predicate>(c->at(1));
+  auto p = caf::get_if<predicate>(&c->at(1));
   REQUIRE(p);
   CHECK_EQUAL(p->op, equal);
 }
@@ -146,47 +146,47 @@ TEST(validation - attribute extractor) {
   // The "type" attribute extractor requires a string operand.
   auto expr = to<expression>("&type == \"foo\"");
   REQUIRE(expr);
-  CHECK(visit(validator{}, *expr));
+  CHECK(caf::visit(validator{}, *expr));
   expr = to<expression>("&type == 42");
   REQUIRE(expr);
-  CHECK(!visit(validator{}, *expr));
+  CHECK(!caf::visit(validator{}, *expr));
   expr = to<expression>("&type == bro::conn");
   REQUIRE(expr);
-  CHECK(!visit(validator{}, *expr));
+  CHECK(!caf::visit(validator{}, *expr));
   // The "time" attribute extractor requires a timestamp operand.
   expr = to<expression>("&time < now");
   REQUIRE(expr);
-  CHECK(visit(validator{}, *expr));
+  CHECK(caf::visit(validator{}, *expr));
   expr = to<expression>("&time < 2017-06-16");
   REQUIRE(expr);
-  CHECK(visit(validator{}, *expr));
+  CHECK(caf::visit(validator{}, *expr));
   expr = to<expression>("&time > -42");
   REQUIRE(expr);
-  CHECK(!visit(validator{}, *expr));
+  CHECK(!caf::visit(validator{}, *expr));
   expr = to<expression>("&time > -42 secs");
   REQUIRE(expr);
-  CHECK(!visit(validator{}, *expr));
+  CHECK(!caf::visit(validator{}, *expr));
 }
 
 TEST(validation - type extractor) {
   auto expr = to<expression>(":port == 443/tcp");
   REQUIRE(expr);
-  CHECK(visit(validator{}, *expr));
+  CHECK(caf::visit(validator{}, *expr));
   expr = to<expression>(":addr in 10.0.0.0/8");
   REQUIRE(expr);
-  CHECK(visit(validator{}, *expr));
+  CHECK(caf::visit(validator{}, *expr));
   expr = to<expression>(":port > -42");
   REQUIRE(expr);
-  CHECK(!visit(validator{}, *expr));
+  CHECK(!caf::visit(validator{}, *expr));
 }
 
 TEST(matcher) {
   auto match = [](const std::string& str, auto&& t) {
     auto expr = to<expression>(str);
     REQUIRE(expr);
-    auto resolved = visit(type_resolver(t), *expr);
+    auto resolved = caf::visit(type_resolver(t), *expr);
     REQUIRE(resolved);
-    return visit(matcher{t}, *resolved);
+    return caf::visit(matcher{t}, *resolved);
   };
   MESSAGE("type extractors");
   CHECK(match(":real < 4.2", real_type{}));

--- a/libvast/test/expression_evaluation.cpp
+++ b/libvast/test/expression_evaluation.cpp
@@ -72,87 +72,87 @@ FIXTURE_SCOPE(evaluation_tests, fixture)
 TEST(evaluation - attributes) {
   auto ast = to<expression>("&time == 2014-01-16+05:30:12");
   REQUIRE(ast);
-  CHECK(visit(event_evaluator{e}, *ast));
+  CHECK(caf::visit(event_evaluator{e}, *ast));
   ast = to<expression>("&time == 2015-01-16+05:30:12"); // slight data change
   REQUIRE(ast);
-  CHECK(!visit(event_evaluator{e}, *ast));
+  CHECK(!caf::visit(event_evaluator{e}, *ast));
   ast = to<expression>("&type == \"foo\"");
   REQUIRE(ast);
-  CHECK(visit(event_evaluator{e}, *ast));
+  CHECK(caf::visit(event_evaluator{e}, *ast));
   ast = to<expression>("! &type == \"bar\"");
   REQUIRE(ast);
-  CHECK(visit(event_evaluator{e}, *ast));
+  CHECK(caf::visit(event_evaluator{e}, *ast));
   ast = to<expression>("&type != \"foo\"");
   REQUIRE(ast);
-  CHECK(!visit(event_evaluator{e}, *ast));
+  CHECK(!caf::visit(event_evaluator{e}, *ast));
 }
 
 TEST(evaluation - types) {
   auto ast = to<expression>(":count == 42");
   REQUIRE(ast);
-  CHECK(visit(event_evaluator{e0}, visit(type_pruner{*foo}, *ast)));
-  CHECK(!visit(event_evaluator{e1}, visit(type_pruner{*bar}, *ast)));
+  CHECK(caf::visit(event_evaluator{e0}, caf::visit(type_pruner{*foo}, *ast)));
+  CHECK(!caf::visit(event_evaluator{e1}, caf::visit(type_pruner{*bar}, *ast)));
   ast = to<expression>(":int != +101");
   REQUIRE(ast);
-  CHECK(visit(event_evaluator{e0}, visit(type_pruner{*foo}, *ast)));
-  CHECK(!visit(event_evaluator{e1}, visit(type_pruner{*bar}, *ast)));
+  CHECK(caf::visit(event_evaluator{e0}, caf::visit(type_pruner{*foo}, *ast)));
+  CHECK(!caf::visit(event_evaluator{e1}, caf::visit(type_pruner{*bar}, *ast)));
   ast = to<expression>(":string ~ /bar/ && :int == +100");
   REQUIRE(ast);
-  CHECK(visit(event_evaluator{e0}, visit(type_pruner{*foo}, *ast)));
-  CHECK(!visit(event_evaluator{e1}, visit(type_pruner{*bar}, *ast)));
+  CHECK(caf::visit(event_evaluator{e0}, caf::visit(type_pruner{*foo}, *ast)));
+  CHECK(!caf::visit(event_evaluator{e1}, caf::visit(type_pruner{*bar}, *ast)));
   ast = to<expression>(":real >= -4.8");
   REQUIRE(ast);
-  CHECK(visit(event_evaluator{e0}, visit(type_pruner{*foo}, *ast)));
-  CHECK(!visit(event_evaluator{e1}, visit(type_pruner{*bar}, *ast)));
+  CHECK(caf::visit(event_evaluator{e0}, caf::visit(type_pruner{*foo}, *ast)));
+  CHECK(!caf::visit(event_evaluator{e1}, caf::visit(type_pruner{*bar}, *ast)));
   ast = to<expression>(
     ":int <= -3 || :int >= +100 && :string !~ /bar/ || :real > 1.0");
   REQUIRE(ast);
-  CHECK(visit(event_evaluator{e0}, visit(type_pruner{*foo}, *ast)));
+  CHECK(caf::visit(event_evaluator{e0}, caf::visit(type_pruner{*foo}, *ast)));
   // For the event of type "bar", this expression degenerates to
   // <nil> because it has no numeric types and the first predicate of the
   // conjunction in the middle renders the entire conjunction not viable.
-  CHECK(!visit(event_evaluator{e1}, visit(type_pruner{*bar}, *ast)));
+  CHECK(!caf::visit(event_evaluator{e1}, caf::visit(type_pruner{*bar}, *ast)));
 }
 
 TEST(evaluation - schema) {
   auto ast = to<expression>("foo.s1 == \"babba\" && d1 <= 1337.0");
   REQUIRE(ast);
-  auto ast_resolved = visit(type_resolver{*foo}, *ast);
+  auto ast_resolved = caf::visit(type_resolver{*foo}, *ast);
   REQUIRE(ast_resolved);
-  CHECK(visit(event_evaluator{e0}, *ast_resolved));
-  CHECK(!visit(event_evaluator{e1}, *ast_resolved));
+  CHECK(caf::visit(event_evaluator{e0}, *ast_resolved));
+  CHECK(!caf::visit(event_evaluator{e1}, *ast_resolved));
   ast = to<expression>("s1 != \"cheetah\"");
   REQUIRE(ast);
-  ast_resolved = visit(type_resolver{*foo}, *ast);
+  ast_resolved = caf::visit(type_resolver{*foo}, *ast);
   REQUIRE(ast_resolved);
-  CHECK(visit(event_evaluator{e0}, *ast_resolved));
-  ast_resolved = visit(type_resolver{*bar}, *ast);
+  CHECK(caf::visit(event_evaluator{e0}, *ast_resolved));
+  ast_resolved = caf::visit(type_resolver{*bar}, *ast);
   REQUIRE(ast_resolved);
-  CHECK(visit(event_evaluator{e1}, *ast_resolved));
+  CHECK(caf::visit(event_evaluator{e1}, *ast_resolved));
   ast = to<expression>("d1 > 0.5");
   REQUIRE(ast);
-  ast_resolved = visit(type_resolver{*foo}, *ast);
+  ast_resolved = caf::visit(type_resolver{*foo}, *ast);
   REQUIRE(ast_resolved);
-  CHECK(visit(event_evaluator{e0}, *ast_resolved));
-  CHECK(!visit(event_evaluator{e1}, *ast_resolved));
+  CHECK(caf::visit(event_evaluator{e0}, *ast_resolved));
+  CHECK(!caf::visit(event_evaluator{e1}, *ast_resolved));
   ast = to<expression>("r.b == F");
   REQUIRE(ast);
-  ast_resolved = visit(type_resolver{*bar}, *ast);
+  ast_resolved = caf::visit(type_resolver{*bar}, *ast);
   REQUIRE(ast_resolved);
-  CHECK(visit(event_evaluator{e1}, *ast_resolved));
+  CHECK(caf::visit(event_evaluator{e1}, *ast_resolved));
   MESSAGE("error cases");
   // Invalid prefix.
   ast = to<expression>("not.there ~ /nil/");
   REQUIRE(ast);
-  ast_resolved = visit(type_resolver{*foo}, *ast);
+  ast_resolved = caf::visit(type_resolver{*foo}, *ast);
   REQUIRE(ast_resolved);
-  CHECK(is<none>(*ast_resolved));
+  CHECK(caf::holds_alternative<none>(*ast_resolved));
   // 'q' doesn't exist in 'r'.
   ast = to<expression>("r.q == 80/tcp");
   REQUIRE(ast);
-  ast_resolved = visit(type_resolver{*bar}, *ast);
+  ast_resolved = caf::visit(type_resolver{*bar}, *ast);
   REQUIRE(ast_resolved);
-  CHECK(is<none>(*ast_resolved));
+  CHECK(caf::holds_alternative<none>(*ast_resolved));
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/json.cpp
+++ b/libvast/test/json.cpp
@@ -25,33 +25,31 @@ using namespace vast;
 using namespace std::string_literals;
 
 TEST(construction) {
-  CHECK(is<json::null>(json{}));
-  CHECK(is<json::null>(json{nil}));
-  CHECK(is<json::boolean>(json{true}));
-  CHECK(is<json::boolean>(json{false}));
-  CHECK(is<json::number>(json{4.2}));
-  CHECK(is<json::number>(json{42u}));
-  CHECK(is<json::number>(json{-1337}));
-  CHECK(is<json::string>(json{"foo"}));
-  CHECK(is<json::string>(json{"foo"s}));
-  CHECK(is<json::array>(json{json::array{{1, 2, 3}}}));
-  CHECK(is<json::object>(json{json::object{{"foo", 42}}}));
+  CHECK(json{}.is<json::null>());
+  CHECK(json{caf::none}.is<json::null>());
+  CHECK(json{true}.is<json::boolean>());
+  CHECK(json{42}.is<json::number>());
+  CHECK(json{4.2}.is<json::number>());
+  CHECK(json{"foo"}.is<json::string>());
+  CHECK(json{"foo"s}.is<json::string>());
+  CHECK(json{json::array{{1, 2, 3}}}.is<json::array>());
+  CHECK(json{json::object{{"foo", 42}}}.is<json::object>());
 }
 
 TEST(assignment) {
   json j;
-  j = nil;
-  CHECK(is<json::null>(j));
+  j = caf::none;
+  CHECK(caf::holds_alternative<json::null>(j.value()));
   j = true;
-  CHECK(is<json::boolean>(j));
+  CHECK(caf::holds_alternative<json::boolean>(j.value()));
   j = 42;
-  CHECK(is<json::number>(j));
+  CHECK(caf::holds_alternative<json::number>(j.value()));
   j = "foo";
-  CHECK(is<std::string>(j));
+  CHECK(caf::holds_alternative<std::string>(j.value()));
   j = json::array{true, false};
-  CHECK(is<json::array>(j));
+  CHECK(caf::holds_alternative<json::array>(j.value()));
   j = json::object{{"x", true}, {"y", false}};
-  CHECK(is<json::object>(j));
+  CHECK(caf::holds_alternative<json::object>(j.value()));
 }
 
 TEST(total order) {
@@ -84,7 +82,7 @@ TEST(parseable) {
   MESSAGE("null");
   str = "null";
   CHECK(parsers::json(str, j));
-  CHECK(j == nil);
+  CHECK(j == caf::none);
   MESSAGE("number");
   str = "42";
   CHECK(parsers::json(str, j));
@@ -108,7 +106,7 @@ TEST(parseable) {
   CHECK(j == json::array{});
   str = R"([ 42,-1337 , "foo", null ,true ])";
   CHECK(parsers::json(str, j));
-  CHECK(j == json::array{42, -1337, "foo", nil, true});
+  CHECK(j == json::array{42, -1337, "foo", caf::none, true});
   MESSAGE("object");
   str = "{}";
   CHECK(parsers::json(str, j));
@@ -118,7 +116,7 @@ TEST(parseable) {
   CHECK(j == json::object{});
   str = R"json({ "baz": 4.2, "inner": null })json";
   CHECK(parsers::json(str, j));
-  CHECK(j == json::object{{"baz", 4.2}, {"inner", nil}});
+  CHECK(j == json::object{{"baz", 4.2}, {"inner", caf::none}});
   str = R"json({
   "baz": 4.2,
   "inner": null,
@@ -132,7 +130,7 @@ TEST(parseable) {
   CHECK(parsers::json(str, j));
   auto o = json::object{
     {"baz", 4.2},
-    {"inner", nil},
+    {"inner", caf::none},
     {"x", json::array{42, -1337, "foo", true}}
   };
   CHECK(j == o);
@@ -148,12 +146,12 @@ TEST(printable) {
   CHECK_EQUAL(to_string(json{"foo"}), "\"foo\"");
   MESSAGE("one line policy");
   std::string line;
-  json::array a{42, -1337, "foo", nil, true};
+  json::array a{42, -1337, "foo", caf::none, true};
   CHECK(printers::json<policy::oneline>(line, json{a}));
   CHECK_EQUAL(line, "[42, -1337, \"foo\", null, true]");
   json::object o;
   o["foo"] = 42;
-  o["bar"] = nil;
+  o["bar"] = caf::none;
   line.clear();
   CHECK(printers::json<policy::oneline>(line, json{o}));
   CHECK_EQUAL(line, "{\"foo\": 42, \"bar\": null}");

--- a/libvast/test/json.cpp
+++ b/libvast/test/json.cpp
@@ -25,31 +25,31 @@ using namespace vast;
 using namespace std::string_literals;
 
 TEST(construction) {
-  CHECK(json{}.is<json::null>());
-  CHECK(json{caf::none}.is<json::null>());
-  CHECK(json{true}.is<json::boolean>());
-  CHECK(json{42}.is<json::number>());
-  CHECK(json{4.2}.is<json::number>());
-  CHECK(json{"foo"}.is<json::string>());
-  CHECK(json{"foo"s}.is<json::string>());
-  CHECK(json{json::array{{1, 2, 3}}}.is<json::array>());
-  CHECK(json{json::object{{"foo", 42}}}.is<json::object>());
+  CHECK(caf::holds_alternative<json::null>(json{}));
+  CHECK(caf::holds_alternative<json::null>(json{caf::none}));
+  CHECK(caf::holds_alternative<json::boolean>(json{true}));
+  CHECK(caf::holds_alternative<json::number>(json{42}));
+  CHECK(caf::holds_alternative<json::number>(json{4.2}));
+  CHECK(caf::holds_alternative<json::string>(json{"foo"}));
+  CHECK(caf::holds_alternative<json::string>(json{"foo"s}));
+  CHECK(caf::holds_alternative<json::array>(json{json::array{{1, 2, 3}}}));
+  CHECK(caf::holds_alternative<json::object>(json{json::object{{"foo", 42}}}));
 }
 
 TEST(assignment) {
   json j;
   j = caf::none;
-  CHECK(caf::holds_alternative<json::null>(j.value()));
+  CHECK(caf::holds_alternative<json::null>(j));
   j = true;
-  CHECK(caf::holds_alternative<json::boolean>(j.value()));
+  CHECK(caf::holds_alternative<json::boolean>(j));
   j = 42;
-  CHECK(caf::holds_alternative<json::number>(j.value()));
+  CHECK(caf::holds_alternative<json::number>(j));
   j = "foo";
-  CHECK(caf::holds_alternative<std::string>(j.value()));
+  CHECK(caf::holds_alternative<std::string>(j));
   j = json::array{true, false};
-  CHECK(caf::holds_alternative<json::array>(j.value()));
+  CHECK(caf::holds_alternative<json::array>(j));
   j = json::object{{"x", true}, {"y", false}};
-  CHECK(caf::holds_alternative<json::object>(j.value()));
+  CHECK(caf::holds_alternative<json::object>(j));
 }
 
 TEST(total order) {

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -51,7 +51,7 @@ TEST(set view) {
   REQUIRE_EQUAL(v->size(), xs.size());
   MESSAGE("check view contents");
   for (auto i = 0u; i < xs.size(); ++i)
-    CHECK_EQUAL(v->at(i), *std::next(xs.begin(), i));
+    CHECK_EQUAL(v->at(i), make_data_view(*std::next(xs.begin(), i)));
   MESSAGE("check iterator semantics");
   CHECK_EQUAL(std::next(v->begin(), 3), v->end());
   CHECK_EQUAL(*std::next(v->begin(), 1), make_data_view(42));
@@ -75,15 +75,15 @@ TEST(map view) {
 
 TEST(make_data_view) {
   auto x = make_data_view(true);
-  CHECK(std::holds_alternative<boolean>(x));
+  CHECK(caf::holds_alternative<boolean>(x));
   auto str = "foo"s;
   x = make_data_view(str);
-  CHECK(std::holds_alternative<view_t<std::string>>(x));
-  CHECK(std::holds_alternative<std::string_view>(x));
+  CHECK(caf::holds_alternative<view_t<std::string>>(x));
+  CHECK(caf::holds_alternative<std::string_view>(x));
   auto xs = vector{42, true, "foo"};
   x = make_data_view(xs);
-  REQUIRE(std::holds_alternative<view_t<vector>>(x));
-  auto v = get<view_t<vector>>(x);
+  REQUIRE(caf::holds_alternative<view_t<vector>>(x));
+  auto v = caf::get<view_t<vector>>(x);
   REQUIRE_EQUAL(v->size(), 3u);
   CHECK_EQUAL(v->at(0), 42);
   CHECK_EQUAL(v->at(1), true);

--- a/libvast/vast/concept/parseable/vast/json.hpp
+++ b/libvast/vast/concept/parseable/vast/json.hpp
@@ -35,15 +35,15 @@ struct json_parser : parser<json_parser> {
     auto lbrace = ws >> '{' >> ws;
     auto rbrace = ws >> '}' >> ws;
     auto delim = ws >> ',' >> ws;
-    auto null = ws >> "null"_p ->* [] { return nil; };
-    auto true_false = ws >> parsers::boolean;
+    auto null = ws >> "null"_p ->* [] { return json::null{}; };
+    auto boolean = ws >> parsers::boolean;
     auto string = ws >> parsers::qq_str;
     auto number = ws >> parsers::real_opt_dot;
     auto array = as<json::array>(lbracket >> ~(j % delim) >> rbracket);
     auto key_value = ws >> string >> ws >> ':' >> ws >> j;
     auto object = as<json::object>(lbrace >> ~(key_value % delim) >> rbrace);
     j = null
-      | true_false
+      | boolean
       | number
       | string
       | array
@@ -65,4 +65,3 @@ static auto const json = make_parser<vast::json>();
 } // namespace parsers
 
 } // namespace vast
-

--- a/libvast/vast/concept/printable/vast/expression.hpp
+++ b/libvast/vast/concept/printable/vast/expression.hpp
@@ -57,7 +57,9 @@ struct expression_printer : printer<expression_printer> {
 
     bool operator()(const predicate& p) const {
       auto op = ' ' << make_printer<relational_operator>{} << ' ';
-      return visit(*this, p.lhs) && op(out_, p.op) && visit(*this, p.rhs);
+      return caf::visit(*this, p.lhs)
+             && op(out_, p.op)
+             && caf::visit(*this, p.rhs);
     }
 
     bool operator()(const attribute_extractor& e) const {
@@ -95,15 +97,13 @@ struct expression_printer : printer<expression_printer> {
          || std::is_same_v<T, disjunction>
          || std::is_same_v<T, negation>,
          bool
-       >
-  {
+       > {
     return visitor<Iterator>{out}(x);
   }
 
   template <class Iterator>
-  bool print(Iterator& out, const expression& e) const
-  {
-    return visit(visitor<Iterator>{out}, e);
+  bool print(Iterator& out, const expression& e) const {
+    return caf::visit(visitor<Iterator>{out}, e);
   }
 };
 
@@ -120,10 +120,8 @@ struct printer_registry<
     || std::is_same_v<T, negation>
     || std::is_same_v<T, expression>
   >
->
-{
+> {
   using type = expression_printer;
 };
 
 } // namespace vast
-

--- a/libvast/vast/concept/printable/vast/json.hpp
+++ b/libvast/vast/concept/printable/vast/json.hpp
@@ -106,7 +106,7 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
       while (begin != end) {
         if (!indent())
           return false;
-        if (!caf::visit(*this, begin->value()))
+        if (!caf::visit(*this, *begin))
           return false;
         ;
         ++begin;
@@ -143,7 +143,7 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
           return false;
         if (!str.print(out_, ": "))
           return false;
-        if (!caf::visit(*this, begin->second.value()))
+        if (!caf::visit(*this, begin->second))
           return false;
         ++begin;
         if (begin != end)
@@ -191,7 +191,7 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
 
   template <class Iterator>
   bool print(Iterator& out, const json& j) const {
-    return caf::visit(print_visitor<Iterator>{out}, j.value());
+    return caf::visit(print_visitor<Iterator>{out}, j);
   }
 };
 

--- a/libvast/vast/concept/printable/vast/json.hpp
+++ b/libvast/vast/concept/printable/vast/json.hpp
@@ -13,11 +13,13 @@
 
 #pragma once
 
+#include "vast/json.hpp"
+
 #include "vast/concept/printable/print.hpp"
 #include "vast/concept/printable/string.hpp"
 #include "vast/concept/printable/core/printer.hpp"
+
 #include "vast/detail/string.hpp"
-#include "vast/json.hpp"
 
 namespace vast {
 
@@ -65,11 +67,11 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
   struct print_visitor {
     print_visitor(Iterator& out) : out_{out} {}
 
-    bool operator()(const none&) {
+    bool operator()(json::null) {
       return printers::str.print(out_, "null");
     }
 
-    bool operator()(bool b) {
+    bool operator()(json::boolean b) {
       return printers::str.print(out_, b ? "true" : "false");
     }
 
@@ -85,7 +87,7 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
       return printers::str.print(out_, str);
     }
 
-    bool operator()(const std::string& str) {
+    bool operator()(const json::string& str) {
       return printers::str.print(out_, detail::json_escape(str));
     }
 
@@ -104,7 +106,7 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
       while (begin != end) {
         if (!indent())
           return false;
-        if (!visit(*this, *begin))
+        if (!caf::visit(*this, begin->value()))
           return false;
         ;
         ++begin;
@@ -141,7 +143,7 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
           return false;
         if (!str.print(out_, ": "))
           return false;
-        if (!visit(*this, begin->second))
+        if (!caf::visit(*this, begin->second.value()))
           return false;
         ++begin;
         if (begin != end)
@@ -181,18 +183,15 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
     int depth_ = 0;
   };
 
+  // Overload for concrete JSON types.
   template <class Iterator, class T>
-  auto print(Iterator& out, const T& x) const
-  -> std::enable_if_t<
-    !std::is_same_v<json::jsonize<T>, std::false_type>,
-    bool
-  > {
+  bool print(Iterator& out, const T& x) const {
     return print_visitor<Iterator>{out}(x);
   }
 
   template <class Iterator>
   bool print(Iterator& out, const json& j) const {
-    return visit(print_visitor<Iterator>{out}, j);
+    return caf::visit(print_visitor<Iterator>{out}, j.value());
   }
 };
 

--- a/libvast/vast/expression.hpp
+++ b/libvast/vast/expression.hpp
@@ -18,15 +18,20 @@
 #include <type_traits>
 #include <vector>
 
+#include <caf/variant.hpp>
+#include <caf/default_sum_type_access.hpp>
+#include <caf/detail/type_list.hpp>
+
 #include "vast/data.hpp"
 #include "vast/key.hpp"
 #include "vast/offset.hpp"
 #include "vast/operator.hpp"
 #include "vast/type.hpp"
-#include "vast/variant.hpp"
 
 #include "vast/concept/hashable/uhash.hpp"
 #include "vast/concept/hashable/xxhash.hpp"
+
+#include "vast/detail/operators.hpp"
 
 namespace vast {
 
@@ -64,7 +69,7 @@ struct key_extractor : detail::totally_ordered<key_extractor> {
   }
 };
 
-/// Extracts one or more values according to a given key.
+/// Extracts one or more values according to a given type.
 struct type_extractor : detail::totally_ordered<type_extractor> {
   type_extractor(vast::type t = {});
 
@@ -81,7 +86,7 @@ struct type_extractor : detail::totally_ordered<type_extractor> {
 
 /// Extracts a specific data value from a type according to an offset. During
 /// AST resolution, the ::key_extractor generates multiple instantiations of
-/// this extractor according to a given ::schema.
+/// this extractor for a given ::schema.
 struct data_extractor : detail::totally_ordered<data_extractor> {
   data_extractor() = default;
 
@@ -103,7 +108,8 @@ struct data_extractor : detail::totally_ordered<data_extractor> {
 struct predicate : detail::totally_ordered<predicate> {
   predicate() = default;
 
-  using operand = variant<
+  /// The operand of a predicate, which can be either LHS or RHS.
+  using operand = caf::variant<
       attribute_extractor,
       key_extractor,
       type_extractor,
@@ -165,16 +171,16 @@ private:
 
 /// A query expression.
 class expression : detail::totally_ordered<expression> {
-  friend access;
-
 public:
-  using node = variant<
+  using types = caf::detail::type_list<
     none,
     conjunction,
     disjunction,
     negation,
     predicate
   >;
+
+  using node = caf::detail::tl_apply_t<types, caf::variant>;
 
   /// Default-constructs empty an expression.
   expression(none = nil) {
@@ -184,10 +190,18 @@ public:
   /// @param x The node to construct an expression from.
   template <
     class T,
-    class = std::enable_if_t<detail::contains<std::decay_t<T>, node::types>{}>
+    class = std::enable_if_t<
+      caf::detail::tl_contains<types, std::decay_t<T>>::value
+    >
   >
-  expression(T&& x) : node_{std::forward<T>(x)} {
+  expression(T&& x) : node_(std::forward<T>(x)) {
+    // nop
   }
+
+  // -- concepts ---------------------------------------------------------------
+
+  const node& data() const;
+  node& data();
 
   friend bool operator==(const expression& lhs, const expression& rhs);
   friend bool operator<(const expression& lhs, const expression& rhs);
@@ -196,8 +210,6 @@ public:
   friend auto inspect(Inspector&f, expression& e) {
     return f(e.node_);
   }
-
-  friend node& expose(expression& d);
 
 private:
   node node_;
@@ -225,7 +237,17 @@ expected<expression> normalize_and_validate(const expression& expr);
 ///          of type *t*.
 expected<expression> tailor(const expression& expr, const type& t);
 
-} // namespace vast
+} // namespace vast 
+
+namespace caf {
+
+template <>
+struct sum_type_access<vast::expression>
+    : default_sum_type_access<vast::expression> {
+  // nop
+};
+
+} // namespace caf
 
 namespace std {
 

--- a/libvast/vast/expression.hpp
+++ b/libvast/vast/expression.hpp
@@ -243,7 +243,7 @@ namespace caf {
 
 template <>
 struct sum_type_access<vast::expression>
-    : default_sum_type_access<vast::expression> {
+  : default_sum_type_access<vast::expression> {
   // nop
 };
 
@@ -294,4 +294,3 @@ struct hash<vast::expression> {
 };
 
 } // namespace std
-

--- a/libvast/vast/json.hpp
+++ b/libvast/vast/json.hpp
@@ -16,19 +16,23 @@
 #include <string>
 #include <vector>
 
+#include <caf/none.hpp>
+#include <caf/variant.hpp>
+
 #include "vast/concept/printable/to.hpp"
+
 #include "vast/detail/operators.hpp"
 #include "vast/detail/steady_map.hpp"
-#include "vast/none.hpp"
-#include "vast/variant.hpp"
+#include "vast/detail/type_traits.hpp"
 
 namespace vast {
 
 /// A JSON data type.
 class json : detail::totally_ordered<json> {
+
 public:
   /// A JSON null type.
-  using null = none;
+  using null = caf::none_t;
 
   /// A JSON bool.
   using boolean = bool;
@@ -40,93 +44,25 @@ public:
   using string = std::string;
 
   /// A JSON array.
-  struct array;
-
-  /// A JSON object.
-  struct object;
-
-  /// Meta-function that converts a type into a JSON value.
-  /// If conversion is impossible it returns `std::false_type`.
-  template <class T>
-  using json_value = std::conditional_t<
-    std::is_same_v<T, none>,
-    null,
-    std::conditional_t<
-      std::is_same_v<T, bool>,
-      boolean,
-      std::conditional_t<
-        std::is_convertible_v<T, number>,
-        number,
-        std::conditional_t<
-          std::is_convertible_v<T, std::string>,
-          string,
-          std::conditional_t<
-            std::is_same_v<T, array>,
-            array,
-            std::conditional_t<
-              std::is_same_v<T, object>,
-              object,
-              std::false_type
-            >
-          >
-        >
-      >
-    >
-  >;
-
-  /// Maps an arbitrary type to a json type.
-  template <class T>
-  using jsonize = json_value<std::decay_t<T>>;
-
-  /// A sequence of JSON values.
   struct array : std::vector<json> {
     using super = std::vector<json>;
     using super::vector;
-
     array() = default;
-
-    array(const super& s) : super(s) {
-    }
-
-    array(super&& s) : super(std::move(s)) {
-    }
+    array(const super& s) : super(s) {}
+    array(super&& s) : super(std::move(s)) {}
   };
 
-  /// An associative data structure exposing key-value pairs with unique keys.
-  struct object : detail::steady_map<string, json> {
-    using super = detail::steady_map<string, json>;
+  /// A JSON object.
+  struct object : detail::steady_map<std::string, json> {
+    using super = detail::steady_map<std::string, json>;
     using super::vector_map;
-
     object() = default;
-
-    object(const super& s) : super(s) {
-    }
-
-    object(super&& s) : super(std::move(s)) {
-    }
+    object(const super& s) : super(s) {}
+    object(super&& s) : super(std::move(s)) {}
   };
 
-  /// Default-constructs a null JSON value.
-  json() = default;
-
-  /// Constructs a JSON value.
-  /// @tparam The JSON type.
-  /// @param x A JSON type.
-  template <
-    class T,
-    class =
-      std::enable_if_t<!std::is_same_v<std::false_type, jsonize<T>>>
-  >
-  json(T&& x)
-    : value_(jsonize<T>(std::forward<T>(x))) {
-  }
-
-  friend auto& expose(json& j) {
-    return j.value_;
-  }
-
-private:
-  using variant_type = variant<
+  /// The sum type of all possible JSON types.
+  using data = caf::variant<
     null,
     boolean,
     number,
@@ -135,64 +71,120 @@ private:
     object
   >;
 
-  variant_type value_;
+  /// Default-constructs a null JSON value.
+  json() = default;
 
-private:
-  struct less_than {
-    template <class T>
-    bool operator()(const T& x, const T& y) {
-      return x < y;
-    }
+  /// Constructs a JSON value.
+  /// @tparam The JSON type.
+  /// @param x A JSON type.
+  template <class T, class>
+  json(T&& x);
 
-    template <class T, class U>
-    bool operator()(const T&, const U&) {
-      return false;
-    }
-  };
+  /// @returns The data variant containing the types.
+  data& value() {
+    return data_;
+  }
 
-  struct equals {
-    template <class T>
-    bool operator()(const T& x, const T& y) {
-      return x == y;
-    }
+  /// @returns The data variant containing the types.
+  const data& value() const {
+    return data_;
+  }
 
-    template <class T, class U>
-    bool operator()(const T&, const U&) {
-      return false;
-    }
-  };
-
-  friend bool operator<(const json& x, const json& y) {
-    if (x.value_.index() == y.value_.index())
-      return visit(less_than{}, x.value_, y.value_);
-    else
-      return x.value_.index() < y.value_.index();
+  /// Checks whether a JSON value is of a certain type.
+  /// @tparam T the type to test.
+  /// @returns `true` iff the value of *this* is of type `T`.
+  template <class T>
+  bool is() const {
+    return caf::holds_alternative<T>(data_);
   }
 
   friend bool operator==(const json& x, const json& y) {
-    return visit(equals{}, x.value_, y.value_);
+    return x.data_ == y.data_;
   }
+
+  friend bool operator<(const json& x, const json& y) {
+    return x.data_ < y.data_;
+  }
+
+private:
+  data data_;
 };
 
+namespace detail {
+
+template <class, class = void>
+struct jsonize_helper : std::false_type {};
+
+template <>
+struct jsonize_helper<caf::none_t> {
+  using type = json::null;
+};
+
+template <>
+struct jsonize_helper<bool> {
+  using type = json::boolean;
+};
+
+template <class T>
+struct jsonize_helper<
+  T,
+  std::enable_if_t<std::is_convertible_v<T, json::number>>
+> {
+  using type = json::number;
+};
+
+template <class T>
+struct jsonize_helper<
+  T,
+  std::enable_if_t<std::is_convertible_v<T, std::string>>
+> {
+  using type = json::string;
+};
+
+template <>
+struct jsonize_helper<json::array> {
+  using type = json::array;
+};
+
+template <>
+struct jsonize_helper<json::object> {
+  using type = json::object;
+};
+
+} // namespace detail
+
+/// Converts an arbitrary type to the corresponding JSON type.
+/// @relates json
+template <class T>
+using jsonize = typename detail::jsonize_helper<std::decay_t<T>>::type;
+
+template <
+  class T,
+  class = std::enable_if_t<std::is_convertible_v<T, jsonize<T>>>
+>
+json::json(T&& x) : data_(jsonize<T>(std::forward<T>(x))) {
+  // nop
+}
+
+/// @relates json
 inline bool convert(bool b, json& j) {
-  j = b;
+  j = json::boolean{b};
   return true;
 }
 
+/// @relates json
 template <class T>
 bool convert(T x, json& j) {
-  if constexpr (std::is_arithmetic_v<T>) {
+  if constexpr (std::is_arithmetic_v<T>)
     j = json::number(x);
-    return true;
-  } else if constexpr (std::is_convertible_v<T, std::string>) {
-    j = std::string{std::forward<T>(x)};
-    return true;
-  } else {
-    static_assert(!std::is_same_v<T, T>,
-                  "T is neither arithmetic nor convertible to std::string");
-  }
+  else if constexpr (std::is_convertible_v<T, std::string>)
+    j = std::string(std::forward<T>(x));
+  else
+    static_assert(detail::always_false_v<T>);
+  return true;
 }
 
+/// @relates json
 template <class T>
 bool convert(const std::vector<T>& v, json& j) {
   json::array a;
@@ -206,6 +198,7 @@ bool convert(const std::vector<T>& v, json& j) {
   return true;
 }
 
+/// @relates json
 template <class K, class V>
 bool convert(const std::map<K, V>& m, json& j) {
   json::object o;
@@ -220,6 +213,7 @@ bool convert(const std::map<K, V>& m, json& j) {
   return true;
 }
 
+/// @relates json
 template <class T, class... Opts>
 json to_json(const T& x, Opts&&... opts) {
   json j;
@@ -229,4 +223,3 @@ json to_json(const T& x, Opts&&... opts) {
 }
 
 } // namespace vast
-

--- a/libvast/vast/json.hpp
+++ b/libvast/vast/json.hpp
@@ -18,6 +18,7 @@
 
 #include <caf/none.hpp>
 #include <caf/variant.hpp>
+#include <caf/detail/type_list.hpp>
 
 #include "vast/concept/printable/to.hpp"
 
@@ -29,7 +30,6 @@ namespace vast {
 
 /// A JSON data type.
 class json : detail::totally_ordered<json> {
-
 public:
   /// A JSON null type.
   using null = caf::none_t;
@@ -62,7 +62,7 @@ public:
   };
 
   /// The sum type of all possible JSON types.
-  using data = caf::variant<
+  using types = caf::detail::type_list<
     null,
     boolean,
     number,
@@ -70,6 +70,9 @@ public:
     array,
     object
   >;
+
+  /// The sum type of all possible JSON types.
+  using variant = caf::detail::tl_apply_t<types, caf::variant>;
 
   /// Default-constructs a null JSON value.
   json() = default;
@@ -80,22 +83,14 @@ public:
   template <class T, class>
   json(T&& x);
 
-  /// @returns The data variant containing the types.
-  data& value() {
+  // -- concepts --------------------------------------------------------------
+
+  variant& data() {
     return data_;
   }
 
-  /// @returns The data variant containing the types.
-  const data& value() const {
+  const variant& data() const {
     return data_;
-  }
-
-  /// Checks whether a JSON value is of a certain type.
-  /// @tparam T the type to test.
-  /// @returns `true` iff the value of *this* is of type `T`.
-  template <class T>
-  bool is() const {
-    return caf::holds_alternative<T>(data_);
   }
 
   friend bool operator==(const json& x, const json& y) {
@@ -107,7 +102,7 @@ public:
   }
 
 private:
-  data data_;
+  variant data_;
 };
 
 namespace detail {
@@ -223,3 +218,10 @@ json to_json(const T& x, Opts&&... opts) {
 }
 
 } // namespace vast
+
+namespace caf {
+
+template <>
+struct sum_type_access<vast::json> : default_sum_type_access<vast::json> {};
+
+} // namespace caf

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -107,14 +107,14 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader&& reader) {
       while (self->state.events.size() < self->state.batch_size) {
         auto e = self->state.reader.read();
         if (e) {
-          if (!is<none>(self->state.filter)) {
+          if (!caf::holds_alternative<none>(self->state.filter)) {
             auto& checker = self->state.checkers[e->type()];
-            if (is<none>(checker)) {
+            if (caf::holds_alternative<none>(checker)) {
               auto x = tailor(self->state.filter, e->type());
               VAST_ASSERT(x);
               checker = std::move(*x);
             }
-            if (!visit(event_evaluator{*e}, checker))
+            if (!caf::visit(event_evaluator{*e}, checker))
               continue;
           }
           self->state.events.push_back(std::move(*e));

--- a/libvast/vast/view.hpp
+++ b/libvast/vast/view.hpp
@@ -15,11 +15,11 @@
 #include <cstdint>
 #include <string>
 #include <type_traits>
-#include <variant>
 
 #include <caf/intrusive_ptr.hpp>
 #include <caf/make_counted.hpp>
 #include <caf/ref_counted.hpp>
+#include <caf/variant.hpp>
 
 #include "vast/aliases.hpp"
 #include "vast/data.hpp"
@@ -189,7 +189,7 @@ struct view<map> {
 
 /// A type-erased view over variout types of data.
 /// @relates view
-using data_view = std::variant<
+using data_view = caf::variant<
   view_t<boolean>,
   view_t<integer>,
   view_t<count>,


### PR DESCRIPTION
This PR converts the various sum types in VAST from `vast::variant` or `std::variant` to `caf::variant`.

Types to convert:
- [x] `vast::json`
- [x] `vast::view`
- [x] `vast::bitmap`
- [x] `vast::expression`
- [ ] `vast::data`
- [ ] `vast::type`

Cleanup:
- [x] Make sure all variant types model the `SumType` concept in CAF.
- [ ] Remove `vast::variant`