### PR TITLE
Make set and map types aliases flat and steady

### DIFF
--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -207,7 +207,7 @@ TEST(serialization) {
   save(buf, d0);
   load(buf, d1);
   CHECK(d0 == d1);
-  CHECK(to_string(d1) == "{8/icmp, 53/udp, 80/tcp}");
+  CHECK(to_string(d1) == "{80/tcp, 53/udp, 8/icmp}");
 }
 
 TEST(printable) {
@@ -296,7 +296,7 @@ TEST(parseable) {
   l = str.end();
   CHECK(p(f, l, d));
   CHECK(f == l);
-  CHECK(d == set{-42, -1, 42});
+  CHECK(d == set{-42, 42, -1});
 
   MESSAGE("map");
   str = "{T->1,F->0}"s;

--- a/libvast/test/value.cpp
+++ b/libvast/test/value.cpp
@@ -124,7 +124,7 @@ TEST(serialization) {
   save(buf, v);
   load(buf, w);
   CHECK(v == w);
-  CHECK(to_string(w) == "{8/icmp, 53/udp, 80/tcp}");
+  CHECK(to_string(w) == "{80/tcp, 53/udp, 8/icmp}");
 }
 
 TEST(json)

--- a/libvast/vast/aliases.hpp
+++ b/libvast/vast/aliases.hpp
@@ -20,6 +20,8 @@
 #include <set>
 #include <vector>
 
+#include "vast/detail/steady_set.hpp"
+
 namespace vast {
 
 // -- data -------------------------------------------------------------------
@@ -35,7 +37,7 @@ using real = double;
 using vector = std::vector<data>;
 
 /// A mathematical set where each element is ::data.
-using set = std::set<data>;
+using set = detail::steady_set<data>;
 
 /// An associative array with ::data as both key and value.
 using map = std::map<data, data>;

--- a/libvast/vast/aliases.hpp
+++ b/libvast/vast/aliases.hpp
@@ -15,12 +15,11 @@
 
 #include <cstdint>
 #include <limits>
-#include <map>
 #include <memory>
-#include <set>
 #include <vector>
 
 #include "vast/detail/steady_set.hpp"
+#include "vast/detail/steady_map.hpp"
 
 namespace vast {
 
@@ -40,7 +39,7 @@ using vector = std::vector<data>;
 using set = detail::steady_set<data>;
 
 /// An associative array with ::data as both key and value.
-using map = std::map<data, data>;
+using map = detail::steady_map<data, data>;
 
 // ---------------------------------------------------------------------------
 

--- a/libvast/vast/detail/vector_map.hpp
+++ b/libvast/vast/detail/vector_map.hpp
@@ -18,6 +18,9 @@
 #include <stdexcept>
 #include <vector>
 
+#include "vast/concept/hashable/uhash.hpp"
+#include "vast/concept/hashable/xxhash.hpp"
+
 #include "vast/detail/operators.hpp"
 
 namespace vast::detail {
@@ -221,9 +224,13 @@ public:
     return xs_;
   }
 
+  template <class Inspector>
+  friend auto inspect(Inspector&f, vector_map& xs) {
+    return f(xs.xs_);
+  }
+
 private:
   vector_type xs_;
 };
 
 } // namespace vast::detail
-

--- a/libvast/vast/detail/vector_map.hpp
+++ b/libvast/vast/detail/vector_map.hpp
@@ -18,9 +18,6 @@
 #include <stdexcept>
 #include <vector>
 
-#include "vast/concept/hashable/uhash.hpp"
-#include "vast/concept/hashable/xxhash.hpp"
-
 #include "vast/detail/operators.hpp"
 
 namespace vast::detail {

--- a/libvast/vast/detail/vector_set.hpp
+++ b/libvast/vast/detail/vector_set.hpp
@@ -195,8 +195,8 @@ public:
   }
 
   template <class Inspector>
-  friend auto inspect(Inspector&f, vector_set<T, Allocator, Policy>& x) {
-    return f(x.xs_);
+  friend auto inspect(Inspector&f, vector_set& xs) {
+    return f(xs.xs_);
   }
 
 private:
@@ -204,17 +204,3 @@ private:
 };
 
 } // namespace vast::detail
-
-namespace std {
-
-template <class T, class Allocator, class Policy>
-struct hash<vast::detail::vector_set<T, Allocator, Policy>> {
-  using vector_type = vast::detail::vector_set<T, Allocator, Policy>;
-  size_t operator()(const vector_type& x) const {
-    return vast::uhash<vast::xxhash>{}(
-      static_cast<const typename vector_type::vector_type&>(x));
-  }
-};
-
-} // namespace std
-

--- a/libvast/vast/detail/vector_set.hpp
+++ b/libvast/vast/detail/vector_set.hpp
@@ -16,9 +16,6 @@
 #include <algorithm>
 #include <vector>
 
-#include "vast/concept/hashable/uhash.hpp"
-#include "vast/concept/hashable/xxhash.hpp"
-
 #include "vast/detail/operators.hpp"
 
 namespace vast::detail {


### PR DESCRIPTION
In this PR we replace the type of the  aliases `set` and `map` by a flat steady_set and steady_map because (i) data is immutable, (ii) it is a more cache-friendly data structure, and (iii) set cardinalities are typically small where sequential brute-force access/find is fast enough.

The first commit replaces the type of `set` and the second commit replaces the type of `map`.