### PR TITLE
Outsource command default values to a separate header

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -25,6 +25,7 @@ set(libvast_sources
   src/concept/hashable/crc.cpp
   src/concept/hashable/xxhash.cpp
   src/data.cpp
+  src/defaults.cpp
   src/detail/adjust_resource_consumption.cpp
   src/detail/compressedbuf.cpp
   src/detail/fdinbuf.cpp

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -50,7 +50,7 @@ int command::run(caf::actor_system& sys, option_map& options,
       break;
   }
   // Check for help option.
-  if (get_or<boolean>(options, "help", false)) {
+  if (get_or(options, "help", false)) {
     std::cerr << usage() << std::endl;
     return EXIT_SUCCESS;
   }

--- a/libvast/src/defaults.cpp
+++ b/libvast/src/defaults.cpp
@@ -1,0 +1,26 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/defaults.hpp"
+
+#include "vast/detail/string.hpp"
+#include "vast/detail/system.hpp"
+
+using namespace vast;
+
+namespace vast::defaults {
+
+const std::string root_command_id
+  = std::string{detail::split(detail::hostname(), ".")[0]};
+
+} // namespace vast::defaults

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -28,6 +28,7 @@
 #include "vast/concept/printable/vast/data.hpp"
 
 #include "vast/system/application.hpp"
+#include "vast/defaults.hpp"
 
 #include "vast/detail/adjust_resource_consumption.hpp"
 #include "vast/detail/overload.hpp"
@@ -68,14 +69,15 @@ using namespace caf;
 namespace vast::system {
 
 application::root_command::root_command() {
-  auto id = detail::split(detail::hostname(), ".")[0];
-  add_opt("dir,d", "directory for persistent state", "vast");
-  add_opt("endpoint,e", "node endpoint", ":42000");
+  using namespace vast::defaults;
+  add_opt("dir,d", "directory for persistent state", root_command_dir);
+  add_opt("endpoint,e", "node endpoint", root_command_endpoint);
   // TODO: Remove explicit conversion to a string.
   // This requires to add support for std::string_view in data.
-  add_opt("id,i", "the unique ID of this node", std::string{id});
-  add_opt("node,n", "spawn a node instead of connecting to one", false);
-  add_opt("version,v", "print version and exit", false);
+  add_opt("id,i", "the unique ID of this node", std::string{root_command_id});
+  add_opt("node,n", "spawn a node instead of connecting to one",
+          root_command_node);
+  add_opt("version,v", "print version and exit", root_command_version);
 }
 
 command::proceed_result
@@ -86,7 +88,7 @@ application::root_command::proceed(caf::actor_system& sys, const option_map& opt
   VAST_TRACE(VAST_ARG(options), VAST_ARG("args", begin, end));
   CAF_IGNORE_UNUSED(sys);
   CAF_IGNORE_UNUSED(options);
-  if (get_or(options, "version", false)) {
+  if (get_or(options, "version", vast::defaults::root_command_version)) {
     std::cout << VAST_VERSION << std::endl;
     return stop_successful;
   }

--- a/libvast/src/system/export_command.cpp
+++ b/libvast/src/system/export_command.cpp
@@ -22,6 +22,7 @@
 #endif // VAST_USE_OPENSSL
 
 #include "vast/logger.hpp"
+#include "vast/defaults.hpp"
 
 #include "vast/system/signal_monitor.hpp"
 #include "vast/system/spawn.hpp"
@@ -33,10 +34,13 @@ using namespace std::chrono_literals;
 
 export_command::export_command(command* parent, std::string_view name)
   : node_command{parent, name} {
-  add_opt("continuous,c", "marks a query as continuous", false);
-  add_opt("historical,h", "marks a query as historical", false);
-  add_opt("unified,u", "marks a query as unified", false);
-  add_opt("events,e", "maximum number of results", 0u);
+  using namespace vast::defaults;
+  add_opt("continuous,c", "marks a query as continuous",
+          export_command_continuous);
+  add_opt("historical,h", "marks a query as historical",
+          export_command_historical);
+  add_opt("unified,u", "marks a query as unified", export_command_unified);
+  add_opt("events,e", "maximum number of results", export_command_events);
 }
 
 int export_command::run_impl(actor_system&, const option_map&, argument_iterator,

--- a/libvast/src/system/node_command.cpp
+++ b/libvast/src/system/node_command.cpp
@@ -24,6 +24,7 @@
 
 #include "vast/filesystem.hpp"
 #include "vast/logger.hpp"
+#include "vast/defaults.hpp"
 
 #include "vast/concept/parseable/vast/endpoint.hpp"
 
@@ -45,30 +46,21 @@ node_command::~node_command() {
 
 expected<actor> node_command::spawn_or_connect_to_node(scoped_actor& self,
                                                        const option_map& opts) {
-  if (get_or<bool>(opts, "node", false))
+  if (get_or(opts, "node", vast::defaults::root_command_node))
     return spawn_node(self, opts);
   return connect_to_node(self, opts);
 }
 
 expected<actor> node_command::spawn_node(scoped_actor& self,
                                          const option_map& opts) {
-  // Fetch node ID from config.
-  auto id_opt = get<std::string>(opts, "id");
-  if (!id_opt)
-    return make_error(sec::invalid_argument, "ID missing in options map");
-  auto id = std::move(*id_opt);
-  // Fetch path to persistent state from config.
-  auto dir_opt = get<std::string>(opts, "dir");
-  if (!dir_opt)
-    return make_error(sec::invalid_argument,
-                      "Directory path missing in options map");
-  auto dir = std::move(*dir_opt);
+  auto id = get_or(opts, "id", vast::defaults::root_command_id);
+  auto dir = get_or(opts, "dir", vast::defaults::root_command_dir);
   auto abs_dir = path{dir}.complete();
   VAST_INFO("spawning local node:", id);
   // Pointer to the root command to system::node.
   auto node = self->spawn(system::node, id, abs_dir);
   node_spawned_ = true;
-  if (!get_or<bool>(opts, "bare", false)) {
+  if (!get_or<bool>(opts, "bare", vast::defaults::start_command_bare)) {
     // If we're not in bare mode, we spawn all core actors.
     auto spawn_component = [&](auto&&... xs) {
       return [&] {
@@ -98,26 +90,15 @@ expected<actor> node_command::spawn_node(scoped_actor& self,
 
 expected<actor> node_command::connect_to_node(scoped_actor& self,
                                               const option_map& opts) {
-  // Fetch node ID from config.
-  auto id_opt = get<std::string>(opts, "id");
-  if (!id_opt)
-    return make_error(sec::invalid_argument, "ID missing in options map");
-  auto id = std::move(*id_opt);
-  // Fetch path to persistent state from config.
-  auto dir_opt = get<std::string>(opts, "dir");
-  if (!dir_opt)
-    return make_error(sec::invalid_argument,
-                      "Directory path missing in options map");
-  auto dir = std::move(*dir_opt);
+  using namespace vast::defaults;
+  auto id = get_or(opts, "id", root_command_id);
+  auto dir = get_or(opts, "dir", root_command_dir);
   auto abs_dir = path{dir}.complete();
-  // Fetch endpoint from config.
-  auto endpoint_opt = get<std::string>(opts, "endpoint");
-  if (!endpoint_opt)
-    return make_error(sec::invalid_argument, "endpoint missing in options map");
+  auto endpoint_opt = get_or(opts, "endpoint", root_command_endpoint);
   endpoint node_endpoint;
-  if (!parsers::endpoint(*endpoint_opt, node_endpoint)) {
+  if (!parsers::endpoint(endpoint_opt, node_endpoint)) {
     std::string err = "invalid endpoint: ";
-    err += *endpoint_opt;
+    err += endpoint_opt;
     return make_error(sec::invalid_argument, std::move(err));
   }
   VAST_INFO("connect to remote node:", id);

--- a/libvast/src/system/writer_command_base.cpp
+++ b/libvast/src/system/writer_command_base.cpp
@@ -27,6 +27,7 @@
 
 #include "vast/expression.hpp"
 #include "vast/logger.hpp"
+#include "vast/defaults.hpp"
 
 #include "vast/system/node_command.hpp"
 #include "vast/system/signal_monitor.hpp"
@@ -47,6 +48,7 @@ int writer_command_base::run_impl(caf::actor_system& sys,
                                   const option_map& options,
                                   argument_iterator begin,
                                   argument_iterator end) {
+  using namespace vast::defaults;
   // Get a convenient and blocking way to interact with actors.
   scoped_actor self{sys};
   // Get VAST node.
@@ -75,13 +77,13 @@ int writer_command_base::run_impl(caf::actor_system& sys,
   //       instead to clean this up
   auto args = caf::message_builder{begin, end}.move_to_message();
   args = make_message("exporter") + args;
-  if (get_or<bool>(options, "continuous", false))
+  if (get_or(options, "continuous", export_command_continuous))
     args += make_message("--continuous");
-  if (get_or<bool>(options, "historical", false))
+  if (get_or(options, "historical", export_command_historical))
     args += make_message("--historical");
-  if (get_or<bool>(options, "unified", false))
+  if (get_or(options, "unified", export_command_unified))
     args += make_message("--unified");
-  auto max_events = get_or<uint64_t>(options, "events", 0u);
+  auto max_events = get_or(options, "events", export_command_events);
   args += make_message("-e", std::to_string(max_events));
   VAST_DEBUG("spawning exporter with parameters:", to_string(args));
   self->request(node, infinite, "spawn", args).receive(

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -17,13 +17,47 @@
 
 namespace vast::defaults {
 
-// -- default root command values ----------------------------------------------
+// -- default root command values ---------------------------------------------
 constexpr auto root_command_dir = "vast";
 constexpr auto root_command_endpoint = ":42000";
 extern const std::string root_command_id;
 constexpr auto root_command_node = false;
 constexpr auto root_command_version = false;
 
+// -- default start command values --------------------------------------------
+constexpr auto start_command_bare = false;
+constexpr auto start_command_foreground = false;
+
+// -- default pcap writer command values --------------------------------------
+constexpr auto pcap_writer_command_write = "-";
+constexpr auto pcap_writer_command_uds = false;
+constexpr auto pcap_writer_command_flush = 10000u;
+
+// -- default pcap reader command values --------------------------------------
+constexpr auto pcap_reader_command_read = "-";
+constexpr auto pcap_reader_command_schema = "";
+constexpr auto pcap_reader_command_uds = false;
+constexpr auto pcap_reader_command_cutoff =
+  std::numeric_limits<uint64_t>::max();
+constexpr auto pcap_reader_command_flow_max = size_t{1} << 20;
+constexpr auto pcap_reader_command_flow_age = 60u;
+constexpr auto pcap_reader_command_flow_expiry = 10u;
+constexpr auto pcap_reader_command_pseudo_realtime = 0;
+
+// -- default export command values -------------------------------------------
+constexpr auto export_command_continuous = false;
+constexpr auto export_command_historical = false;
+constexpr auto export_command_unified = false;
+constexpr auto export_command_events = 0u;
+
+// -- default reader command values -------------------------------------------
+constexpr auto reader_command_read = "-";
+constexpr auto reader_command_schema = "";
+constexpr auto reader_command_uds = false;
+
+// -- default writer command values -------------------------------------------
+constexpr auto writer_command_write = "-";
+constexpr auto writer_command_uds = false;
 
 } // namespace vast::defaults
 

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -1,0 +1,29 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <string>
+
+namespace vast::defaults {
+
+// -- default root command values ----------------------------------------------
+constexpr auto root_command_dir = "vast";
+constexpr auto root_command_endpoint = ":42000";
+extern const std::string root_command_id;
+constexpr auto root_command_node = false;
+constexpr auto root_command_version = false;
+
+
+} // namespace vast::defaults
+

--- a/libvast/vast/option_map.hpp
+++ b/libvast/vast/option_map.hpp
@@ -87,7 +87,8 @@ private:
 };
 
 template <class T>
-optional<const T&> get(const option_map& xs, std::string_view name) {
+optional<const detail::make_data_type<T>&> get(const option_map& xs,
+                                               std::string_view name) {
   auto x = xs[name];
   if (!x)
     return {};
@@ -98,8 +99,8 @@ optional<const T&> get(const option_map& xs, std::string_view name) {
 }
 
 template <class T>
-T get_or(const option_map& xs, std::string_view name,
-         const T& default_value) {
+detail::make_data_type<T> get_or(const option_map& xs, std::string_view name,
+                                 const T& default_value) {
   if (auto x = get<T>(xs, name); x)
     return *x;
   return default_value;


### PR DESCRIPTION
Some command classes use `get_or()` to retrieve an option from `option_map`. However, providing a default value to retrieve an option has the disadvantage that redundant default values are scattered throughout the code base. In this PR we exchange all `get_or()` functions with `get()` and check with an assert whether the retrieved option is valid.

This PR depends on #187.