### PR TITLE
Add conversion from views back to values

### DIFF
--- a/libvast/src/address.cpp
+++ b/libvast/src/address.cpp
@@ -43,6 +43,10 @@ address::address() {
   bytes_.fill(0);
 }
 
+address::address(const array_type& bytes) : bytes_(bytes) {
+  // nop
+}
+
 address::address(const void* bytes, family fam, byte_order order) {
   auto b = reinterpret_cast<const uint32_t*>(bytes);
   if (fam == ipv4) {

--- a/libvast/src/view.cpp
+++ b/libvast/src/view.cpp
@@ -184,8 +184,8 @@ subnet materialize(subnet_view x) {
 
 namespace {
 
-std::pair<data, data> materialize(std::pair<data_view, data_view> x) {
-  return std::make_pair(materialize(x.first), materialize(x.second));
+auto materialize(std::pair<data_view, data_view> x) {
+  return std::pair(materialize(x.first), materialize(x.second));
 }
 
 template <class Result, class T>

--- a/libvast/src/view.cpp
+++ b/libvast/src/view.cpp
@@ -164,4 +164,55 @@ data make_data(data_view x) {
   ), x);
 }
 
+// -- materialization ----------------------------------------------------------
+
+std::string materialize(std::string_view x) {
+  return std::string{x};
+}
+
+pattern materialize(pattern_view x) {
+  return pattern{std::string{x.string()}};
+}
+
+address materialize(address_view x) {
+  return address{x.data()};
+}
+
+subnet materialize(subnet_view x) {
+  return subnet{materialize(x.network()), x.length()};
+}
+
+namespace {
+
+std::pair<data, data> materialize(std::pair<data_view, data_view> x) {
+  return std::make_pair(materialize(x.first), materialize(x.second));
+}
+
+template <class Result, class T>
+Result materialize_container(const T& xs) {
+  Result result;
+  if (xs)
+    for (auto x : *xs)
+      result.insert(result.end(), materialize(x));
+  return result;
+}
+
+} // namespace <anonymous>
+
+vector materialize(vector_view_ptr xs) {
+  return materialize_container<vector>(xs);
+}
+
+set materialize(set_view_ptr xs) {
+  return materialize_container<set>(xs);
+}
+
+map materialize(map_view_ptr xs) {
+  return materialize_container<map>(xs);
+}
+
+data materialize(data_view x) {
+  return caf::visit([](auto y) { return data{materialize(y)}; }, x);
+}
+
 } // namespace vast

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -126,7 +126,7 @@ TEST(make_data_view) {
   CHECK_EQUAL(v->at(0), integer{42});
   CHECK_EQUAL(v->at(1), true);
   CHECK_EQUAL(v->at(2), "foo"sv);
-  CHECK_EQUAL(x, materialize(v));
+  CHECK_EQUAL(xs, materialize(v));
 }
 
 TEST(increment decrement container_view_iterator) {

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -49,6 +49,7 @@ TEST(string view) {
   CHECK_EQUAL(v, "foobar");
   str[3] = 'z';
   CHECK_EQUAL(v, "foozar");
+  CHECK_EQUAL(str, materialize(v));
 }
 
 TEST(vector view) {
@@ -70,6 +71,7 @@ TEST(vector view) {
   CHECK_EQUAL(i - j, xs.size() - 1);
   MESSAGE("check conversion back to data");
   CHECK(make_data(v) == xs);
+  CHECK_EQUAL(xs, materialize(v));
 }
 
 TEST(set view) {
@@ -84,6 +86,7 @@ TEST(set view) {
   CHECK_EQUAL(*std::next(v->begin(), 1), make_data_view(42));
   MESSAGE("check conversion back to data");
   CHECK(make_data(v) == xs);
+  CHECK_EQUAL(xs, materialize(v));
 }
 
 TEST(map view) {
@@ -105,6 +108,7 @@ TEST(map view) {
   CHECK_EQUAL(value, make_data_view(true));
   MESSAGE("check conversion back to data");
   CHECK(make_data(v) == xs);
+  CHECK_EQUAL(xs, materialize(v));
 }
 
 TEST(make_data_view) {
@@ -122,6 +126,7 @@ TEST(make_data_view) {
   CHECK_EQUAL(v->at(0), integer{42});
   CHECK_EQUAL(v->at(1), true);
   CHECK_EQUAL(v->at(2), "foo"sv);
+  CHECK_EQUAL(x, materialize(v));
 }
 
 TEST(increment decrement container_view_iterator) {

--- a/libvast/vast/address.hpp
+++ b/libvast/vast/address.hpp
@@ -31,6 +31,9 @@ class address : detail::totally_ordered<address>, detail::bitwise<address> {
   static std::array<uint8_t, 12> const v4_mapped_prefix;
 
 public:
+  /// Array for storing 128-bit IPv6 addresses.
+  using array_type = std::array<uint8_t, 16>;
+
   /// Address family.
   enum family { ipv4, ipv6 };
 
@@ -51,6 +54,8 @@ public:
 
   /// Default-constructs an (invalid) address.
   address();
+
+  explicit address(const array_type& bytes);
 
   /// Constructs an address from raw bytes.
   /// @param bytes A pointer to the raw byte representation. This must point

--- a/libvast/vast/view.hpp
+++ b/libvast/vast/view.hpp
@@ -46,6 +46,9 @@ using view_t = typename view<T>::type;
   template <>                                                                  \
   struct view<type_name> {                                                     \
     using type = type_name;                                                    \
+  };                                                                           \
+  inline auto materialize(type_name x) {                                       \
+    return x;                                                                  \
   }
 
 VAST_VIEW_TRAIT(boolean);
@@ -64,11 +67,13 @@ struct view<caf::none_t> {
   using type = caf::none_t;
 };
 
+
 /// @relates view
 template <>
 struct view<std::string> {
   using type = std::string_view;
 };
+
 
 /// @relates view
 class pattern_view : detail::totally_ordered<pattern_view> {
@@ -146,6 +151,7 @@ template <>
 struct view<subnet> {
   using type = subnet_view;
 };
+
 
 struct vector_view_ptr;
 struct set_view_ptr;
@@ -373,5 +379,27 @@ data_view make_data_view(const T& x) {
 /// Creates a data instance from a data_view.
 /// @relates view data
 data make_data(data_view x);
+
+// -- materialization ----------------------------------------------------------
+
+constexpr auto materialize(caf::none_t x) {
+  return x;
+}
+
+std::string materialize(std::string_view x);
+
+pattern materialize(pattern_view x);
+
+address materialize(address_view x);
+
+subnet materialize(subnet_view x);
+
+vector materialize(vector_view_ptr xs);
+
+set materialize(set_view_ptr xs);
+
+map materialize(map_view_ptr xs);
+
+data materialize(data_view xs);
 
 } // namespace vast


### PR DESCRIPTION
Currently there's no way to convert a `data_view` back to `data`. The new `materialize` function adds this feature.