### PR TITLE
Allow getting events from table slice rows

### DIFF
--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -13,7 +13,16 @@
 
 #include "vast/table_slice.hpp"
 
+#include "caf/sum_type.hpp"
+
+#include "vast/detail/overload.hpp"
+#include "vast/event.hpp"
+
 namespace vast {
+
+namespace {
+
+} // namespace <anonymous>
 
 table_slice::table_slice(record_type layout)
   : layout_(std::move(layout)),
@@ -24,6 +33,46 @@ table_slice::table_slice(record_type layout)
 
 table_slice::~table_slice() {
   // no
+}
+
+caf::optional<event> table_slice::row_to_event(size_type row,
+                                               size_type first_column,
+                                               size_type num_columns) const {
+  auto result = rows_to_events(row, 1, first_column, num_columns);
+  if (result.empty())
+    return caf::none;
+  VAST_ASSERT(result.size() == 1u);
+  return std::move(result.front());
+}
+
+std::vector<event> table_slice::rows_to_events(size_type first_row,
+                                               size_type num_rows,
+                                               size_type first_column,
+                                               size_type num_columns) const {
+  auto cap =[](size_type pos, size_type num, size_type last){
+    return num == npos ? last : std::min(last, pos + num);
+  };
+  std::vector<event> result;
+  if (first_column >= columns_ || first_row >= rows_)
+    return result;
+  auto col_begin = first_column;
+  auto col_end = cap(first_column, num_columns, columns_);
+  auto row_begin = first_row;
+  auto row_end = cap(first_row, num_rows, rows_);
+  std::vector<record_field> sub_records{layout_.fields.begin() + col_begin,
+                                        layout_.fields.begin() + col_end};
+  record_type event_layout{std::move(sub_records)};
+  for (size_type row = row_begin; row < row_end; ++row) {
+    vector xs;
+    for (size_type col = col_begin; col < col_end; ++col) {
+      auto opt = at(row, col);
+      if (!opt)
+        return {};
+      xs.emplace_back(materialize(*opt));
+    }
+    result.emplace_back(event::make(std::move(xs), event_layout));
+  }
+  return result;
 }
 
 } // namespace vast

--- a/libvast/src/table_slice_builder.cpp
+++ b/libvast/src/table_slice_builder.cpp
@@ -13,10 +13,28 @@
 
 #include "vast/table_slice_builder.hpp"
 
+#include <algorithm>
+
+#include "vast/data.hpp"
+#include "vast/detail/overload.hpp"
+
 namespace vast {
 
 table_slice_builder::~table_slice_builder() {
   // nop
+}
+
+bool table_slice_builder::recursive_add(const data& x) {
+  return caf::visit(detail::overload(
+                      [&](const vector& xs) {
+                        auto first = xs.begin();
+                        auto last = xs.end();
+                        return std::all_of(first, last, [&](const auto& y) {
+                          return recursive_add(y);
+                        });
+                      },
+                      [&](const auto&) { return add(make_view(x)); }),
+                    x);
 }
 
 } // namespace vast

--- a/libvast/test/default_table_slice.cpp
+++ b/libvast/test/default_table_slice.cpp
@@ -14,23 +14,65 @@
 #include <string>
 
 #include "vast/default_table_slice.hpp"
+#include "vast/event.hpp"
 #include "vast/table_slice_builder.hpp"
 #include "vast/view.hpp"
 
-#define SUITE table
+#define SUITE default_table_slice
 #include "test.hpp"
 
 using namespace vast;
 using namespace std::string_literals;
 
-TEST(default_table_slice) {
-  auto layout = record_type{
+namespace {
+
+struct fixture {
+  record_type layout = record_type{
     {"a", integer_type{}},
     {"b", string_type{}},
     {"c", real_type{}}
   };
-  auto builder = default_table_slice::make_builder(layout);
-  REQUIRE(builder);
+
+  table_slice_builder_ptr builder = default_table_slice::make_builder(layout);
+
+  using tup = std::tuple<integer, std::string, real>;
+
+  std::vector<tup> test_data;
+  std::vector<event> test_events;
+
+  fixture() {
+    REQUIRE_NOT_EQUAL(builder, nullptr);
+    test_data.assign({
+      tup{1, "abc", 1.2},
+      tup{2, "def", 2.1},
+      tup{3, "ghi", 42.},
+      tup{4, "jkl", .42}
+    });
+    for (auto& x : test_data)
+      test_events.emplace_back(event::make(make_vector(x), layout));
+  }
+
+  auto make_slice() {
+    for (auto& x : test_data)
+      std::apply(
+        [&](auto... xs) {
+          if ((!builder->add(make_view(xs)) || ...))
+            FAIL("builder failed to add element");
+        },
+        x);
+    return builder->finish();
+  }
+
+  std::vector<event> subset(size_t from, size_t num) {
+    return {test_events.begin() + from, test_events.begin() + (from + num)};
+  }
+};
+
+} // namespace <anonymous>
+
+FIXTURE_SCOPE(default_table_slice_tests, fixture)
+
+TEST(add) {
   MESSAGE("1st row");
   auto foo = "foo"s;
   auto bar = "foo"s;
@@ -53,3 +95,19 @@ TEST(default_table_slice) {
   REQUIRE(x);
   CHECK_EQUAL(*x, make_view(4.3));
 }
+
+TEST(rows to events) {
+  auto slice = make_slice();
+  CHECK_EQUAL(slice->row_to_event(0), test_events[0]);
+  CHECK_EQUAL(slice->row_to_event(1), test_events[1]);
+  CHECK_EQUAL(slice->row_to_event(2), test_events[2]);
+  CHECK_EQUAL(slice->row_to_event(3), test_events[3]);
+  CHECK_EQUAL(slice->rows_to_events(), test_events);
+  CHECK_EQUAL(slice->rows_to_events(0, 1), subset(0, 1));
+  CHECK_EQUAL(slice->rows_to_events(1, 1), subset(1, 1));
+  CHECK_EQUAL(slice->rows_to_events(2, 1), subset(2, 1));
+  CHECK_EQUAL(slice->rows_to_events(0, 2), subset(0, 2));
+  CHECK_EQUAL(slice->rows_to_events(1, 2), subset(1, 2));
+}
+
+FIXTURE_SCOPE_END()

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -15,6 +15,7 @@
 
 #include <chrono>
 #include <string>
+#include <tuple>
 #include <type_traits>
 
 #include <caf/default_sum_type_access.hpp>
@@ -287,6 +288,18 @@ bool convert(const data& v, json& j);
 /// records contains the field names from the type corresponding to the given
 /// data.
 bool convert(const data& v, json& j, const type& t);
+
+/// @relates data
+template <class... Ts>
+auto make_vector(Ts... xs) {
+  return vector{data{std::move(xs)}...};
+}
+
+template <class... Ts>
+auto make_vector(std::tuple<Ts...> tup) {
+  return std::apply([](auto&... xs) { return make_vector(std::move(xs)...); },
+                    tup);
+}
 
 } // namespace vast
 

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -34,6 +34,7 @@ class subnet;
 class table_slice;
 class table_slice_builder;
 class type;
+class value;
 
 // -- structs ------------------------------------------------------------------
 

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 
 #include <caf/fwd.hpp>
 #include <caf/ref_counted.hpp>
@@ -33,6 +34,8 @@ public:
 
   using size_type = uint64_t;
 
+  static constexpr size_type npos = std::numeric_limits<size_type>::max();
+
   // -- constructors, destructors, and assignment operators --------------------
 
   ~table_slice();
@@ -43,10 +46,19 @@ public:
 
   // -- properties -------------------------------------------------------------
 
-  /// @returns The table layout.
+  /// @returns the table layout.
   inline const record_type& layout() const noexcept {
     return layout_;
   }
+
+  /// @returns the content of a row wrapped into an event.
+  caf::optional<event> row_to_event(size_type row, size_type first_column = 0u,
+                                    size_type num_columns = npos) const;
+
+  std::vector<event> rows_to_events(size_type first_row = 0u,
+                                    size_type num_rows = npos,
+                                    size_type first_column = 0u,
+                                    size_type num_columns = npos) const;
 
   /// @returns the number of rows in the slice.
   inline size_type rows() const noexcept {

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -51,11 +51,11 @@ public:
     return layout_;
   }
 
-  /// @returns the content of a row wrapped into an event.
-  caf::optional<event> row_to_event(size_type row, size_type first_column = 0u,
+  /// @returns the content of a row wrapped into an value.
+  caf::optional<value> row_to_value(size_type row, size_type first_column = 0u,
                                     size_type num_columns = npos) const;
 
-  std::vector<event> rows_to_events(size_type first_row = 0u,
+  std::vector<value> rows_to_values(size_type first_row = 0u,
                                     size_type num_rows = npos,
                                     size_type first_column = 0u,
                                     size_type num_columns = npos) const;

--- a/libvast/vast/table_slice_builder.hpp
+++ b/libvast/vast/table_slice_builder.hpp
@@ -32,6 +32,10 @@ public:
 
   // -- properties -------------------------------------------------------------
 
+  /// Calls `add(x)` as long as `x` is not a vector, otherwise calls `add(y)`
+  /// for each `y` in `x`.
+  bool recursive_add(const data& x);
+
   /// Adds data to the builder.
   /// @param x The data to add.
   /// @returns `true` on success.


### PR DESCRIPTION
Extracting events from table slices greatly simplifies (once could argue enables) testing.