### PR TITLE
Rename: view -> view_trait, view_t -> view

### DIFF
--- a/libvast/src/value_index.cpp
+++ b/libvast/src/value_index.cpp
@@ -211,7 +211,7 @@ void string_index::init() {
 }
 
 bool string_index::append_impl(data_view x, size_type skip) {
-  auto str = caf::get_if<view_t<std::string>>(&x);
+  auto str = caf::get_if<view<std::string>>(&x);
   if (!str)
     return false;
   init();
@@ -236,7 +236,7 @@ string_index::lookup_impl(relational_operator op, data_view x) const {
     [&](auto x) -> expected<ids> {
       return make_error(ec::type_clash, materialize(x));
     },
-    [&](view_t<std::string> str) -> expected<ids> {
+    [&](view<std::string> str) -> expected<ids> {
       auto str_size = str.size();
       if (str_size > max_length_)
         str_size = max_length_;
@@ -294,8 +294,8 @@ string_index::lookup_impl(relational_operator op, data_view x) const {
         }
       }
     },
-    [&](view_t<vector> xs) { return detail::container_lookup(*this, op, xs); },
-    [&](view_t<set> xs) { return detail::container_lookup(*this, op, xs); }
+    [&](view<vector> xs) { return detail::container_lookup(*this, op, xs); },
+    [&](view<set> xs) { return detail::container_lookup(*this, op, xs); }
   ), x);
 }
 
@@ -309,7 +309,7 @@ void address_index::init() {
 
 bool address_index::append_impl(data_view x, size_type skip) {
   init();
-  auto addr = caf::get_if<view_t<address>>(&x);
+  auto addr = caf::get_if<view<address>>(&x);
   if (!addr)
     return false;
   auto& bytes = addr->data();
@@ -334,7 +334,7 @@ address_index::lookup_impl(relational_operator op, data_view d) const {
     [&](auto x) -> expected<ids> {
       return make_error(ec::type_clash, materialize(x));
     },
-    [&](view_t<address> x) -> expected<ids> {
+    [&](view<address> x) -> expected<ids> {
       if (!(op == equal || op == not_equal))
         return make_error(ec::unsupported_operator, op);
       auto result = x.is_v4() ? v4_.coder().storage() : bitmap{v4_.size(), true};
@@ -348,7 +348,7 @@ address_index::lookup_impl(relational_operator op, data_view d) const {
         result.flip();
       return result;
     },
-    [&](view_t<subnet> x) -> expected<ids> {
+    [&](view<subnet> x) -> expected<ids> {
       if (!(op == in || op == not_in))
         return make_error(ec::unsupported_operator, op);
       auto topk = x.length();
@@ -372,8 +372,8 @@ address_index::lookup_impl(relational_operator op, data_view d) const {
         result.flip();
       return result;
     },
-    [&](view_t<vector> xs) { return detail::container_lookup(*this, op, xs); },
-    [&](view_t<set> xs) { return detail::container_lookup(*this, op, xs); }
+    [&](view<vector> xs) { return detail::container_lookup(*this, op, xs); },
+    [&](view<set> xs) { return detail::container_lookup(*this, op, xs); }
   ), d);
 }
 
@@ -385,7 +385,7 @@ void subnet_index::init() {
 }
 
 bool subnet_index::append_impl(data_view x, size_type skip) {
-  if (auto sn = caf::get_if<view_t<subnet>>(&x)) {
+  if (auto sn = caf::get_if<view<subnet>>(&x)) {
     init();
     auto id = length_.size() + skip;
     length_.skip(skip);
@@ -401,7 +401,7 @@ subnet_index::lookup_impl(relational_operator op, data_view d) const {
     [&](auto x) -> expected<ids> {
       return make_error(ec::type_clash, materialize(x));
     },
-    [&](view_t<subnet> x) -> expected<ids> {
+    [&](view<subnet> x) -> expected<ids> {
       switch (op) {
         default:
           return make_error(ec::unsupported_operator, op);
@@ -448,8 +448,8 @@ subnet_index::lookup_impl(relational_operator op, data_view d) const {
         }
       }
     },
-    [&](view_t<vector> xs) { return detail::container_lookup(*this, op, xs); },
-    [&](view_t<set> xs) { return detail::container_lookup(*this, op, xs); }
+    [&](view<vector> xs) { return detail::container_lookup(*this, op, xs); },
+    [&](view<set> xs) { return detail::container_lookup(*this, op, xs); }
   ), d);
 }
 
@@ -463,7 +463,7 @@ void port_index::init() {
 }
 
 bool port_index::append_impl(data_view x, size_type skip) {
-  if (auto p = caf::get_if<view_t<port>>(&x)) {
+  if (auto p = caf::get_if<view<port>>(&x)) {
     init();
     num_.skip(skip);
     num_.append(p->number());
@@ -482,7 +482,7 @@ port_index::lookup_impl(relational_operator op, data_view d) const {
     [&](auto x) -> expected<ids> {
       return make_error(ec::type_clash, materialize(x));
     },
-    [&](view_t<port> x) -> expected<ids> {
+    [&](view<port> x) -> expected<ids> {
       if (op == in || op == not_in)
         return make_error(ec::unsupported_operator, op);
       auto n = num_.lookup(op, x.number());
@@ -492,8 +492,8 @@ port_index::lookup_impl(relational_operator op, data_view d) const {
         n &= proto_.lookup(equal, x.type());
       return n;
     },
-    [&](view_t<vector> xs) { return detail::container_lookup(*this, op, xs); },
-    [&](view_t<set> xs) { return detail::container_lookup(*this, op, xs); }
+    [&](view<vector> xs) { return detail::container_lookup(*this, op, xs); },
+    [&](view<set> xs) { return detail::container_lookup(*this, op, xs); }
   ), d);
 }
 
@@ -514,9 +514,9 @@ void sequence_index::init() {
 }
 
 bool sequence_index::append_impl(data_view x, size_type skip) {
-  if (auto xs = caf::get_if<view_t<vector>>(&x))
+  if (auto xs = caf::get_if<view<vector>>(&x))
     return container_append(**xs, skip);
-  if (auto xs = caf::get_if<view_t<set>>(&x))
+  if (auto xs = caf::get_if<view<set>>(&x))
     return container_append(**xs, skip);
   return false;
 }

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -20,13 +20,13 @@ using namespace vast;
 using namespace std::literals;
 
 TEST(copying views) {
-  MESSAGE("calling view_t directly");
-  CHECK_EQUAL(view_t<caf::none_t>{caf::none}, caf::none);
-  CHECK_EQUAL(view_t<boolean>{true}, true);
-  CHECK_EQUAL(view_t<integer>{42}, 42);
-  CHECK_EQUAL(view_t<count>{42}, 42u);
-  CHECK_EQUAL(view_t<real>{4.2}, 4.2);
-  CHECK_EQUAL(view_t<port>(53, port::udp), port(53, port::udp));
+  MESSAGE("calling view directly");
+  CHECK_EQUAL(view<caf::none_t>{caf::none}, caf::none);
+  CHECK_EQUAL(view<boolean>{true}, true);
+  CHECK_EQUAL(view<integer>{42}, 42);
+  CHECK_EQUAL(view<count>{42}, 42u);
+  CHECK_EQUAL(view<real>{4.2}, 4.2);
+  CHECK_EQUAL(view<port>(53, port::udp), port(53, port::udp));
   MESSAGE("using make_view");
   CHECK_EQUAL(make_view(caf::none), caf::none);
   CHECK_EQUAL(make_view(true), true);
@@ -120,12 +120,12 @@ TEST(make_data_view) {
   CHECK(caf::holds_alternative<boolean>(x));
   auto str = "foo"s;
   x = make_data_view(str);
-  CHECK(caf::holds_alternative<view_t<std::string>>(x));
+  CHECK(caf::holds_alternative<view<std::string>>(x));
   CHECK(caf::holds_alternative<std::string_view>(x));
   auto xs = vector{42, true, "foo"};
   x = make_data_view(xs);
-  REQUIRE(caf::holds_alternative<view_t<vector>>(x));
-  auto v = caf::get<view_t<vector>>(x);
+  REQUIRE(caf::holds_alternative<view<vector>>(x));
+  auto v = caf::get<view<vector>>(x);
   REQUIRE_EQUAL(v->size(), 3u);
   CHECK_EQUAL(v->at(0), integer{42});
   CHECK_EQUAL(v->at(1), true);

--- a/libvast/vast/value_index.hpp
+++ b/libvast/vast/value_index.hpp
@@ -130,14 +130,14 @@ expected<ids> container_lookup_impl(const Index& idx, relational_operator op,
 
 template <class Index>
 expected<ids> container_lookup(const Index& idx, relational_operator op,
-                               view_t<vector> xs) {
+                               view<vector> xs) {
   VAST_ASSERT(xs);
   return container_lookup_impl(idx, op, *xs);
 }
 
 template <class Index>
 expected<ids> container_lookup(const Index& idx, relational_operator op,
-                               view_t<set> xs) {
+                               view<set> xs) {
   VAST_ASSERT(xs);
   return container_lookup_impl(idx, op, *xs);
 }
@@ -211,12 +211,12 @@ private:
     };
     return caf::visit(detail::overload(
       [&](auto&&) { return false; },
-      [&](view_t<boolean> x) { return append(x); },
-      [&](view_t<integer> x) { return append(x); },
-      [&](view_t<count> x) { return append(x); },
-      [&](view_t<real> x) { return append(x); },
-      [&](view_t<timespan> x) { return append(x.count()); },
-      [&](view_t<timestamp> x) { return append(x.time_since_epoch().count()); }
+      [&](view<boolean> x) { return append(x); },
+      [&](view<integer> x) { return append(x); },
+      [&](view<count> x) { return append(x); },
+      [&](view<real> x) { return append(x); },
+      [&](view<timespan> x) { return append(x.count()); },
+      [&](view<timestamp> x) { return append(x.time_since_epoch().count()); }
     ), d);
   }
 
@@ -226,18 +226,18 @@ private:
       [&](auto x) -> expected<ids> {
         return make_error(ec::type_clash, value_type{}, materialize(x));
       },
-      [&](view_t<boolean> x) -> expected<ids> { return bmi_.lookup(op, x); },
-      [&](view_t<integer> x) -> expected<ids> { return bmi_.lookup(op, x); },
-      [&](view_t<count> x) -> expected<ids> { return bmi_.lookup(op, x); },
-      [&](view_t<real> x) -> expected<ids> { return bmi_.lookup(op, x); },
-      [&](view_t<timespan> x) -> expected<ids> {
+      [&](view<boolean> x) -> expected<ids> { return bmi_.lookup(op, x); },
+      [&](view<integer> x) -> expected<ids> { return bmi_.lookup(op, x); },
+      [&](view<count> x) -> expected<ids> { return bmi_.lookup(op, x); },
+      [&](view<real> x) -> expected<ids> { return bmi_.lookup(op, x); },
+      [&](view<timespan> x) -> expected<ids> {
         return bmi_.lookup(op, x.count());
       },
-      [&](view_t<timestamp> x) -> expected<ids> {
+      [&](view<timestamp> x) -> expected<ids> {
         return bmi_.lookup(op, x.time_since_epoch().count());
       },
-      [&](view_t<vector> xs) { return detail::container_lookup(*this, op, xs); },
-      [&](view_t<set> xs) { return detail::container_lookup(*this, op, xs); }
+      [&](view<vector> xs) { return detail::container_lookup(*this, op, xs); },
+      [&](view<set> xs) { return detail::container_lookup(*this, op, xs); }
     ), d);
   };
 

--- a/libvast/vast/view.hpp
+++ b/libvast/vast/view.hpp
@@ -36,15 +36,15 @@ namespace vast {
 
 /// A type-safe overlay over an immutable sequence of bytes.
 template <class>
-struct view;
+struct view_trait;
 
-/// @relates view
+/// @relates view_trait
 template <class T>
-using view_t = typename view<T>::type;
+using view = typename view_trait<T>::type;
 
 #define VAST_VIEW_TRAIT(type_name)                                             \
   template <>                                                                  \
-  struct view<type_name> {                                                     \
+  struct view_trait<type_name> {                                               \
     using type = type_name;                                                    \
   };                                                                           \
   inline auto materialize(type_name x) {                                       \
@@ -63,21 +63,21 @@ VAST_VIEW_TRAIT(subnet);
 
 #undef VAST_VIEW_TRAIT
 
-/// @relates view
+/// @relates view_trait
 template <>
-struct view<caf::none_t> {
+struct view_trait<caf::none_t> {
   using type = caf::none_t;
 };
 
 
-/// @relates view
+/// @relates view_trait
 template <>
-struct view<std::string> {
+struct view_trait<std::string> {
   using type = std::string_view;
 };
 
 
-/// @relates view
+/// @relates view_trait
 class pattern_view : detail::totally_ordered<pattern_view> {
 public:
   static pattern glob(std::string_view x);
@@ -95,9 +95,9 @@ private:
   std::string_view pattern_;
 };
 
-//// @relates view
+//// @relates view_trait
 template <>
-struct view<pattern> {
+struct view_trait<pattern> {
   using type = pattern_view;
 };
 
@@ -106,60 +106,60 @@ struct vector_view_ptr;
 struct set_view_ptr;
 struct map_view_ptr;
 
-/// @relates view
+/// @relates view_trait
 template <>
-struct view<vector> {
+struct view_trait<vector> {
   using type = vector_view_ptr;
 };
 
-/// @relates view
+/// @relates view_trait
 template <>
-struct view<set> {
+struct view_trait<set> {
   using type = set_view_ptr;
 };
 
-/// @relates view
+/// @relates view_trait
 template <>
-struct view<map> {
+struct view_trait<map> {
   using type = map_view_ptr;
 };
 
 /// A type-erased view over variout types of data.
-/// @relates view
+/// @relates view_trait
 using data_view = caf::variant<
-  view_t<caf::none_t>,
-  view_t<boolean>,
-  view_t<integer>,
-  view_t<count>,
-  view_t<real>,
-  view_t<timespan>,
-  view_t<timestamp>,
-  view_t<std::string>,
-  view_t<pattern>,
-  view_t<address>,
-  view_t<subnet>,
-  view_t<port>,
-  view_t<vector>,
-  view_t<set>,
-  view_t<map>
+  view<caf::none_t>,
+  view<boolean>,
+  view<integer>,
+  view<count>,
+  view<real>,
+  view<timespan>,
+  view<timestamp>,
+  view<std::string>,
+  view<pattern>,
+  view<address>,
+  view<subnet>,
+  view<port>,
+  view<vector>,
+  view<set>,
+  view<map>
 >;
 
-/// @relates view
+/// @relates view_trait
 template <>
-struct view<data> {
+struct view_trait<data> {
   using type = data_view;
 };
 
 template <class T>
 struct container_view;
 
-/// @relates view
+/// @relates view_trait
 template <class T>
 using container_view_ptr = caf::intrusive_ptr<container_view<T>>;
 
 namespace detail {
 
-/// @relates view
+/// @relates view_trait
 template <class T>
 class container_view_iterator
   : public detail::iterator_facade<
@@ -210,7 +210,7 @@ private:
 } // namespace detail
 
 /// Base class for container views.
-/// @relates view
+/// @relates view_trait
 template <class T>
 struct container_view : caf::ref_counted {
   using value_type = T;
@@ -237,17 +237,17 @@ struct container_view : caf::ref_counted {
   virtual size_type size() const noexcept = 0;
 };
 
-// @relates view
+// @relates view_trait
 struct vector_view_ptr : container_view_ptr<data_view> {};
 
-// @relates view
+// @relates view_trait
 struct set_view_ptr : container_view_ptr<data_view> {};
 
-// @relates view
+// @relates view_trait
 struct map_view_ptr : container_view_ptr<std::pair<data_view, data_view>> {};
 
 /// A view over a @ref vector.
-/// @relates view
+/// @relates view_trait
 class default_vector_view
   : public container_view<data_view>,
     detail::totally_ordered<default_vector_view> {
@@ -263,7 +263,7 @@ private:
 };
 
 /// A view over a @ref set.
-/// @relates view
+/// @relates view_trait
 class default_set_view
   : public container_view<data_view>,
     detail::totally_ordered<default_set_view> {
@@ -279,7 +279,7 @@ private:
 };
 
 /// A view over a @ref map.
-/// @relates view
+/// @relates view_trait
 class default_map_view
   : public container_view<std::pair<data_view, data_view>>,
     detail::totally_ordered<default_map_view> {
@@ -295,9 +295,9 @@ private:
 };
 
 /// Creates a view from a specific type.
-/// @relates view
+/// @relates view_trait
 template <class T>
-view_t<T> make_view(const T& x) {
+view<T> make_view(const T& x) {
   constexpr auto directly_constructible
     = detail::is_any_v<T, caf::none_t, boolean, integer, count, real, timespan,
                        timestamp, std::string, pattern, address, subnet, port>;
@@ -316,9 +316,9 @@ view_t<T> make_view(const T& x) {
 }
 
 /// Creates a view from a string literal.
-/// @relates view
+/// @relates view_trait
 template <size_t N>
-view_t<std::string> make_view(const char (&xs)[N]) {
+view<std::string> make_view(const char (&xs)[N]) {
   return std::string_view(xs, N - 1);
 }
 
@@ -326,7 +326,7 @@ view_t<std::string> make_view(const char (&xs)[N]) {
 data_view make_view(const data& x);
 
 /// Creates a type-erased data view from a specific type.
-/// @relates view
+/// @relates view_trait
 template <class T>
 data_view make_data_view(const T& x) {
   return make_view(x);


### PR DESCRIPTION
This PR cleans up the user-facing side of the view API.