### PR TITLE
Perform deep view comparison

### DIFF
--- a/libvast/src/view.cpp
+++ b/libvast/src/view.cpp
@@ -35,75 +35,6 @@ bool operator<(pattern_view x, pattern_view y) noexcept {
   return x.string() < y.string();
 }
 
-// -- data_view ---------------------------------------------------------------
-
-namespace {
-
-template <template <class> class Predicate, class T>
-bool compare(T x, T y) {
-  auto cmp = [](auto xs, auto ys) {
-    return xs && ys && Predicate{}(*xs, *ys);
-  };
-  return caf::visit(detail::overload(
-    [=](const auto& x, const auto& y) {
-      using lhs_type = std::decay_t<decltype(x)>;
-      using rhs_type = std::decay_t<decltype(y)>;
-      if constexpr (std::is_same_v<lhs_type, rhs_type>) {
-        return Predicate{}(x, y);
-      } else {
-        return false;
-      }
-    },
-    [=](view<vector> xs, view<vector> ys) {
-      return cmp(xs, ys);
-    },
-    [=](view<set> xs, view<set> ys) {
-      return cmp(xs, ys);
-    },
-    [=](view<map> xs, view<map> ys) {
-      return cmp(xs, ys);
-    }
-  ), x, y);
-}
-
-} // namespace <anonymous>
-
-bool operator==(const data_view& x, const data_view& y) {
-  return x.index() == y.index() && compare<std::equal_to>(x, y);
-}
-
-bool operator!=(const data_view& x, const data_view& y) {
-  return !(x == y);
-}
-
-bool operator<(const data_view& x, const data_view& y) {
-  if (y.valueless_by_exception())
-    return false;
-  if (x.valueless_by_exception())
-    return true;
-  auto i = x.index();
-  auto j = y.index();
-  return i != j ? i < j : compare<std::less>(x, y);
-}
-
-bool operator>(const data_view& x, const data_view& y) {
-  if (x.valueless_by_exception())
-    return false;
-  if (y.valueless_by_exception())
-    return true;
-  auto i = x.index();
-  auto j = y.index();
-  return i != j ? i < j : compare<std::greater>(x, y);
-}
-
-bool operator<=(const data_view& x, const data_view& y) {
-  return !(x > y);
-}
-
-bool operator>=(const data_view& x, const data_view& y) {
-  return !(x < y);
-}
-
 // -- default_vector_view -----------------------------------------------------
 
 default_vector_view::default_vector_view(const vector& xs) : xs_{xs} {
@@ -180,15 +111,15 @@ Result materialize_container(const T& xs) {
 
 } // namespace <anonymous>
 
-vector materialize(vector_view_ptr xs) {
+vector materialize(vector_view_handle xs) {
   return materialize_container<vector>(xs);
 }
 
-set materialize(set_view_ptr xs) {
+set materialize(set_view_handle xs) {
   return materialize_container<set>(xs);
 }
 
-map materialize(map_view_ptr xs) {
+map materialize(map_view_handle xs) {
   return materialize_container<map>(xs);
 }
 

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -144,3 +144,19 @@ TEST(increment decrement container_view_iterator) {
   --it1;
   CAF_CHECK_EQUAL(it1.distance_to(it2), 0u);
 }
+
+TEST(container comparison) {
+  data xs = vector{42};
+  data ys = vector{42};
+  CHECK(make_view(xs) == make_view(ys));
+  CHECK(!(make_view(xs) < make_view(ys)));
+  caf::get<vector>(ys).push_back(0);
+  CHECK(make_view(xs) != make_view(ys));
+  CHECK(make_view(xs) < make_view(ys));
+  ys = map{{42, true}};
+  CHECK(make_view(xs) != make_view(ys));
+  CHECK(make_view(xs) < make_view(ys));
+  ys = map{{42, false}};
+  CHECK(make_view(xs) != make_view(ys));
+  CHECK(make_view(xs) > make_view(ys));
+}

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -156,7 +156,6 @@ TEST(container comparison) {
   ys = map{{42, true}};
   CHECK(make_view(xs) != make_view(ys));
   CHECK(make_view(xs) < make_view(ys));
-  ys = map{{42, false}};
-  CHECK(make_view(xs) != make_view(ys));
+  xs = map{{43, true}};
   CHECK(make_view(xs) > make_view(ys));
 }

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -138,11 +138,11 @@ TEST(increment decrement container_view_iterator) {
   auto v = make_view(xs);
   auto it1 = v->begin();
   auto it2 = v->begin();
-  CAF_CHECK_EQUAL(it1.distance_to(it2), 0u);
+  CHECK_EQUAL(it1.distance_to(it2), 0u);
   ++it1;
-  CAF_CHECK_NOT_EQUAL(it1.distance_to(it2), 0u);
+  CHECK_NOT_EQUAL(it1.distance_to(it2), 0u);
   --it1;
-  CAF_CHECK_EQUAL(it1.distance_to(it2), 0u);
+  CHECK_EQUAL(it1.distance_to(it2), 0u);
 }
 
 TEST(container comparison) {

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -158,4 +158,11 @@ TEST(container comparison) {
   CHECK(make_view(xs) < make_view(ys));
   xs = map{{43, true}};
   CHECK(make_view(xs) > make_view(ys));
+  MESSAGE("strict weak ordering corner cases");
+  auto zs = set{1, 2, 3};
+  CHECK(!(view<set>{} < view<set>{}));
+  CHECK(view<set>{} < make_view(zs));
+  CHECK(!(make_view(zs) < view<set>{}));
+  CHECK(make_data_view(zs) < make_view(xs));
+  CHECK(!(make_view(xs) < make_data_view(zs)));
 }

--- a/libvast/vast/view.hpp
+++ b/libvast/vast/view.hpp
@@ -88,12 +88,15 @@ public:
   bool search(std::string_view x) const;
   std::string_view string() const;
 
-  friend bool operator==(pattern_view x, pattern_view y) noexcept;
-  friend bool operator<(pattern_view x, pattern_view y) noexcept;
-
 private:
   std::string_view pattern_;
 };
+
+/// @relates pattern_view
+bool operator==(pattern_view x, pattern_view y) noexcept;
+
+/// @relates pattern_view
+bool operator<(pattern_view x, pattern_view y) noexcept;
 
 //// @relates view_trait
 template <>
@@ -143,6 +146,24 @@ using data_view = caf::variant<
   view<set>,
   view<map>
 >;
+
+/// @relates data_view
+bool operator==(const data_view& x, const data_view& y);
+
+/// @relates data_view
+bool operator!=(const data_view& x, const data_view& y);
+
+/// @relates data_view
+bool operator<(const data_view& x, const data_view& y);
+
+/// @relates data_view
+bool operator>(const data_view& x, const data_view& y);
+
+/// @relates data_view
+bool operator<=(const data_view& x, const data_view& y);
+
+/// @relates data_view
+bool operator>=(const data_view& x, const data_view& y);
 
 /// @relates view_trait
 template <>
@@ -212,7 +233,9 @@ private:
 /// Base class for container views.
 /// @relates view_trait
 template <class T>
-struct container_view : caf::ref_counted {
+struct container_view
+  : caf::ref_counted,
+    detail::totally_ordered<container_view<T>> {
   using value_type = T;
   using size_type = size_t;
   using iterator = detail::container_view_iterator<T>;
@@ -236,6 +259,26 @@ struct container_view : caf::ref_counted {
   /// @returns The number of elements in the container.
   virtual size_type size() const noexcept = 0;
 };
+
+template <class T>
+bool operator==(const container_view<T>& xs, const container_view<T>& ys) {
+  if (xs.size() != ys.size())
+    return false;
+  for (auto i = 0u; i < xs.size(); ++i)
+    if (xs.at(i) != ys.at(i))
+      return false;
+  return true;
+}
+
+template <class T>
+bool operator<(const container_view<T>& xs, const container_view<T>& ys) {
+  if (xs.size() != ys.size())
+    return xs.size() < ys.size();
+  for (auto i = 0u; i < xs.size(); ++i)
+    if (xs.at(i) < ys.at(i))
+      return true;
+  return false;
+}
 
 // @relates view_trait
 struct vector_view_ptr : container_view_ptr<data_view> {};

--- a/libvast/vast/view.hpp
+++ b/libvast/vast/view.hpp
@@ -208,7 +208,11 @@ bool operator==(const container_view_handle<Pointer>& x,
 template <class Pointer>
 bool operator<(const container_view_handle<Pointer>& x,
                const container_view_handle<Pointer>& y) {
-  return x && y && *x < *y;
+  if (!x)
+    return static_cast<bool>(y);
+  if (!y)
+    return false;
+  return *x < *y;
 }
 
 namespace detail {


### PR DESCRIPTION
Views previously had shallow comparison semantics for containers, which were only comparing pointer values.