### PR TITLE
Port VAST components to table slices

### DIFF
--- a/libvast/src/default_table_slice.cpp
+++ b/libvast/src/default_table_slice.cpp
@@ -41,4 +41,15 @@ table_slice_builder_ptr default_table_slice::make_builder(record_type layout) {
   return caf::make_counted<default_table_slice_builder>(std::move(layout));
 }
 
+table_slice_ptr default_table_slice::make(record_type layout,
+                                          std::vector<vector>& rows) {
+  auto builder = make_builder(std::move(layout));
+  for (auto& row : rows)
+    for (auto& item : row)
+      builder->add(make_view(item));
+  auto result = builder->finish();
+  VAST_ASSERT(result != nullptr);
+  return result;
+}
+
 } // namespace vast

--- a/libvast/src/default_table_slice.cpp
+++ b/libvast/src/default_table_slice.cpp
@@ -42,7 +42,7 @@ table_slice_builder_ptr default_table_slice::make_builder(record_type layout) {
 }
 
 table_slice_ptr default_table_slice::make(record_type layout,
-                                          std::vector<vector>& rows) {
+                                          const std::vector<vector>& rows) {
   auto builder = make_builder(std::move(layout));
   for (auto& row : rows)
     for (auto& item : row)

--- a/libvast/src/default_table_slice_builder.cpp
+++ b/libvast/src/default_table_slice_builder.cpp
@@ -58,4 +58,8 @@ table_slice_ptr default_table_slice_builder::finish() {
   return result;
 };
 
+size_t default_table_slice_builder::rows() const noexcept {
+  return slice_ == nullptr ? 0u : slice_->xs_.size();
+}
+
 } // namespace vast

--- a/libvast/src/defaults.cpp
+++ b/libvast/src/defaults.cpp
@@ -39,4 +39,10 @@ std::string node_id = std::string{detail::split(detail::hostname(), ".")[0]};
 
 } // namespace command
 
+namespace system {
+
+size_t table_slice_size = 10000;
+
+} // namespace system
+
 } // namespace vast::defaults

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -312,7 +312,7 @@ behavior index(stateful_actor<index_state>* self, const path& dir,
                    "partitions left for query ID", query_id);
       }
     },
-    [=](caf::stream<event> in) {
+    [=](caf::stream<const_table_slice_ptr> in) {
       VAST_DEBUG(self, "got a new source");
       return self->state.stage->add_inbound_path(in);
     }
@@ -323,7 +323,7 @@ behavior index(stateful_actor<index_state>* self, const path& dir,
       st.next_worker = worker;
       self->become(keep_behavior, st.has_worker);
     },
-    [=](caf::stream<event> in) {
+    [=](caf::stream<const_table_slice_ptr> in) {
       VAST_DEBUG(self, "got a new source");
       return self->state.stage->add_inbound_path(in);
     }

--- a/libvast/src/system/indexer_manager.cpp
+++ b/libvast/src/system/indexer_manager.cpp
@@ -24,26 +24,27 @@ indexer_manager::indexer_manager(partition& parent, indexer_factory f)
   // nop
 }
 
-std::pair<caf::actor, bool> indexer_manager::get_or_add(const type& key) {
+std::pair<caf::actor, bool>
+indexer_manager::get_or_add(const record_type& key) {
   VAST_TRACE(VAST_ARG(key));
   auto i = indexers_.find(key);
   if (i != indexers_.end())
     return {i->second, false};
   auto digest = to_digest(key);
-  parent_.add_type(digest, key);
+  parent_.add_layout(digest, key);
   auto res = indexers_.emplace(key, make_indexer(key, digest));
   VAST_ASSERT(res.second == true);
   return {res.first->second, true};
 }
 
-caf::actor indexer_manager::make_indexer(const type& key,
+caf::actor indexer_manager::make_indexer(const record_type& key,
                                          const std::string& digest) {
   VAST_TRACE(VAST_ARG(key), VAST_ARG(digest));
   VAST_ASSERT(make_indexer_ != nullptr);
   return make_indexer_(parent_.dir() / digest, key);
 }
 
-caf::actor indexer_manager::make_indexer(const type& key) {
+caf::actor indexer_manager::make_indexer(const record_type& key) {
   VAST_TRACE(VAST_ARG(key));
   return make_indexer(key, to_digest(key));
 }

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -76,8 +76,8 @@ caf::error partition::flush_to_disk() {
   return caf::none;
 }
 
-std::vector<type> partition::types() const {
-  std::vector<type> result;
+std::vector<record_type> partition::layouts() const {
+  std::vector<record_type> result;
   auto& ts = meta_data_.types;
   result.reserve(ts.size());
   std::transform(ts.begin(), ts.end(), std::back_inserter(result),
@@ -110,7 +110,7 @@ partition_ptr make_partition(const path& base_dir, uuid id,
 
 partition_ptr make_partition(caf::local_actor* self, const path& base_dir,
                              uuid id) {
-  auto f = [=](path indexer_path, type indexer_type) {
+  auto f = [=](path indexer_path, record_type indexer_type) {
     VAST_DEBUG(self, "creates INDEXER in partition", id, "for type",
                indexer_type);
     return self->spawn<caf::lazy_init>(indexer, std::move(indexer_path),

--- a/libvast/src/system/pcap_reader_command.cpp
+++ b/libvast/src/system/pcap_reader_command.cpp
@@ -69,7 +69,7 @@ pcap_reader_command::make_source(caf::scoped_actor& self,
                                 defaults::command::pseudo_realtime_factor);
   format::pcap::reader reader{input,    cutoff,      flow_max,
                               flow_age, flow_expiry, pseudo_realtime};
-  return self->spawn(source<format::pcap::reader>, std::move(reader));
+  return self->spawn(default_source<format::pcap::reader>, std::move(reader));
 }
 
 } // namespace vast::system

--- a/libvast/src/system/spawn.cpp
+++ b/libvast/src/system/spawn.cpp
@@ -21,9 +21,10 @@
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/concept/printable/vast/expression.hpp"
 #include "vast/data.hpp"
+#include "vast/defaults.hpp"
+#include "vast/error.hpp"
 #include "vast/expression.hpp"
 #include "vast/expression_visitors.hpp"
-#include "vast/error.hpp"
 #include "vast/query_options.hpp"
 
 #include "vast/system/atoms.hpp"
@@ -124,7 +125,9 @@ expected<actor> spawn_importer(stateful_actor<node_state>* self,
   if (!r.error.empty())
     return make_error(ec::syntax_error, r.error);
   // FIXME: Notify exporters with a continuous query.
-  return self->spawn(importer, opts.dir / opts.label);
+  // TODO: make table slice size configurable
+  return self->spawn(importer, opts.dir / opts.label,
+                     defaults::system::table_slice_size);
 }
 
 expected<actor> spawn_index(local_actor* self, options& opts) {

--- a/libvast/src/system/spawn_source.cpp
+++ b/libvast/src/system/spawn_source.cpp
@@ -84,7 +84,7 @@ expected<actor> spawn_source(local_actor* self, options& opts) {
       return make_error(ec::syntax_error, r.error);
     format::pcap::reader reader{input, cutoff, flow_max, flow_age, flow_expiry,
                                 pseudo_realtime};
-    src = self->spawn(source<format::pcap::reader>, std::move(reader));
+    src = self->spawn(default_source<format::pcap::reader>, std::move(reader));
 #endif
   } else if (format == "bro" || format == "bgpdump" || format == "mrt") {
     auto in = detail::make_input_stream(input, r.opts.count("uds") > 0);
@@ -92,13 +92,14 @@ expected<actor> spawn_source(local_actor* self, options& opts) {
       return in.error();
     if (format == "bro") {
       format::bro::reader reader{std::move(*in)};
-      src = self->spawn(source<format::bro::reader>, std::move(reader));
+      src = self->spawn(default_source<format::bro::reader>, std::move(reader));
     } else if (format == "bgpdump") {
       format::bgpdump::reader reader{std::move(*in)};
-      src = self->spawn(source<format::bgpdump::reader>, std::move(reader));
+      src = self->spawn(default_source<format::bgpdump::reader>,
+                        std::move(reader));
     } else if (format == "mrt") {
       format::mrt::reader reader{std::move(*in)};
-      src = self->spawn(source<format::mrt::reader>, std::move(reader));
+      src = self->spawn(default_source<format::mrt::reader>, std::move(reader));
     }
   } else if (format == "test") {
     auto seed = size_t{0};
@@ -112,7 +113,7 @@ expected<actor> spawn_source(local_actor* self, options& opts) {
     if (!r.error.empty())
       return make_error(ec::syntax_error, r.error);
     format::test::reader reader{seed, n, base};
-    src = self->spawn(source<format::test::reader>, std::move(reader));
+    src = self->spawn(default_source<format::test::reader>, std::move(reader));
     // Since the test source doesn't consume any data and only generates
     // events out of thin air, we use the input channel to specify the schema.
     schema_file = input;

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -32,7 +32,8 @@ auto cap (size_type pos, size_type num, size_type last) {
 } // namespace <anonymous>
 
 table_slice::table_slice(record_type layout)
-  : layout_(std::move(layout)),
+  : offset_(0),
+    layout_(std::move(layout)),
     rows_(0),
     columns_(flat_size(layout_)) {
   // nop
@@ -97,7 +98,8 @@ std::vector<event> table_slice::rows_to_events(size_type first_row,
   result.reserve(values.size());
   auto event_id = offset() + first_row;
   for (size_t i = 0; i < values.size(); ++i) {
-    result.emplace_back(event::make(std::move(values[i])));
+    result.emplace_back(event::make(std::move(values[i].data()),
+                                    values[i].type().name(layout_.name())));
     result.back().id(event_id++);
     result.back().timestamp(get<timestamp>(get<vector>(timestamps[i])[0]));
   }

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -70,4 +70,23 @@ std::vector<value> table_slice::rows_to_values(size_type first_row,
   return result;
 }
 
+bool operator==(const table_slice& x, const table_slice& y) {
+  if (&x == &y)
+    return true;
+  if (x.rows() != y.rows()
+      || x.columns() != y.columns()
+      || x.layout() != y.layout())
+    return false;
+  for (size_t row = 0; row < x.rows(); ++row)
+    for (size_t col = 0; col < x.columns(); ++col) {
+      // TODO: fix comparison of string_view
+      //if (x.at(row, col) != y.at(row, col))
+      auto lhs = x.at(row, col);
+      auto rhs = y.at(row, col);
+      if (!lhs || !rhs || materialize(*lhs) != materialize(*rhs))
+        return false;
+    }
+  return true;
+}
+
 } // namespace vast

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -424,6 +424,18 @@ type flatten(const type& t) {
   return r ? flatten(*r) : t;
 }
 
+bool is_flat(const record_type& rec) {
+  auto& fs = rec.fields;
+  return std::all_of(fs.begin(), fs.end(), [](auto& f) {
+    return !caf::holds_alternative<record_type>(f.type);
+  });
+}
+
+bool is_flat(const type& t) {
+  auto r = get_if<record_type>(&t);
+  return r ? is_flat(*r) : true;
+}
+
 size_t flat_size(const record_type& rec) {
   auto op = [](size_t x, const auto& y) { return x + flat_size(y.type); };
   return std::accumulate(rec.fields.begin(), rec.fields.end(), size_t{0}, op);

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -443,7 +443,7 @@ bool is_flat(const record_type& rec) {
 
 bool is_flat(const type& t) {
   auto r = get_if<record_type>(&t);
-  return r ? is_flat(*r) : true;
+  return !r || is_flat(*r);
 }
 
 size_t flat_size(const record_type& rec) {

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -415,7 +415,9 @@ caf::optional<size_t> record_type::flat_index_at(offset o) const {
 }
 
 record_type flatten(const record_type& rec) {
-  record_type result;
+  /// Make a copy of the original to keep name and attributes.
+  record_type result = rec;
+  result.fields.clear();
   for (auto& outer : rec.fields)
     if (auto r = get_if<record_type>(&outer.type)) {
       auto flat = flatten(*r);

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -374,6 +374,14 @@ const type* record_type::at(const offset& o) const {
   return nullptr;
 }
 
+bool record_type::equals(const abstract_type& other) const {
+  return super::equals(other) && fields == downcast(other).fields;
+}
+
+bool record_type::less_than(const abstract_type& other) const {
+  return super::less_than(other) || fields < downcast(other).fields;
+}
+
 caf::optional<size_t> record_type::flat_index_at(offset o) const {
   // Empty offsets are invalid.
   if (o.empty())

--- a/libvast/test/column_index.cpp
+++ b/libvast/test/column_index.cpp
@@ -20,6 +20,9 @@
 #include "vast/column_index.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
+#include "vast/default_table_slice.hpp"
+#include "vast/table_slice.hpp"
+#include "vast/table_slice_builder.hpp"
 #include "vast/type.hpp"
 
 using namespace vast;
@@ -32,7 +35,13 @@ struct fixture : fixtures::events, fixtures::filesystem {
   }
 
   template <class T>
-  T unbox(expected<T> x) {
+  T unbox(caf::expected<T> x) {
+    REQUIRE(x);
+    return std::move(*x);
+  }
+
+  template <class T>
+  T unbox(caf::optional<T> x) {
     REQUIRE(x);
     return std::move(*x);
   }
@@ -42,43 +51,47 @@ struct fixture : fixtures::events, fixtures::filesystem {
 
 FIXTURE_SCOPE(column_index_tests, fixture)
 
-TEST(flat column type) {
+TEST(integer values) {
   MESSAGE("ingest integer values");
   integer_type column_type;
-  auto col = unbox(make_flat_data_index(directory, column_type));
-  std::vector<int> xs{1, 2, 3, 1, 2, 3, 1, 2, 3};
-  size_t next_id = 0;
-  for (auto i : xs)
-    col->add(event::make(i, column_type, next_id++));
+  record_type layout{{"value", column_type}};
+  auto col = unbox(make_column_index(directory, column_type, 0));
+  auto rows = make_rows(1, 2, 3, 1, 2, 3, 1, 2, 3);
+  auto slice = default_table_slice::make(layout, rows);
+  col->add(slice);
+  REQUIRE_EQUAL(slice->rows(), rows.size());
+  auto slice_size = rows.size();
   MESSAGE("generate test queries");
   auto is1 = unbox(to<predicate>(":int == +1"));
   auto is2 = unbox(to<predicate>(":int == +2"));
   auto is3 = unbox(to<predicate>(":int == +3"));
   auto is4 = unbox(to<predicate>(":int == +4"));
   MESSAGE("verify column index");
-  CHECK_EQUAL(unbox(col->lookup(is1)), make_ids({0, 3, 6}, xs.size()));
-  CHECK_EQUAL(unbox(col->lookup(is2)), make_ids({1, 4, 7}, xs.size()));
-  CHECK_EQUAL(unbox(col->lookup(is3)), make_ids({2, 5, 8}, xs.size()));
-  CHECK_EQUAL(unbox(col->lookup(is4)), make_ids({}, xs.size()));
+  CHECK_EQUAL(unbox(col->lookup(is1)), make_ids({0, 3, 6}, slice_size));
+  CHECK_EQUAL(unbox(col->lookup(is2)), make_ids({1, 4, 7}, slice_size));
+  CHECK_EQUAL(unbox(col->lookup(is3)), make_ids({2, 5, 8}, slice_size));
+  CHECK_EQUAL(unbox(col->lookup(is4)), make_ids({}, slice_size));
   MESSAGE("persist and reload from disk");
   col->flush_to_disk();
   col.reset();
-  col = unbox(make_flat_data_index(directory, integer_type{}));
+  col = unbox(make_column_index(directory, column_type, 0));
   MESSAGE("verify column index again");
-  CHECK_EQUAL(unbox(col->lookup(is1)), make_ids({0, 3, 6}, xs.size()));
-  CHECK_EQUAL(unbox(col->lookup(is2)), make_ids({1, 4, 7}, xs.size()));
-  CHECK_EQUAL(unbox(col->lookup(is3)), make_ids({2, 5, 8}, xs.size()));
-  CHECK_EQUAL(unbox(col->lookup(is4)), make_ids({}, xs.size()));
+  CHECK_EQUAL(unbox(col->lookup(is1)), make_ids({0, 3, 6}, slice_size));
+  CHECK_EQUAL(unbox(col->lookup(is2)), make_ids({1, 4, 7}, slice_size));
+  CHECK_EQUAL(unbox(col->lookup(is3)), make_ids({2, 5, 8}, slice_size));
+  CHECK_EQUAL(unbox(col->lookup(is4)), make_ids({}, slice_size));
 }
 
 TEST(bro conn log) {
   MESSAGE("ingest originators from bro conn log");
-  auto row_type = caf::get<record_type>(bro_conn_log[0].type());
-  auto col_offset = unbox(row_type.resolve(key{"id", "orig_h"}));
+  auto row_type = bro_conn_log_layout();
+  auto col_offset = unbox(row_type.resolve(key{"id.orig_h"}));
   auto col_type = row_type.at(col_offset);
-  auto col = unbox(make_field_data_index(directory, *col_type, col_offset));
-  for (auto entry : bro_conn_log)
-    col->add(entry);
+  auto col_index = unbox(row_type.flat_index_at(col_offset));
+  REQUIRE_EQUAL(col_index, 3u);
+  auto col = unbox(make_column_index(directory, *col_type, col_index));
+  for (auto slice : const_bro_conn_log_slices)
+    col->add(slice);
   MESSAGE("verify column index");
   auto pred = unbox(to<predicate>(":addr == 169.254.225.22"));
   auto expected_result = make_ids({680, 682, 719, 720}, bro_conn_log.size());
@@ -87,7 +100,7 @@ TEST(bro conn log) {
   col->flush_to_disk();
   col.reset();
   MESSAGE("verify column index again");
-  col = unbox(make_field_data_index(directory, *col_type, col_offset));
+  col = unbox(make_column_index(directory, *col_type, col_index));
   CHECK_EQUAL(unbox(col->lookup(pred)), expected_result);
 }
 

--- a/libvast/test/fixtures/events.cpp
+++ b/libvast/test/fixtures/events.cpp
@@ -22,11 +22,7 @@
 
 namespace fixtures {
 
-namespace {
-
-static constexpr size_t slice_size = 100;
-
-} // namespace <anonymous>
+size_t events::slice_size = 100;
 
 std::vector<event> events::bro_conn_log;
 std::vector<event> events::bro_dns_log;

--- a/libvast/test/fixtures/events.cpp
+++ b/libvast/test/fixtures/events.cpp
@@ -11,19 +11,34 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include "vast/format/bro.hpp"
-#include "vast/format/bgpdump.hpp"
-#include "vast/format/test.hpp"
-
 #include "fixtures/events.hpp"
 
+#include "vast/default_table_slice.hpp"
+#include "vast/format/bgpdump.hpp"
+#include "vast/format/bro.hpp"
+#include "vast/format/test.hpp"
+#include "vast/table_slice_builder.hpp"
+#include "vast/type.hpp"
+
 namespace fixtures {
+
+namespace {
+
+static constexpr size_t slice_size = 100;
+
+} // namespace <anonymous>
 
 std::vector<event> events::bro_conn_log;
 std::vector<event> events::bro_dns_log;
 std::vector<event> events::bro_http_log;
 std::vector<event> events::bgpdump_txt;
 std::vector<event> events::random;
+
+std::vector<table_slice_ptr> events::bro_conn_log_slices;
+std::vector<table_slice_ptr> events::bro_dns_log_slices;
+std::vector<table_slice_ptr> events::bro_http_log_slices;
+std::vector<table_slice_ptr> events::bgpdump_txt_slices;
+std::vector<table_slice_ptr> events::random_slices;
 
 events::events() {
   static bool initialized = false;
@@ -47,6 +62,40 @@ events::events() {
   i += 1000; // Cause an artificial gap in the ID sequence.
   assign(bro_http_log);
   assign(bgpdump_txt);
+  MESSAGE("building slices of " << slice_size << " events each");
+  auto slice_up = [&](const std::vector<event>& src) {
+    VAST_ASSERT(src.size() > 0);
+    auto layout = caf::get<record_type>(src.front().type());
+    record_field tstamp_field{"timestamp", timestamp_type{}};
+    layout.fields.insert(layout.fields.begin(), std::move(tstamp_field));
+    auto builder = default_table_slice::make_builder(std::move(layout));
+    auto full_slices = src.size() / slice_size;
+    std::vector<table_slice_ptr> slices;
+    auto i = src.begin();
+    auto make_slice = [&](size_t size) {
+      if (size == 0)
+        return;
+      auto first_id_in_slice = i->id();
+      for (size_t j = 0; j < size; ++j) {
+        auto& e = *i++;
+        builder->add(e.timestamp());
+        builder->recursive_add(e.data());
+      }
+      slices.emplace_back(builder->finish());
+      slices.back()->offset(first_id_in_slice);
+    };
+    // Insert full slices.
+    for (size_t i = 0; i < full_slices; ++i)
+      make_slice(slice_size);
+    // Insert remaining events.
+    make_slice(src.size() % slice_size);
+    return slices;
+  };
+  bro_conn_log_slices = slice_up(bro_conn_log);
+  bro_dns_log_slices = slice_up(bro_dns_log);
+  bro_http_log_slices = slice_up(bro_http_log);
+  bgpdump_txt_slices = slice_up(bgpdump_txt);
+  random_slices = slice_up(random);
 }
 
 } // namespace fixtures

--- a/libvast/test/fixtures/events.hpp
+++ b/libvast/test/fixtures/events.hpp
@@ -29,6 +29,9 @@ using namespace vast;
 struct events {
   events();
 
+  /// Size of all pre-filled slice vectors.
+  static size_t slice_size;
+
   static std::vector<event> bro_conn_log;
   static std::vector<event> bro_dns_log;
   static std::vector<event> bro_http_log;

--- a/libvast/test/fixtures/events.hpp
+++ b/libvast/test/fixtures/events.hpp
@@ -17,6 +17,7 @@
 
 #include "vast/error.hpp"
 #include "vast/event.hpp"
+#include "vast/fwd.hpp"
 
 #include "data.hpp"
 #include "test.hpp"
@@ -33,6 +34,12 @@ struct events {
   static std::vector<event> bro_http_log;
   static std::vector<event> bgpdump_txt;
   static std::vector<event> random;
+
+  static std::vector<table_slice_ptr> bro_http_log_slices;
+  static std::vector<table_slice_ptr> bro_conn_log_slices;
+  static std::vector<table_slice_ptr> bro_dns_log_slices;
+  static std::vector<table_slice_ptr> bgpdump_txt_slices;
+  static std::vector<table_slice_ptr> random_slices;
 
 private:
   template <class Reader>

--- a/libvast/test/fixtures/events.hpp
+++ b/libvast/test/fixtures/events.hpp
@@ -38,11 +38,20 @@ struct events {
   static std::vector<event> bgpdump_txt;
   static std::vector<event> random;
 
-  static std::vector<table_slice_ptr> bro_http_log_slices;
   static std::vector<table_slice_ptr> bro_conn_log_slices;
-  static std::vector<table_slice_ptr> bro_dns_log_slices;
-  static std::vector<table_slice_ptr> bgpdump_txt_slices;
-  static std::vector<table_slice_ptr> random_slices;
+  // TODO: table_slice::recursive_add flattens too much, why the following
+  //       slices won't work. However, flatten(value) is also broken
+  //       at the moment (cf. #3215), so we can't fix it until then.
+  // static std::vector<table_slice_ptr> bro_http_log_slices;
+  // static std::vector<table_slice_ptr> bro_dns_log_slices;
+  // static std::vector<table_slice_ptr> bgpdump_txt_slices;
+  // static std::vector<table_slice_ptr> random_slices;
+
+  static std::vector<const_table_slice_ptr> const_bro_conn_log_slices;
+  // static std::vector<const_table_slice_ptr> const_bro_http_log_slices;
+  // static std::vector<const_table_slice_ptr> const_bro_dns_log_slices;
+  // static std::vector<const_table_slice_ptr> const_bgpdump_txt_slices;
+  // static std::vector<const_table_slice_ptr> const_random_slices;
 
 private:
   template <class Reader>

--- a/libvast/test/fixtures/events.hpp
+++ b/libvast/test/fixtures/events.hpp
@@ -58,6 +58,11 @@ struct events {
   static std::vector<table_slice_ptr> ascending_integers_slices;
   static std::vector<const_table_slice_ptr> const_ascending_integers_slices;
 
+  /// 10000 integer values, alternating between 0 and 1.
+  static std::vector<event> alternating_integers;
+  static std::vector<table_slice_ptr> alternating_integers_slices;
+  static std::vector<const_table_slice_ptr> const_alternating_integers_slices;
+
   static record_type bro_conn_log_layout();
 
   template <class... Ts>

--- a/libvast/test/fixtures/events.hpp
+++ b/libvast/test/fixtures/events.hpp
@@ -29,7 +29,7 @@ using namespace vast;
 struct events {
   events();
 
-  /// Size of all pre-filled slice vectors.
+  /// Maximum size of all generated slices.
   static size_t slice_size;
 
   static std::vector<event> bro_conn_log;
@@ -52,6 +52,18 @@ struct events {
   // static std::vector<const_table_slice_ptr> const_bro_dns_log_slices;
   // static std::vector<const_table_slice_ptr> const_bgpdump_txt_slices;
   // static std::vector<const_table_slice_ptr> const_random_slices;
+
+  /// 10000 ascending integer values, starting at 0.
+  static std::vector<event> ascending_integers;
+  static std::vector<table_slice_ptr> ascending_integers_slices;
+  static std::vector<const_table_slice_ptr> const_ascending_integers_slices;
+
+  static record_type bro_conn_log_layout();
+
+  template <class... Ts>
+  static std::vector<vector> make_rows(Ts... xs) {
+    return {make_vector(xs)...};
+  }
 
 private:
   template <class Reader>

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -30,7 +30,6 @@ namespace {
 
 static constexpr size_t num_partitions = 4;
 static constexpr size_t num_events_per_parttion = 25;
-static constexpr size_t num_events_per_type = 20;
 
 timestamp epoch;
 

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -16,8 +16,10 @@
 
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
-#include "vast/event.hpp"
+#include "vast/default_table_slice.hpp"
 #include "vast/meta_index.hpp"
+#include "vast/table_slice.hpp"
+#include "vast/table_slice_builder.hpp"
 #include "vast/uuid.hpp"
 
 using namespace vast;
@@ -32,44 +34,49 @@ static constexpr size_t num_events_per_type = 20;
 
 timestamp epoch;
 
+timestamp get_timestamp(caf::optional<data_view> element){
+  return materialize(caf::get<view<timestamp>>(*element));
+}
+
 // Builds a chain of events that are 1s apart, where consecutive chunk of
 // num_events_per_type events have the same type (order: integer, string,
 // boolean, real).
 struct generator {
-  size_t i;
+  id offset;
 
-  generator(size_t first_event_id) : i(first_event_id) {
+  explicit generator(size_t first_event_id) : offset(first_event_id) {
     // nop
   }
 
-  event operator()() {
-    event result;
-    switch  (i / num_events_per_type) {
-      case 0: result = event::make(i * i, integer_type{}); break;
-      case 1: result = event::make("foo" + std::to_string(i)); break;
-      case 2: result = event::make(i % 2 == 0, boolean_type{}); break;
-      case 3: result = event::make(1.0 / i, real_type{}); break;
-      case 4: result = event::make(vector{i}, vector_type{}); break;
-      default: FAIL("trying to create too many events using the generator");
+  const_table_slice_ptr operator()(size_t num) {
+    record_type layout = record_type{
+      {"timestamp", timestamp_type{}},
+      {"content", string_type{}}
+    };
+    auto builder = default_table_slice::make_builder(layout);
+    auto str = "foo";
+    for (size_t i = 0; i < num; ++i) {
+      auto ts = epoch + std::chrono::seconds(i + offset);
+      builder->add(make_data_view(ts));
+      builder->add(make_data_view(str));
     }
-    result.id(i);
-    result.timestamp(epoch + std::chrono::seconds(i));
-    ++i;
-    return result;
+    auto slice = builder->finish();
+    slice->offset(offset);
+    offset += num;
+    return slice;
   }
 };
 
 struct mock_partition {
   mock_partition(uuid uid, size_t num) : id(std::move(uid)) {
     generator g{num_events_per_parttion * num};
-    for (size_t i = 0; i < num_events_per_parttion; ++i)
-      events.emplace_back(g());
-    range.from = events.front().timestamp();
-    range.to = events.back().timestamp();
+    slice = g(num_events_per_parttion);
+    range.from = get_timestamp(slice->at(0, 0));
+    range.to = get_timestamp(slice->at(slice->rows() - 1, 0));
   }
 
   uuid id;
-  std::vector<event> events;
+  const_table_slice_ptr slice;
   meta_index::interval range;
 };
 
@@ -143,7 +150,7 @@ TEST(uuid lookup) {
   std::vector<mock_partition> mock_partitions;
   for (size_t i = 0; i < num_partitions; ++i) {
     auto& mp = mock_partitions.emplace_back(ids[i], i);
-    uut.add(mp.id, mp.events);
+    uut.add(mp.id, mp.slice);
   }
   MESSAGE("verify generated timestamps");
   {

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -28,8 +28,8 @@ using std::literals::operator""s;
 
 namespace {
 
-static constexpr size_t num_partitions = 4;
-static constexpr size_t num_events_per_parttion = 25;
+constexpr size_t num_partitions = 4;
+constexpr size_t num_events_per_parttion = 25;
 
 timestamp epoch;
 

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -60,7 +60,8 @@ struct fixture : fixture_base {
   }
 
   void spawn_importer() {
-    importer = self->spawn(system::importer, directory / "importer");
+    importer = self->spawn(system::importer, directory / "importer",
+                           slice_size);
   }
 
   void spawn_consensus() {

--- a/libvast/test/system/source.cpp
+++ b/libvast/test/system/source.cpp
@@ -11,37 +11,88 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include "vast/format/bro.hpp"
+#define SUITE source
+
 #include "vast/system/source.hpp"
 
-#include "vast/detail/make_io_stream.hpp"
-
-#define SUITE system
-#include "test.hpp"
 #include "data.hpp"
-#include "fixtures/actor_system.hpp"
+#include "test.hpp"
+
+#include "fixtures/actor_system_and_events.hpp"
+
+#include "vast/detail/make_io_stream.hpp"
+#include "vast/format/bro.hpp"
+#include "vast/system/atoms.hpp"
+#include "vast/table_slice.hpp"
 
 using namespace vast;
 using namespace vast::system;
 
-FIXTURE_SCOPE(source_tests, fixtures::actor_system)
+namespace {
 
-TEST(Bro source) {
+struct test_sink_state {
+  std::vector<table_slice_ptr> slices;
+  inline static constexpr const char* name = "test-sink";
+};
+
+using test_sink_type = caf::stateful_actor<test_sink_state>;
+
+caf::behavior test_sink(test_sink_type* self, caf::actor src) {
+  self->send(src, sink_atom::value, self);
+  return {
+    [=](caf::stream<table_slice_ptr> in) {
+      return self->make_sink(
+        in,
+        [](caf::unit_t&) {
+          // nop
+        },
+        [=](caf::unit_t&, table_slice_ptr ptr) {
+          self->state.slices.emplace_back(std::move(ptr));
+        },
+        [=](caf::unit_t&, const error&) {
+          CAF_MESSAGE(self->name() << " is done");
+        }
+      );
+    }
+  };
+}
+
+} // namespace <anonymous>
+
+FIXTURE_SCOPE(source_tests, fixtures::deterministic_actor_system_and_events)
+
+TEST(bro source) {
+  MESSAGE("start reader");
+  namespace bf = format::bro;
   auto stream = detail::make_input_stream(bro::conn);
   REQUIRE(stream);
-  format::bro::reader reader{std::move(*stream)};
-  auto src = self->spawn(source<format::bro::reader>, std::move(reader));
-  self->monitor(src);
-  self->send(src, sink_atom::value, self);
-  self->send(src, run_atom::value);
-  self->receive([&](const std::vector<event>& events) {
-    CHECK_EQUAL(events.size(), 8462u);
-    CHECK_EQUAL(events[0].type().name(), "bro::conn");
-  });
-  // A source terminates normally after having consumed the entire input.
-  self->receive([&](const caf::down_msg& msg) {
-    CHECK(msg.reason == caf::exit_reason::normal);
-  });
+  bf::reader reader{std::move(*stream)};
+  MESSAGE("start source for producing table slices of size 100");
+  auto src = self->spawn(source<bf::reader>, std::move(reader),
+                         default_table_slice::make_builder,
+                         100u);
+  sched.run();
+  MESSAGE("start sink and run exhaustively");
+  auto snk = self->spawn(test_sink, src);
+  run_exhaustively();
+  MESSAGE("collect all rows as values");
+  auto& st = deref<test_sink_type>(snk).state;
+  REQUIRE_EQUAL(st.slices.size(), 85u);
+  std::vector<value> row_contents;
+  for (size_t row = 0; row < 85u; ++row) {
+    /// The first column is the automagically added timestamp.
+    auto xs = st.slices[row]->rows_to_values(0, table_slice::npos, 1);
+    std::move(xs.begin(), xs.end(), std::back_inserter(row_contents));
+  }
+  std::vector<value> bro_conn_log_values;
+  for (auto& x : bro_conn_log)
+    bro_conn_log_values.emplace_back(flatten(x));
+  REQUIRE_EQUAL(row_contents.size(), bro_conn_log_values.size());
+  for (size_t i = 0; i < row_contents.size(); ++i)
+    REQUIRE_EQUAL(row_contents[i], bro_conn_log_values[i]);
+  MESSAGE("shutdown");
+  self->send_exit(src, caf::exit_reason::user_shutdown);
+  sched.run();
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -110,12 +110,8 @@ TEST(equality comparison) {
 TEST(less-than comparison) {
   CHECK(!(type{} < type{}));
   CHECK(!(real_type{} < real_type{}));
-  auto x = string_type{}.name("a");
-  auto y = string_type{}.name("b");
-  CHECK(x < y);
-  x = x.name("b");
-  y = y.name("a");
-  CHECK(x > y);
+  CHECK(string_type{}.name("a") < string_type{}.name("b"));
+  CHECK(record_type{}.name("a") < record_type{}.name("b"));
 }
 
 TEST(strict weak ordering) {

--- a/libvast/vast/column_index.hpp
+++ b/libvast/vast/column_index.hpp
@@ -28,24 +28,14 @@ namespace vast {
 
 // -- free functions -----------------------------------------------------------
 
-/// Creates a single column for the timestamp.
-/// @relates column_index
-caf::expected<column_index_ptr> make_time_index(path filename);
-
 /// Creates a single column for the type name.
 /// @relates column_index
-caf::expected<column_index_ptr> make_type_index(path filename);
+caf::expected<column_index_ptr> make_type_column_index(path filename);
 
-/// Creates a single colum for a value of non-record type `event_type`.
+/// Creates a single colum for a value at column `col`.
 /// @relates column_index
-caf::expected<column_index_ptr> make_flat_data_index(path filename,
-                                                     type event_type);
-
-/// Creates a single colum for a field of record type `event_type`.
-/// @relates column_index
-caf::expected<column_index_ptr> make_field_data_index(path filename,
-                                                      type field_type,
-                                                      offset off);
+caf::expected<column_index_ptr>
+make_column_index(path filename, type column_type, size_t column);
 
 // -- class definition ---------------------------------------------------------
 
@@ -71,7 +61,7 @@ public:
 
   /// Adds an event to the index.
   /// @pre `init()` was called previously.
-  virtual void add(const event& x) = 0;
+  virtual void add(const const_table_slice_ptr& x) = 0;
 
   /// Queries event IDs that fulfill the given predicate.
   /// @pre `init()` was called previously.

--- a/libvast/vast/default_table_slice.hpp
+++ b/libvast/vast/default_table_slice.hpp
@@ -15,6 +15,7 @@
 
 #include <vector>
 
+#include "vast/data.hpp"
 #include "vast/fwd.hpp"
 #include "vast/table_slice.hpp"
 
@@ -37,6 +38,8 @@ public:
   /// @param layout The layout of the table_slice.
   /// @returns The builder instance.
   static table_slice_builder_ptr make_builder(record_type layout);
+
+  static table_slice_ptr make(record_type layout, std::vector<vector>& rows);
 
   // -- properties -------------------------------------------------------------
 

--- a/libvast/vast/default_table_slice.hpp
+++ b/libvast/vast/default_table_slice.hpp
@@ -39,7 +39,8 @@ public:
   /// @returns The builder instance.
   static table_slice_builder_ptr make_builder(record_type layout);
 
-  static table_slice_ptr make(record_type layout, std::vector<vector>& rows);
+  static table_slice_ptr make(record_type layout,
+                              const std::vector<vector>& rows);
 
   // -- properties -------------------------------------------------------------
 

--- a/libvast/vast/default_table_slice_builder.hpp
+++ b/libvast/vast/default_table_slice_builder.hpp
@@ -34,6 +34,8 @@ public:
 
   table_slice_ptr finish() final;
 
+  size_t rows() const noexcept final;
+
 private:
   // -- member variables -------------------------------------------------------
 

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -21,25 +21,55 @@ namespace vast::defaults {
 
 namespace command {
 
+/// Path to persistent state.
 extern const char* directory;
+
+/// Locator for connecting to a remote node in "host:port" notation.
 extern const char* endpoint;
+
+/// Server ID for the consensus module.
 extern const char* id;
+
+/// Path for reading input events or `-` for reading from STDIN.
 extern const char* read_path;
+
+/// Path to alternate schema.
 extern const char* schema_path;
+
+/// Path for writing query results or `-` for writing to STDOUT.
 extern const char* write_path;
+
+/// Inverse factor by which to delay packets. For example, if 5, then for two
+/// packets spaced *t* seconds apart, the source will sleep for *t/5* seconds.
 extern int64_t pseudo_realtime_factor;
+
+/// Number of bytes to keep per event.
 extern size_t cutoff;
+
+/// Flow table expiration interval.
 extern size_t flow_expiry;
+
+/// Flush to disk after that many packets.
 extern size_t flush_interval;
+
+/// Maximum number of results.
 extern size_t max_events;
+
+/// Maximum flow lifetime before eviction.
 extern size_t max_flow_age;
+
+
+/// Number of concurrent flows to track.
 extern size_t max_flows;
+
+/// The unique ID of this node.
 extern std::string node_id;
 
 } // namespace command
 
 namespace system {
 
+/// Maximum size for sources that generate table slices.
 extern size_t table_slice_size;
 
 } // namespace system

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -38,4 +38,10 @@ extern std::string node_id;
 
 } // namespace command
 
+namespace system {
+
+extern size_t table_slice_size;
+
+} // namespace system
+
 } // namespace vast::defaults

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -31,6 +31,7 @@ class path;
 class pattern;
 class port;
 class schema;
+class store;
 class subnet;
 class table_index;
 class table_slice;

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -99,8 +99,10 @@ private:
 
 // -- related free functions ---------------------------------------------------
 
+/// @relates meta_index::interval
 bool operator==(const meta_index::interval&, const meta_index::interval&);
 
+/// @relates meta_index::interval
 inline bool operator!=(const meta_index::interval& x,
                        const meta_index::interval& y) {
   return !(x == y);

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -53,17 +53,7 @@ public:
   /// Returns the synopsis for a partition if present, returns `none` otherwise.
   caf::optional<partition_synopsis> operator[](const uuid& partition) const;
 
-  /// Adds a set of events to the index for a given partition.
-  template <class EventIterator>
-  void add(const uuid& partition, EventIterator first, EventIterator last) {
-    auto& rng = partitions_[partition].range;
-    for_each(first, last, [&](const event& x) { add_one(rng, x); });
-  }
-
-  template <class Container>
-  void add(const uuid& partition, const Container& xs) {
-    add(partition, xs.begin(), xs.end());
-  }
+  void add(const uuid& partition, const const_table_slice_ptr& slice);
 
   /// Retrieves the list of partition IDs for a given expression.
   std::vector<uuid> lookup(const expression& expr) const;
@@ -102,15 +92,12 @@ public:
   }
 
 private:
-  // -- utility ----------------------------------------------------------------
-
-  /// Adds `x` to the time interval `rng`.
-  static void add_one(interval& rng, const event& x);
-
   // -- member variables -------------------------------------------------------
 
   map_type partitions_;
 };
+
+// -- related free functions ---------------------------------------------------
 
 bool operator==(const meta_index::interval&, const meta_index::interval&);
 

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -15,12 +15,15 @@
 
 #include <vector>
 
-#include <caf/all.hpp>
+#include <caf/fwd.hpp>
+#include <caf/replies_to.hpp>
+#include <caf/stateful_actor.hpp>
+#include <caf/typed_actor.hpp>
+#include <caf/typed_event_based_actor.hpp>
 
-#include "vast/event.hpp"
-#include "vast/filesystem.hpp"
+#include "vast/fwd.hpp"
+#include "vast/ids.hpp"
 #include "vast/store.hpp"
-
 #include "vast/system/atoms.hpp"
 
 namespace vast::system {
@@ -34,7 +37,7 @@ struct archive_state {
 /// @relates archive
 // TODO: change the interface from 'vector<event>' to 'batch'.
 using archive_type = caf::typed_actor<
-  caf::reacts_to<caf::stream<event>>,
+  caf::reacts_to<caf::stream<const_table_slice_ptr>>,
   caf::reacts_to<std::vector<event>>,
   caf::replies_to<ids>::with<std::vector<event>>
 >;

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -35,7 +35,6 @@ struct archive_state {
 };
 
 /// @relates archive
-// TODO: change the interface from 'vector<event>' to 'batch'.
 using archive_type = caf::typed_actor<
   caf::reacts_to<caf::stream<const_table_slice_ptr>>,
   caf::reacts_to<std::vector<event>>,

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -19,8 +19,9 @@
 #include <unordered_map>
 
 #include "vast/aliases.hpp"
-#include "vast/ids.hpp"
+#include "vast/event.hpp"
 #include "vast/expression.hpp"
+#include "vast/ids.hpp"
 #include "vast/query_options.hpp"
 #include "vast/uuid.hpp"
 

--- a/libvast/vast/system/indexer.hpp
+++ b/libvast/vast/system/indexer.hpp
@@ -33,11 +33,11 @@ struct indexer_state {
   static inline const char* name = "indexer";
 };
 
-/// Indexes an event.
+/// Indexes table slices.
 /// @param self The actor handle.
 /// @param dir The directory where to store the indexes in.
-/// @param type event_type The type of the event to index.
+/// @param layout The type of individual columns in slices.
 caf::behavior indexer(caf::stateful_actor<indexer_state>* self, path dir,
-                      type event_type);
+                      record_type layout);
 
 } // namespace vast::system

--- a/libvast/vast/system/indexer_manager.hpp
+++ b/libvast/vast/system/indexer_manager.hpp
@@ -31,7 +31,7 @@ namespace vast::system {
 /// Manages a set of INDEXER actors for a single partition.
 class indexer_manager {
 public:
-  using indexer_factory = std::function<caf::actor (path, type)>;
+  using indexer_factory = std::function<caf::actor (path, record_type)>;
 
   indexer_manager(partition& parent, indexer_factory f);
 
@@ -69,15 +69,15 @@ public:
   /// Adds an INDEXER to the manager if no INDEXER is assigned to `key` yet.
   /// @returns The INDEXER assigned to `key` and whether the INDEXER was
   ///          newly added.
-  std::pair<caf::actor, bool> get_or_add(const type& key);
+  std::pair<caf::actor, bool> get_or_add(const record_type& key);
 
 private:
-  caf::actor make_indexer(const type& key, const std::string& digest);
+  caf::actor make_indexer(const record_type& key, const std::string& digest);
 
-  caf::actor make_indexer(const type& key);
+  caf::actor make_indexer(const record_type& key);
 
-  /// Stores one INDEXER actor per type.
-  caf::detail::unordered_flat_map<type, caf::actor> indexers_;
+  /// Stores one INDEXER actor per layout.
+  caf::detail::unordered_flat_map<record_type, caf::actor> indexers_;
 
   /// Factory for spawning INDEXER actors.
   indexer_factory make_indexer_;

--- a/libvast/vast/system/indexer_stage_driver.hpp
+++ b/libvast/vast/system/indexer_stage_driver.hpp
@@ -88,7 +88,9 @@ private:
   /// Generates new partitions whenever the current partition becomes full.
   partition_factory factory_;
 
-  /// Stores how many rows approximately form one partition.
+  /// Threshold for closing partitions, i.e., the stage driver creates a new
+  /// partition once a slice pushes the size of the current partition to or
+  /// over this value.
   size_t max_partition_size_;
 };
 

--- a/libvast/vast/system/indexer_stage_driver.hpp
+++ b/libvast/vast/system/indexer_stage_driver.hpp
@@ -16,39 +16,43 @@
 #include <caf/broadcast_downstream_manager.hpp>
 #include <caf/stream_stage_driver.hpp>
 
+#include "vast/table_slice.hpp"
 #include "vast/type.hpp"
-#include "vast/event.hpp"
 
 #include "vast/system/fwd.hpp"
 
 namespace vast::system {
 
 /// @relates indexer_stage_driver
-/// Filter type for dispatching events to INDEXER actors.
+/// Filter type for dispatching slices to INDEXER actors.
 using indexer_stage_filter = type;
 
 /// @relates indexer_stage_driver
 /// Selects an INDEXER actor based on its filter.
 struct indexer_stage_selector {
-  inline bool operator()(const indexer_stage_filter& f, const event& x) const {
-    return f == x.type();
+  inline bool operator()(const indexer_stage_filter& f,
+                         const const_table_slice_ptr& x) const {
+    return f == x->layout();
   }
 };
 
 /// @relates indexer_stage_driver
 /// A downstream manager type for dispatching data to INDEXER actors.
 using indexer_downstream_manager
-  = caf::broadcast_downstream_manager<event, indexer_stage_filter,
+  = caf::broadcast_downstream_manager<const_table_slice_ptr,
+                                      indexer_stage_filter,
                                       indexer_stage_selector>;
 
-/// A stream stage for dispatching events to INDEXER actors. One set of INDEXER
+/// A stream stage for dispatching slices to INDEXER actors. One set of INDEXER
 /// actors is used per partition.
 class indexer_stage_driver
-  : public caf::stream_stage_driver<event, indexer_downstream_manager> {
+  : public caf::stream_stage_driver<const_table_slice_ptr,
+                                    indexer_downstream_manager> {
 public:
   // -- member types -----------------------------------------------------------
 
-  using super = caf::stream_stage_driver<event, indexer_downstream_manager>;
+  using super = caf::stream_stage_driver<const_table_slice_ptr,
+                                         indexer_downstream_manager>;
 
   using partition_factory = std::function<partition_ptr()>;
 
@@ -67,19 +71,15 @@ public:
 
   // -- interface implementation -----------------------------------------------
 
-  void process(downstream_type& out, batch_type& batch) override;
+  void process(downstream_type& out, batch_type& slices) override;
 
 private:
-  // -- utility ----------------------------------------------------------------
-
-  void consume(downstream_type& out, batch_iterator first, batch_iterator last);
-
   // -- member variables -------------------------------------------------------
 
   /// Keeps statistics for all partitions.
   meta_index& pindex_;
 
-  /// Stores how many events remain in the current partition.
+  /// Stores how many rows remain in the current partition.
   size_t remaining_in_partition_;
 
   /// Our current partition.
@@ -88,7 +88,7 @@ private:
   /// Generates new partitions whenever the current partition becomes full.
   partition_factory factory_;
 
-  /// Stores how many events form one partition.
+  /// Stores how many rows approximately form one partition.
   size_t max_partition_size_;
 };
 

--- a/libvast/vast/system/partition.hpp
+++ b/libvast/vast/system/partition.hpp
@@ -40,8 +40,9 @@ public:
 
   /// Persistent meta state for the partition.
   struct meta_data {
-    /// Maps type digests (used as directory names) to types.
-    caf::detail::unordered_flat_map<std::string, type> types;
+    /// Maps type digests (used as directory names) to layouts (i.e. record
+    /// types).
+    caf::detail::unordered_flat_map<std::string, record_type> types;
 
     /// Stores whether we modified `types` after loading it.
     bool dirty = false;
@@ -88,15 +89,15 @@ public:
     return id_;
   }
 
-  /// Returns a list of all types in this partition.
-  std::vector<type> types() const;
+  /// Returns all layouts in this partition.
+  std::vector<record_type> layouts() const;
 
   /// Returns the file name for saving or loading the ::meta_data.
   path meta_file() const;
 
   // -- operations -------------------------------------------------------------
 
-  /// Checks what types could match `expr` and calls
+  /// Checks what layout could match `expr` and calls
   /// `self->request(...).then(f)` for each matching INDEXER.
   /// @returns the number of matched INDEXER actors.
   template <class F>
@@ -117,9 +118,9 @@ public:
   std::vector<caf::actor> get_indexers(const expression& expr);
 
 private:
-  /// Called from the INDEXER manager whenever a new type gets added during
+  /// Called from the INDEXER manager whenever a new layout gets added during
   /// ingestion.
-  inline void add_type(const std::string& digest, const type& t) {
+  inline void add_layout(const std::string& digest, const record_type& t) {
     if (meta_data_.types.emplace(digest, t).second && !meta_data_.dirty)
       meta_data_.dirty = true;
   }

--- a/libvast/vast/system/reader_command.hpp
+++ b/libvast/vast/system/reader_command.hpp
@@ -61,7 +61,7 @@ protected:
     if (!in)
       return in.error();
     Reader reader{std::move(*in)};
-    auto src = self->spawn(source<Reader>, std::move(reader));
+    auto src = self->spawn(default_source<Reader>, std::move(reader));
     // Supply an alternate schema, if requested.
     auto schema_file = get_or(options, "schema",
                               defaults::command::schema_path);

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -69,6 +69,7 @@ struct source_state {
   using factory_type = table_slice_builder_ptr (*)(record_type);
 
   using downstream_manager = caf::broadcast_downstream_manager<table_slice_ptr>;
+
   // -- member variables -------------------------------------------------------
 
   /// Filters events, i.e., causes the source to drop all matching events.

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -15,7 +15,9 @@
 
 #include <cstddef>
 #include <limits>
+#include <vector>
 
+#include <caf/allowed_unsafe_message_type.hpp>
 #include <caf/fwd.hpp>
 #include <caf/ref_counted.hpp>
 
@@ -102,3 +104,11 @@ using table_slice_ptr = caf::intrusive_ptr<table_slice>;
 using const_table_slice_ptr = caf::intrusive_ptr<const table_slice>;
 
 } // namespace vast
+
+CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::table_slice_ptr)
+
+CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::vector<vast::table_slice_ptr>)
+
+CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::const_table_slice_ptr)
+
+CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::vector<vast::const_table_slice_ptr>)

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -67,6 +67,9 @@ public:
                                     size_type first_column = 0u,
                                     size_type num_columns = npos) const;
 
+  std::vector<event> rows_to_events(size_type first_row = 0u,
+                                    size_type num_rows = npos) const;
+
   /// @returns the number of rows in the slice.
   inline size_type rows() const noexcept {
     return rows_;

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -53,6 +53,11 @@ public:
     return layout_;
   }
 
+  /// @returns the layout for columns in range
+  /// [first_column, first_column + num_columns).
+  record_type layout(size_type first_column,
+                     size_type num_columns = npos) const;
+
   /// @returns the content of a row wrapped into an value.
   caf::optional<value> row_to_value(size_type row, size_type first_column = 0u,
                                     size_type num_columns = npos) const;

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -98,6 +98,14 @@ protected:
 };
 
 /// @relates table_slice
+bool operator==(const table_slice& x, const table_slice& y);
+
+/// @relates table_slice
+inline bool operator!=(const table_slice& x, const table_slice& y) {
+  return !(x == y);
+}
+
+/// @relates table_slice
 using table_slice_ptr = caf::intrusive_ptr<table_slice>;
 
 /// @relates table_slice

--- a/libvast/vast/table_slice_builder.hpp
+++ b/libvast/vast/table_slice_builder.hpp
@@ -47,6 +47,9 @@ public:
   /// @returns A table slice from the accumulated calls to add or `nullptr` on
   ///          failure.
   virtual table_slice_ptr finish() = 0;
+
+  /// Returns the current number of rows in the table slice.
+  virtual size_t rows() const noexcept = 0;
 };
 
 /// @relates table_slice_builder

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -638,13 +638,9 @@ struct record_type final : recursive_type<record_type> {
 
   std::vector<record_field> fields;
 
-  bool equals(const abstract_type& other) const final {
-    return super::equals(other) && fields == downcast(other).fields;
-  }
+  bool equals(const abstract_type& other) const final;
 
-  bool less_than(const abstract_type& other) const final {
-    return super::less_than(other) && fields < downcast(other).fields;
-  }
+  bool less_than(const abstract_type& other) const final;
 };
 
 /// An alias of another type.

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -665,6 +665,14 @@ record_type flatten(const record_type& rec);
 /// @relates type record_type
 type flatten(const type& t);
 
+/// Queries whether `rec` is a flattened record.
+/// @relates type record_type
+bool is_flat(const record_type& rec);
+
+/// Queries whether `rec` is a flattened record.
+/// @relates type record_type
+bool is_flat(const type& t);
+
 /// Computes the size of a flat representation of `rec`.
 size_t flat_size(const record_type& rec);
 


### PR DESCRIPTION
Port SOURCE, IMPORTER, ARCHIVE, and INDEX to the new table slice API. The source now streams `table_slice_ptr` to the importer and the importer streams `const_table_slice_ptr` to all other components after assigning IDs.