### PR TITLE
Add new handle types for table slices

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -25,6 +25,7 @@ set(libvast_sources
   src/compression.cpp
   src/concept/hashable/crc.cpp
   src/concept/hashable/xxhash.cpp
+  src/const_table_slice_handle.cpp
   src/data.cpp
   src/default_table_slice.cpp
   src/default_table_slice_builder.cpp
@@ -97,6 +98,7 @@ set(libvast_sources
   src/table_index.cpp
   src/table_slice.cpp
   src/table_slice_builder.cpp
+  src/table_slice_handle.cpp
   src/time.cpp
   src/type.cpp
   src/uuid.cpp

--- a/libvast/src/const_table_slice_handle.cpp
+++ b/libvast/src/const_table_slice_handle.cpp
@@ -1,0 +1,39 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/const_table_slice_handle.hpp"
+
+#include <caf/detail/scope_guard.hpp>
+#include <caf/error.hpp>
+
+#include "vast/table_slice.hpp"
+
+namespace vast {
+
+const_table_slice_handle::~const_table_slice_handle() {
+  // nop
+}
+
+caf::error inspect(caf::serializer& sink, const_table_slice_handle& hdl) {
+  return table_slice::save_ptr(sink, hdl.get());
+}
+
+caf::error inspect(caf::deserializer& source, const_table_slice_handle& hdl) {
+  table_slice_ptr ptr;
+  auto guard = caf::detail::make_scope_guard([&] {
+    hdl = const_table_slice_handle{std::move(ptr)};
+  });
+  return table_slice::load_ptr(source, ptr);
+}
+
+} // namespace vast

--- a/libvast/src/const_table_slice_handle.cpp
+++ b/libvast/src/const_table_slice_handle.cpp
@@ -25,7 +25,7 @@ const_table_slice_handle::~const_table_slice_handle() {
 }
 
 caf::error inspect(caf::serializer& sink, const_table_slice_handle& hdl) {
-  return table_slice::save_ptr(sink, hdl.get());
+  return table_slice::serialize_ptr(sink, hdl.get());
 }
 
 caf::error inspect(caf::deserializer& source, const_table_slice_handle& hdl) {
@@ -33,7 +33,7 @@ caf::error inspect(caf::deserializer& source, const_table_slice_handle& hdl) {
   auto guard = caf::detail::make_scope_guard([&] {
     hdl = const_table_slice_handle{std::move(ptr)};
   });
-  return table_slice::load_ptr(source, ptr);
+  return table_slice::deserialize_ptr(source, ptr);
 }
 
 } // namespace vast

--- a/libvast/src/default_table_slice.cpp
+++ b/libvast/src/default_table_slice.cpp
@@ -13,7 +13,9 @@
 
 #include "vast/default_table_slice.hpp"
 
+#include <caf/deserializer.hpp>
 #include <caf/make_counted.hpp>
+#include <caf/serializer.hpp>
 
 #include "vast/default_table_slice_builder.hpp"
 
@@ -26,6 +28,16 @@ default_table_slice::default_table_slice(record_type layout)
 
 table_slice_ptr default_table_slice::clone() const {
   return caf::make_counted<default_table_slice>(*this);
+}
+
+caf::error default_table_slice::save(caf::serializer& sink) {
+  return sink(offset_, xs_);
+}
+
+caf::error default_table_slice::load(caf::deserializer& source) {
+  auto err = source(offset_, xs_);
+  rows_ = xs_.size();
+  return err;
 }
 
 caf::optional<data_view>
@@ -54,6 +66,10 @@ table_slice_ptr default_table_slice::make(record_type layout,
   auto result = builder->finish();
   VAST_ASSERT(result != nullptr);
   return result;
+}
+
+caf::atom_value default_table_slice::implementation_id() const noexcept {
+  return caf::atom("DEFAULT");
 }
 
 } // namespace vast

--- a/libvast/src/default_table_slice.cpp
+++ b/libvast/src/default_table_slice.cpp
@@ -30,11 +30,11 @@ table_slice_ptr default_table_slice::clone() const {
   return caf::make_counted<default_table_slice>(*this);
 }
 
-caf::error default_table_slice::save(caf::serializer& sink) const {
+caf::error default_table_slice::serialize(caf::serializer& sink) const {
   return sink(offset_, xs_);
 }
 
-caf::error default_table_slice::load(caf::deserializer& source) {
+caf::error default_table_slice::deserialize(caf::deserializer& source) {
   auto err = source(offset_, xs_);
   rows_ = xs_.size();
   return err;

--- a/libvast/src/default_table_slice.cpp
+++ b/libvast/src/default_table_slice.cpp
@@ -30,7 +30,7 @@ table_slice_ptr default_table_slice::clone() const {
   return caf::make_counted<default_table_slice>(*this);
 }
 
-caf::error default_table_slice::save(caf::serializer& sink) {
+caf::error default_table_slice::save(caf::serializer& sink) const {
   return sink(offset_, xs_);
 }
 

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -28,12 +28,15 @@
 #include "vast/batch.hpp"
 #include "vast/bitmap.hpp"
 #include "vast/config.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/error.hpp"
 #include "vast/event.hpp"
 #include "vast/expression.hpp"
 #include "vast/operator.hpp"
 #include "vast/query_options.hpp"
 #include "vast/schema.hpp"
+#include "vast/table_slice.hpp"
+#include "vast/table_slice_handle.hpp"
 #include "vast/time.hpp"
 #include "vast/type.hpp"
 #include "vast/uuid.hpp"
@@ -69,6 +72,8 @@ configuration::configuration() {
   add_message_type<type>("vast::type");
   add_message_type<timespan>("vast::timespan");
   add_message_type<uuid>("vast::uuid");
+  add_message_type<table_slice_handle>("vast::table_slice_handle");
+  add_message_type<const_table_slice_handle>("vast::const_table_slice_handle");
   // Containers
   add_message_type<std::vector<event>>("std::vector<vast::event>");
   // Actor-specific messages

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -70,19 +70,19 @@ table_slice_ptr table_slice::make(record_type layout, caf::actor_system&,
   return nullptr;
 }
 
-caf::error table_slice::save_ptr(caf::serializer& sink,
-                                 const_table_slice_ptr ptr) {
+caf::error table_slice::serialize_ptr(caf::serializer& sink,
+                                      const_table_slice_ptr ptr) {
   if (!ptr) {
     record_type dummy;
     return sink(dummy);
   }
   return caf::error::eval([&] { return sink(ptr->layout()); },
                           [&] { return sink(ptr->implementation_id()); },
-                          [&] { return ptr->save(sink); });
+                          [&] { return ptr->serialize(sink); });
 }
 
-caf::error table_slice::load_ptr(caf::deserializer& source,
-                                 table_slice_ptr& ptr) {
+caf::error table_slice::deserialize_ptr(caf::deserializer& source,
+                                        table_slice_ptr& ptr) {
   if (source.context() == nullptr)
     return caf::sec::no_context;
   record_type layout;
@@ -99,7 +99,7 @@ caf::error table_slice::load_ptr(caf::deserializer& source,
   ptr = make(std::move(layout), source.context()->system(), impl_id);
   if (!ptr)
     return ec::invalid_table_slice_type;
-  return ptr->load(source);
+  return ptr->deserialize(source);
 }
 
 caf::optional<value> table_slice::row_to_value(size_type row,

--- a/libvast/src/table_slice_handle.cpp
+++ b/libvast/src/table_slice_handle.cpp
@@ -25,7 +25,7 @@ table_slice_handle::~table_slice_handle() {
 }
 
 caf::error inspect(caf::serializer& sink, table_slice_handle& hdl) {
-  return table_slice::save_ptr(sink, hdl.get());
+  return table_slice::serialize_ptr(sink, hdl.get());
 }
 
 caf::error inspect(caf::deserializer& source, table_slice_handle& hdl) {
@@ -33,7 +33,7 @@ caf::error inspect(caf::deserializer& source, table_slice_handle& hdl) {
   auto guard = caf::detail::make_scope_guard([&] {
     hdl = table_slice_handle{std::move(ptr)};
   });
-  return table_slice::load_ptr(source, ptr);
+  return table_slice::deserialize_ptr(source, ptr);
 }
 
 } // namespace vast

--- a/libvast/src/table_slice_handle.cpp
+++ b/libvast/src/table_slice_handle.cpp
@@ -1,0 +1,39 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/table_slice_handle.hpp"
+
+#include <caf/detail/scope_guard.hpp>
+#include <caf/error.hpp>
+
+#include "vast/table_slice.hpp"
+
+namespace vast {
+
+table_slice_handle::~table_slice_handle() {
+  // nop
+}
+
+caf::error inspect(caf::serializer& sink, table_slice_handle& hdl) {
+  return table_slice::save_ptr(sink, hdl.get());
+}
+
+caf::error inspect(caf::deserializer& source, table_slice_handle& hdl) {
+  table_slice_ptr ptr;
+  auto guard = caf::detail::make_scope_guard([&] {
+    hdl = table_slice_handle{std::move(ptr)};
+  });
+  return table_slice::load_ptr(source, ptr);
+}
+
+} // namespace vast

--- a/libvast/test/default_table_slice.cpp
+++ b/libvast/test/default_table_slice.cpp
@@ -144,10 +144,10 @@ TEST(object serialization) {
   auto slice1 = make_slice();
   auto slice2 = caf::make_counted<default_table_slice>(slice1->layout());
   MESSAGE("save content of the first slice into the buffer");
-  CHECK_EQUAL(slice1->save(sink), caf::none);
+  CHECK_EQUAL(slice1->serialize(sink), caf::none);
   MESSAGE("load content for the second slice from the buffer");
   auto source = make_source();
-  CHECK_EQUAL(slice2->load(source), caf::none);
+  CHECK_EQUAL(slice2->deserialize(source), caf::none);
   MESSAGE("check result of serialization roundtrip");
   CHECK_EQUAL(*slice1, *slice2);
 }
@@ -157,10 +157,10 @@ TEST(smart pointer serialization) {
   auto slice1 = make_slice();
   table_slice_ptr slice2;
   MESSAGE("save content of the first slice into the buffer");
-  CHECK_EQUAL(table_slice::save_ptr(sink, slice1), caf::none);
+  CHECK_EQUAL(table_slice::serialize_ptr(sink, slice1), caf::none);
   MESSAGE("load content for the second slice from the buffer");
   auto source = make_source();
-  CHECK_EQUAL(table_slice::load_ptr(source, slice2), caf::none);
+  CHECK_EQUAL(table_slice::deserialize_ptr(source, slice2), caf::none);
   MESSAGE("check result of serialization roundtrip");
   REQUIRE_NOT_EQUAL(slice2, nullptr);
   CHECK_EQUAL(*slice1, *slice2);

--- a/libvast/test/default_table_slice.cpp
+++ b/libvast/test/default_table_slice.cpp
@@ -128,7 +128,7 @@ TEST(equality) {
   CHECK_EQUAL(*slice1, *slice2);
 }
 
-TEST(serialization) {
+TEST(object serialization) {
   MESSAGE("make slices");
   auto slice1 = make_slice();
   auto slice2 = caf::make_counted<default_table_slice>(slice1->layout());
@@ -143,6 +143,25 @@ TEST(serialization) {
     caf::binary_deserializer bs{sys, buf};
     CHECK_EQUAL(slice2->load(bs), caf::none);
   }
+  CHECK_EQUAL(*slice1, *slice2);
+}
+
+TEST(smart pointer serialization) {
+  MESSAGE("make slices");
+  auto slice1 = make_slice();
+  table_slice_ptr slice2;
+  std::vector<char> buf;
+  MESSAGE("save content of the first slice into the buffer");
+  {
+    caf::binary_serializer bs{sys, buf};
+    CHECK_EQUAL(table_slice::save_ptr(bs, slice1), caf::none);
+  }
+  MESSAGE("load content for the second slice from the buffer");
+  {
+    caf::binary_deserializer bs{sys, buf};
+    CHECK_EQUAL(table_slice::load_ptr(bs, slice2), caf::none);
+  }
+  REQUIRE_NOT_EQUAL(slice2, nullptr);
   CHECK_EQUAL(*slice1, *slice2);
 }
 

--- a/libvast/vast/const_table_slice_handle.hpp
+++ b/libvast/vast/const_table_slice_handle.hpp
@@ -1,0 +1,48 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <caf/detail/comparable.hpp>
+#include <caf/fwd.hpp>
+
+#include "vast/fwd.hpp"
+#include "vast/ptr_handle.hpp"
+
+namespace vast {
+
+/// Wraps a pointer to a table slize and makes it serializable.
+class const_table_slice_handle
+  : public ptr_handle<const table_slice>,
+    caf::detail::comparable<const_table_slice_handle> {
+public:
+  // -- member types -----------------------------------------------------------
+
+  using super = ptr_handle<const table_slice>;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  using super::super;
+
+  ~const_table_slice_handle() override;
+};
+
+// -- related free functions ---------------------------------------------------
+
+/// @relates table_slice_handle
+caf::error inspect(caf::serializer& sink, const_table_slice_handle& hdl);
+
+/// @relates table_slice_handle
+caf::error inspect(caf::deserializer& source, const_table_slice_handle& hdl);
+
+} // namespace vast

--- a/libvast/vast/default_table_slice.hpp
+++ b/libvast/vast/default_table_slice.hpp
@@ -40,7 +40,7 @@ public:
 
   // -- persistence ------------------------------------------------------------
 
-  caf::error save(caf::serializer& sink) final;
+  caf::error save(caf::serializer& sink) const final;
 
   caf::error load(caf::deserializer& source) final;
 

--- a/libvast/vast/default_table_slice.hpp
+++ b/libvast/vast/default_table_slice.hpp
@@ -40,9 +40,9 @@ public:
 
   // -- persistence ------------------------------------------------------------
 
-  caf::error save(caf::serializer& sink) const final;
+  caf::error serialize(caf::serializer& sink) const final;
 
-  caf::error load(caf::deserializer& source) final;
+  caf::error deserialize(caf::deserializer& source) final;
 
   // -- static factory functions -----------------------------------------------
 

--- a/libvast/vast/default_table_slice.hpp
+++ b/libvast/vast/default_table_slice.hpp
@@ -38,6 +38,12 @@ public:
 
   table_slice_ptr clone() const final;
 
+  // -- persistence ------------------------------------------------------------
+
+  caf::error save(caf::serializer& sink) final;
+
+  caf::error load(caf::deserializer& source) final;
+
   // -- static factory functions -----------------------------------------------
 
   /// Constructs a builder that generates a default_table_slice.
@@ -51,6 +57,8 @@ public:
   // -- properties -------------------------------------------------------------
 
   caf::optional<data_view> at(size_type row, size_type col) const final;
+
+  caf::atom_value implementation_id() const noexcept final;
 
 private:
   // -- member variables -------------------------------------------------------

--- a/libvast/vast/error.hpp
+++ b/libvast/vast/error.hpp
@@ -46,6 +46,8 @@ enum class ec : uint8_t {
   version_error,
   /// A command does not adhere to the expected syntax.
   syntax_error,
+  /// Deserialization failed because an unknown implementation type was found.
+  invalid_table_slice_type,
 };
 
 /// @relates ec

--- a/libvast/vast/ptr_handle.hpp
+++ b/libvast/vast/ptr_handle.hpp
@@ -1,0 +1,139 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include <caf/intrusive_ptr.hpp>
+
+namespace vast {
+
+/// Wraps a `caf::intrusive_ptr<T>` to give it a distinct type.
+template <class T>
+class ptr_handle {
+public:
+  // -- member types -----------------------------------------------------------
+
+  /// Pointer to a `T`.
+  using pointer = std::add_pointer_t<T>;
+
+  /// Pointer to an immutable `T`.
+  using const_pointer = std::add_const_t<pointer>;
+
+  /// Reference to a `T`.
+  using reference = std::add_lvalue_reference_t<T>;
+
+  /// Reference to an immutable `T`.
+  using const_reference = std::add_const_t<reference>;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  ptr_handle() = default;
+
+  ptr_handle(ptr_handle&&) = default;
+
+  ptr_handle(const ptr_handle&) = default;
+
+  ptr_handle& operator=(ptr_handle&&) = default;
+
+  ptr_handle& operator=(const ptr_handle&) = default;
+
+  explicit ptr_handle(caf::intrusive_ptr<T> ptr) : ptr_(std::move(ptr)) {
+    // nop
+  }
+
+  virtual ~ptr_handle() {
+    // nop
+  }
+
+  // -- properties -------------------------------------------------------------
+
+  /// @returns the stored pointer.
+  pointer get() noexcept {
+    return ptr_.get();
+  }
+
+  /// @returns the stored pointer.
+  const_pointer get() const noexcept {
+    return ptr_.get();
+  }
+
+  // -- comparison -------------------------------------------------------------
+
+  /// @returns `get() - other.get()` for total ordering of handles by comparing
+  ///           the pointer values.
+  ptrdiff_t compare(const ptr_handle& other) const noexcept {
+    return get() - other.get();
+  }
+
+  // -- operators --------------------------------------------------------------
+
+  reference operator*() {
+    return *get();
+  }
+
+  const_reference operator*() const {
+    return *get();
+  }
+
+  pointer operator->() {
+    return get();
+  }
+
+  const_pointer operator->() const {
+    return get();
+  }
+
+  bool operator!() const noexcept {
+    return get() == nullptr;
+  }
+
+  explicit operator bool() const noexcept {
+    return get() != nullptr;
+  }
+
+protected:
+  // -- member variables -------------------------------------------------------
+
+  caf::intrusive_ptr<T> ptr_;
+};
+
+// -- related free functions ---------------------------------------------------
+
+/// @relates ptr_handle
+template <class T>
+bool operator==(const ptr_handle<T>& x, std::nullptr_t) {
+  return !x;
+}
+
+/// @relates ptr_handle
+template <class T>
+bool operator==(std::nullptr_t, const ptr_handle<T>& x) {
+  return !x;
+}
+
+/// @relates ptr_handle
+template <class T>
+bool operator!=(const ptr_handle<T>& x, std::nullptr_t) {
+  return static_cast<bool>(x);
+}
+
+/// @relates ptr_handle
+template <class T>
+bool operator!=(std::nullptr_t, const ptr_handle<T>& x) {
+  return static_cast<bool>(x);
+}
+
+} // namespace vast

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -53,12 +53,23 @@ public:
   /// Makes a copy of this slice.
   virtual table_slice_ptr clone() const = 0;
 
+  // -- persistence ------------------------------------------------------------
+
+  /// Saves the contents (excluding the layout!) of this slice to `sink`.
+  virtual caf::error save(caf::serializer& sink) = 0;
+
+  /// Loads the contents for this slice from `source`.
+  virtual caf::error load(caf::deserializer& source) = 0;
+
   // -- properties -------------------------------------------------------------
 
   /// @returns the table layout.
   inline const record_type& layout() const noexcept {
     return layout_;
   }
+
+  /// @returns an identifier for the implementing class.
+  virtual caf::atom_value implementation_id() const noexcept = 0;
 
   /// @returns the layout for columns in range
   /// [first_column, first_column + num_columns).

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -53,13 +53,24 @@ public:
   /// Makes a copy of this slice.
   virtual table_slice_ptr clone() const = 0;
 
+  /// @returns a handle holding an instance of type `impl` with given layout if
+  ///          `impl` is a registered type in `sys`, otherwise `nullptr`.
+  static table_slice_ptr make(record_type layout, caf::actor_system& sys,
+                              caf::atom_value impl);
+
   // -- persistence ------------------------------------------------------------
 
   /// Saves the contents (excluding the layout!) of this slice to `sink`.
-  virtual caf::error save(caf::serializer& sink) = 0;
+  virtual caf::error save(caf::serializer& sink) const = 0;
 
   /// Loads the contents for this slice from `source`.
   virtual caf::error load(caf::deserializer& source) = 0;
+
+  /// Saves the table slice in `ptr` to `sink`.
+  static caf::error save_ptr(caf::serializer& sink, const_table_slice_ptr ptr);
+
+  /// Loads a table slice from `source` into `ptr`.
+  static caf::error load_ptr(caf::deserializer& source, table_slice_ptr& ptr);
 
   // -- properties -------------------------------------------------------------
 

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -61,16 +61,18 @@ public:
   // -- persistence ------------------------------------------------------------
 
   /// Saves the contents (excluding the layout!) of this slice to `sink`.
-  virtual caf::error save(caf::serializer& sink) const = 0;
+  virtual caf::error serialize(caf::serializer& sink) const = 0;
 
   /// Loads the contents for this slice from `source`.
-  virtual caf::error load(caf::deserializer& source) = 0;
+  virtual caf::error deserialize(caf::deserializer& source) = 0;
 
   /// Saves the table slice in `ptr` to `sink`.
-  static caf::error save_ptr(caf::serializer& sink, const_table_slice_ptr ptr);
+  static caf::error serialize_ptr(caf::serializer& sink,
+                                  const_table_slice_ptr ptr);
 
   /// Loads a table slice from `source` into `ptr`.
-  static caf::error load_ptr(caf::deserializer& source, table_slice_ptr& ptr);
+  static caf::error deserialize_ptr(caf::deserializer& source,
+                                    table_slice_ptr& ptr);
 
   // -- properties -------------------------------------------------------------
 

--- a/libvast/vast/table_slice_handle.hpp
+++ b/libvast/vast/table_slice_handle.hpp
@@ -1,0 +1,47 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <caf/detail/comparable.hpp>
+#include <caf/fwd.hpp>
+
+#include "vast/fwd.hpp"
+#include "vast/ptr_handle.hpp"
+
+namespace vast {
+
+/// Wraps a pointer to a table slize and makes it serializable.
+class table_slice_handle : public ptr_handle<table_slice>,
+                           caf::detail::comparable<table_slice_handle> {
+public:
+  // -- member types -----------------------------------------------------------
+
+  using super = ptr_handle<table_slice>;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  using super::super;
+
+  ~table_slice_handle() override;
+};
+
+// -- related free functions ---------------------------------------------------
+
+/// @relates table_slice_handle
+caf::error inspect(caf::serializer& sink, table_slice_handle& hdl);
+
+/// @relates table_slice_handle
+caf::error inspect(caf::deserializer& source, table_slice_handle& hdl);
+
+} // namespace vast


### PR DESCRIPTION
We currently send `table_slice_ptr` between actors and mark them as unsafe message type to get it compiling. Adding a properly serializable `table_slice_handle` type is the first step to get back clean, distributable messaging.

Both handle types (`table_slice_handle` and `const_table_slice_handle`) *could* be implemented header-only (as alias to `ptr_handle`). However, by moving the `inspect` functions to .cpp files and giving them proper types we get away with very lean headers that rely almost exclusively on forward declarations.