### PR TITLE
Switch from table_slice_ptr to table_slice_handle in SOURCE, IMPORTER, etc.

### DIFF
--- a/libvast/src/column_index.cpp
+++ b/libvast/src/column_index.cpp
@@ -13,6 +13,7 @@
 
 #include "vast/column_index.hpp"
 
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/expression_visitors.hpp"
 #include "vast/load.hpp"
 #include "vast/logger.hpp"
@@ -42,7 +43,7 @@ caf::expected<column_index_ptr> make_type_column_index(path filename) {
       // nop
     }
 
-    void add(const const_table_slice_ptr& x) override {
+    void add(const const_table_slice_handle& x) override {
       VAST_TRACE(VAST_ARG(x));
       auto tn = x->layout().name();
       auto offset = x->offset();
@@ -62,7 +63,7 @@ make_column_index(path filename, type column_type, size_t column) {
         // nop
     }
 
-    void add(const const_table_slice_ptr& x) override {
+    void add(const const_table_slice_handle& x) override {
       VAST_TRACE(VAST_ARG(x));
       auto offset = x->offset();
       for (table_slice::size_type row = 0; row < x->rows(); ++row)

--- a/libvast/src/const_table_slice_handle.cpp
+++ b/libvast/src/const_table_slice_handle.cpp
@@ -17,8 +17,15 @@
 #include <caf/error.hpp>
 
 #include "vast/table_slice.hpp"
+#include "vast/table_slice_handle.hpp"
 
 namespace vast {
+
+const_table_slice_handle::const_table_slice_handle(
+  const table_slice_handle& other)
+  : super(other.ptr()) {
+  // nop
+}
 
 const_table_slice_handle::~const_table_slice_handle() {
   // nop

--- a/libvast/src/default_table_slice.cpp
+++ b/libvast/src/default_table_slice.cpp
@@ -18,6 +18,7 @@
 #include <caf/serializer.hpp>
 
 #include "vast/default_table_slice_builder.hpp"
+#include "vast/table_slice_handle.hpp"
 
 namespace vast {
 
@@ -26,8 +27,8 @@ default_table_slice::default_table_slice(record_type layout)
   // nop
 }
 
-table_slice_ptr default_table_slice::clone() const {
-  return caf::make_counted<default_table_slice>(*this);
+table_slice_handle default_table_slice::clone() const {
+  return table_slice_handle{caf::make_counted<default_table_slice>(*this)};
 }
 
 caf::error default_table_slice::serialize(caf::serializer& sink) const {
@@ -57,8 +58,8 @@ table_slice_builder_ptr default_table_slice::make_builder(record_type layout) {
   return caf::make_counted<default_table_slice_builder>(std::move(layout));
 }
 
-table_slice_ptr default_table_slice::make(record_type layout,
-                                          const std::vector<vector>& rows) {
+table_slice_handle default_table_slice::make(record_type layout,
+                                             const std::vector<vector>& rows) {
   auto builder = make_builder(std::move(layout));
   for (auto& row : rows)
     for (auto& item : row)

--- a/libvast/src/default_table_slice_builder.cpp
+++ b/libvast/src/default_table_slice_builder.cpp
@@ -13,6 +13,10 @@
 
 #include "vast/default_table_slice_builder.hpp"
 
+#include <utility>
+
+#include "vast/table_slice_handle.hpp"
+
 namespace vast {
 
 default_table_slice_builder::default_table_slice_builder(record_type layout)
@@ -44,7 +48,7 @@ bool default_table_slice_builder::add(data_view x) {
   return append(materialize(x));
 }
 
-table_slice_ptr default_table_slice_builder::finish() {
+table_slice_handle default_table_slice_builder::finish() {
   // If we have an incomplete row, we take it as-is and keep the remaining null
   // values. Better to have incomplete than no data.
   if (col_ != 0)
@@ -53,9 +57,10 @@ table_slice_ptr default_table_slice_builder::finish() {
   // TODO: this feels messy, but allows for non-virtual parent accessors.
   slice_->rows_ = slice_->xs_.size();
   slice_->columns_ = layout_.fields.size();
-  auto result = slice_;
-  slice_ = {};
-  return result;
+  using std::swap;
+  default_table_slice_ptr result;
+  swap(slice_, result);
+  return table_slice_handle{std::move(result)};
 };
 
 size_t default_table_slice_builder::rows() const noexcept {

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -13,6 +13,7 @@
 
 #include "vast/meta_index.hpp"
 
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/event.hpp"
 #include "vast/expression_visitors.hpp"
 #include "vast/logger.hpp"
@@ -46,7 +47,7 @@ operator[](const uuid& partition) const {
 }
 
 void meta_index::add(const uuid& partition,
-                     const const_table_slice_ptr& slice) {
+                     const const_table_slice_handle& slice) {
   auto& rng = partitions_[partition].range;
   // The first column always contains the timestamp.
   for (size_t row = 0; row < slice->rows(); ++row) {

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 
 #include "vast/batch.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/event.hpp"
 #include "vast/expected.hpp"
 #include "vast/logger.hpp"
@@ -74,13 +75,13 @@ archive(archive_type::stateful_pointer<archive_state> self,
                    self->system().render(result.error()));
       return result;
     },
-    [=](stream<const_table_slice_ptr> in) {
+    [=](stream<const_table_slice_handle> in) {
       self->make_sink(
         in,
         [](unit_t&) {
           // nop
         },
-        [=](unit_t&, std::vector<const_table_slice_ptr>& batch) {
+        [=](unit_t&, std::vector<const_table_slice_handle>& batch) {
           // TODO: port store to table slice API (#3214)
           for (auto& slice : batch)
             handle_batch(slice->rows_to_events());

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -13,14 +13,15 @@
 
 #include <caf/all.hpp>
 
-#include "vast/event.hpp"
-#include "vast/logger.hpp"
 #include "vast/concept/printable/std/chrono.hpp"
 #include "vast/concept/printable/vast/event.hpp"
 #include "vast/concept/printable/vast/expression.hpp"
 #include "vast/concept/printable/vast/uuid.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/event.hpp"
 #include "vast/expression_visitors.hpp"
+#include "vast/logger.hpp"
 #include "vast/table_slice.hpp"
 
 #include "vast/system/archive.hpp"
@@ -283,13 +284,13 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
         }
       );
     },
-    [=](caf::stream<const_table_slice_ptr> in) {
+    [=](caf::stream<const_table_slice_handle> in) {
       return self->make_sink(
         in,
         [](caf::unit_t&) {
           // nop
         },
-        [=](caf::unit_t&, const const_table_slice_ptr& slice) {
+        [=](caf::unit_t&, const const_table_slice_handle& slice) {
           // TODO: port to new table slice API
           auto candidates = slice->rows_to_events();
           handle_batch(candidates);

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -16,10 +16,12 @@
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/error.hpp"
 #include "vast/concept/printable/vast/filesystem.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/logger.hpp"
 #include "vast/system/atoms.hpp"
 #include "vast/system/importer.hpp"
 #include "vast/table_slice.hpp"
+#include "vast/table_slice_handle.hpp"
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -312,7 +312,7 @@ behavior index(stateful_actor<index_state>* self, const path& dir,
                    "partitions left for query ID", query_id);
       }
     },
-    [=](caf::stream<const_table_slice_ptr> in) {
+    [=](caf::stream<const_table_slice_handle> in) {
       VAST_DEBUG(self, "got a new source");
       return self->state.stage->add_inbound_path(in);
     }
@@ -323,7 +323,7 @@ behavior index(stateful_actor<index_state>* self, const path& dir,
       st.next_worker = worker;
       self->become(keep_behavior, st.has_worker);
     },
-    [=](caf::stream<const_table_slice_ptr> in) {
+    [=](caf::stream<const_table_slice_handle> in) {
       VAST_DEBUG(self, "got a new source");
       return self->state.stage->add_inbound_path(in);
     }

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -19,6 +19,7 @@
 
 #include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/vast/expression.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/expression.hpp"
 #include "vast/filesystem.hpp"
@@ -69,13 +70,13 @@ behavior indexer(stateful_actor<indexer_state>* self, path dir,
         return err;
       return caf::unit;
     },
-    [=](stream<const_table_slice_ptr> in) {
+    [=](stream<const_table_slice_handle> in) {
       self->make_sink(
         in,
         [](unit_t&) {
           // nop
         },
-        [=](unit_t&, const std::vector<const_table_slice_ptr>& xs) {
+        [=](unit_t&, const std::vector<const_table_slice_handle>& xs) {
           for (auto& x : xs)
             self->state.tbl.add(x);
         },

--- a/libvast/src/table.cpp
+++ b/libvast/src/table.cpp
@@ -16,6 +16,7 @@
 #include <caf/none.hpp>
 #include <caf/optional.hpp>
 
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/table_slice.hpp"
 
 namespace vast {
@@ -26,7 +27,7 @@ table::table(record_type layout)
   // nop
 }
 
-bool table::add(const_table_slice_ptr slice) {
+bool table::add(const_table_slice_handle slice) {
   if (slice == nullptr || layout_ != slice->layout())
     return false;
   auto offset = slice->offset();

--- a/libvast/src/table_index.cpp
+++ b/libvast/src/table_index.cpp
@@ -13,6 +13,7 @@
 
 #include "vast/table_index.hpp"
 
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/expression_visitors.hpp"
 #include "vast/load.hpp"
@@ -69,7 +70,7 @@ column_index* table_index::by_name(std::string_view column_name) {
   return i != columns_.end() ? i->get() : nullptr;
 }
 
-caf::error table_index::add(const const_table_slice_ptr& x) {
+caf::error table_index::add(const const_table_slice_handle& x) {
   VAST_ASSERT(x != nullptr);
   VAST_ASSERT(x->layout() == layout());
   VAST_TRACE(VAST_ARG(x));

--- a/libvast/test/column_index.cpp
+++ b/libvast/test/column_index.cpp
@@ -20,9 +20,11 @@
 #include "vast/column_index.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/default_table_slice.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder.hpp"
+#include "vast/table_slice_handle.hpp"
 #include "vast/type.hpp"
 
 using namespace vast;

--- a/libvast/test/default_table_slice.cpp
+++ b/libvast/test/default_table_slice.cpp
@@ -154,7 +154,7 @@ TEST(object serialization) {
 
 TEST(smart pointer serialization) {
   MESSAGE("make slices");
-  auto slice1 = make_slice();
+  auto slice1 = make_slice().ptr();
   table_slice_ptr slice2;
   MESSAGE("save content of the first slice into the buffer");
   CHECK_EQUAL(table_slice::serialize_ptr(sink, slice1), caf::none);
@@ -182,7 +182,7 @@ TEST(handle serialization) {
 
 TEST(const handle serialization) {
   MESSAGE("make slices");
-  auto slice1 = const_table_slice_handle{make_slice()};
+  auto slice1 = const_table_slice_handle{make_slice().ptr()};
   const_table_slice_handle slice2;
   MESSAGE("save content of the first slice into the buffer");
   CHECK_EQUAL(sink(slice1), caf::none);

--- a/libvast/test/fixtures/events.cpp
+++ b/libvast/test/fixtures/events.cpp
@@ -13,11 +13,13 @@
 
 #include "fixtures/events.hpp"
 
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/default_table_slice.hpp"
 #include "vast/format/bgpdump.hpp"
 #include "vast/format/bro.hpp"
 #include "vast/format/test.hpp"
 #include "vast/table_slice_builder.hpp"
+#include "vast/table_slice_handle.hpp"
 #include "vast/type.hpp"
 
 namespace fixtures {
@@ -57,32 +59,33 @@ std::vector<event> events::bro_http_log;
 std::vector<event> events::bgpdump_txt;
 std::vector<event> events::random;
 
-std::vector<table_slice_ptr> events::bro_conn_log_slices;
-// std::vector<table_slice_ptr> events::bro_dns_log_slices;
-// std::vector<table_slice_ptr> events::bro_http_log_slices;
-// std::vector<table_slice_ptr> events::bgpdump_txt_slices;
-// std::vector<table_slice_ptr> events::random_slices;
+std::vector<table_slice_handle> events::bro_conn_log_slices;
+// std::vector<table_slice_handle> events::bro_dns_log_slices;
+// std::vector<table_slice_handle> events::bro_http_log_slices;
+// std::vector<table_slice_handle> events::bgpdump_txt_slices;
+// std::vector<table_slice_handle> events::random_slices;
 
-std::vector<const_table_slice_ptr> events::const_bro_conn_log_slices;
-// std::vector<const_table_slice_ptr> events::const_bro_http_log_slices;
-// std::vector<const_table_slice_ptr> events::const_bro_dns_log_slices;
-// std::vector<const_table_slice_ptr> events::const_bgpdump_txt_slices;
-// std::vector<const_table_slice_ptr> events::const_random_slices;
+std::vector<const_table_slice_handle> events::const_bro_conn_log_slices;
+// std::vector<const_table_slice_handle> events::const_bro_http_log_slices;
+// std::vector<const_table_slice_handle> events::const_bro_dns_log_slices;
+// std::vector<const_table_slice_handle> events::const_bgpdump_txt_slices;
+// std::vector<const_table_slice_handle> events::const_random_slices;
 
 std::vector<event> events::ascending_integers;
-std::vector<table_slice_ptr> events::ascending_integers_slices;
-std::vector<const_table_slice_ptr> events::const_ascending_integers_slices;
+std::vector<table_slice_handle> events::ascending_integers_slices;
+std::vector<const_table_slice_handle> events::const_ascending_integers_slices;
 
 std::vector<event> events::alternating_integers;
-std::vector<table_slice_ptr> events::alternating_integers_slices;
-std::vector<const_table_slice_ptr> events::const_alternating_integers_slices;
+std::vector<table_slice_handle> events::alternating_integers_slices;
+std::vector<const_table_slice_handle> events::const_alternating_integers_slices;
 
 record_type events::bro_conn_log_layout() {
   return const_bro_conn_log_slices[0]->layout();
 }
 
-std::vector<table_slice_ptr> events::copy(std::vector<table_slice_ptr> xs) {
-  std::vector<table_slice_ptr> result;
+std::vector<table_slice_handle>
+events::copy(std::vector<table_slice_handle> xs) {
+  std::vector<table_slice_handle> result;
   result.reserve(xs.size());
   for (auto& x : xs)
     result.emplace_back(x->clone());
@@ -124,7 +127,7 @@ events::events() {
     layout.fields.insert(layout.fields.begin(), std::move(tstamp_field));
     auto builder = default_table_slice::make_builder(std::move(layout));
     auto full_slices = src.size() / slice_size;
-    std::vector<table_slice_ptr> slices;
+    std::vector<table_slice_handle> slices;
     auto i = src.begin();
     auto make_slice = [&](size_t size) {
       if (size == 0)
@@ -157,7 +160,7 @@ events::events() {
   ascending_integers_slices = slice_up(ascending_integers);
   alternating_integers_slices = slice_up(alternating_integers);
   auto to_const_vector = [](const auto& xs) {
-    std::vector<const_table_slice_ptr> result;
+    std::vector<const_table_slice_handle> result;
     result.reserve(xs.size());
     result.insert(result.end(), xs.begin(), xs.end());
     return result;

--- a/libvast/test/fixtures/events.hpp
+++ b/libvast/test/fixtures/events.hpp
@@ -38,30 +38,31 @@ struct events {
   static std::vector<event> bgpdump_txt;
   static std::vector<event> random;
 
-  static std::vector<table_slice_ptr> bro_conn_log_slices;
+  static std::vector<table_slice_handle> bro_conn_log_slices;
   // TODO: table_slice::recursive_add flattens too much, why the following
   //       slices won't work. However, flatten(value) is also broken
   //       at the moment (cf. #3215), so we can't fix it until then.
-  // static std::vector<table_slice_ptr> bro_http_log_slices;
-  // static std::vector<table_slice_ptr> bro_dns_log_slices;
-  // static std::vector<table_slice_ptr> bgpdump_txt_slices;
-  // static std::vector<table_slice_ptr> random_slices;
+  // static std::vector<table_slice_handle> bro_http_log_slices;
+  // static std::vector<table_slice_handle> bro_dns_log_slices;
+  // static std::vector<table_slice_handle> bgpdump_txt_slices;
+  // static std::vector<table_slice_handle> random_slices;
 
-  static std::vector<const_table_slice_ptr> const_bro_conn_log_slices;
-  // static std::vector<const_table_slice_ptr> const_bro_http_log_slices;
-  // static std::vector<const_table_slice_ptr> const_bro_dns_log_slices;
-  // static std::vector<const_table_slice_ptr> const_bgpdump_txt_slices;
-  // static std::vector<const_table_slice_ptr> const_random_slices;
+  static std::vector<const_table_slice_handle> const_bro_conn_log_slices;
+  // static std::vector<const_table_slice_handle> const_bro_http_log_slices;
+  // static std::vector<const_table_slice_handle> const_bro_dns_log_slices;
+  // static std::vector<const_table_slice_handle> const_bgpdump_txt_slices;
+  // static std::vector<const_table_slice_handle> const_random_slices;
 
   /// 10000 ascending integer values, starting at 0.
   static std::vector<event> ascending_integers;
-  static std::vector<table_slice_ptr> ascending_integers_slices;
-  static std::vector<const_table_slice_ptr> const_ascending_integers_slices;
+  static std::vector<table_slice_handle> ascending_integers_slices;
+  static std::vector<const_table_slice_handle> const_ascending_integers_slices;
 
   /// 10000 integer values, alternating between 0 and 1.
   static std::vector<event> alternating_integers;
-  static std::vector<table_slice_ptr> alternating_integers_slices;
-  static std::vector<const_table_slice_ptr> const_alternating_integers_slices;
+  static std::vector<table_slice_handle> alternating_integers_slices;
+  static std::vector<const_table_slice_handle>
+    const_alternating_integers_slices;
 
   static record_type bro_conn_log_layout();
 
@@ -70,7 +71,7 @@ struct events {
     return {make_vector(xs)...};
   }
 
-  std::vector<table_slice_ptr> copy(std::vector<table_slice_ptr> xs);
+  std::vector<table_slice_handle> copy(std::vector<table_slice_handle> xs);
 
 private:
   template <class Reader>

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -16,10 +16,12 @@
 
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/default_table_slice.hpp"
 #include "vast/meta_index.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder.hpp"
+#include "vast/table_slice_handle.hpp"
 #include "vast/uuid.hpp"
 
 using namespace vast;
@@ -47,7 +49,7 @@ struct generator {
     // nop
   }
 
-  const_table_slice_ptr operator()(size_t num) {
+  const_table_slice_handle operator()(size_t num) {
     record_type layout = record_type{
       {"timestamp", timestamp_type{}},
       {"content", string_type{}}
@@ -75,7 +77,7 @@ struct mock_partition {
   }
 
   uuid id;
-  const_table_slice_ptr slice;
+  const_table_slice_handle slice;
   meta_index::interval range;
 };
 

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -13,8 +13,9 @@
 
 #include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/vast/event.hpp"
-#include "vast/system/archive.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/ids.hpp"
+#include "vast/system/archive.hpp"
 #include "vast/table_slice.hpp"
 
 #include "vast/detail/spawn_container_source.hpp"

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -13,7 +13,9 @@
 
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
+
 #include "vast/query_options.hpp"
+#include "vast/table_slice_handle.hpp"
 
 #include "vast/system/archive.hpp"
 #include "vast/system/exporter.hpp"

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -13,12 +13,14 @@
 
 #include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/vast/event.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/detail/spawn_container_source.hpp"
 #include "vast/event.hpp"
 #include "vast/system/archive.hpp"
 #include "vast/system/data_store.hpp"
 #include "vast/system/importer.hpp"
 #include "vast/table_slice.hpp"
+#include "vast/table_slice_handle.hpp"
 
 #define SUITE import
 #include "test.hpp"
@@ -45,13 +47,13 @@ auto unbox(caf::optional<T> res) {
 
 behavior dummy_sink(event_based_actor* self, shared_event_buffer buf) {
   return {
-    [=](stream<const_table_slice_ptr> in) {
+    [=](stream<const_table_slice_handle> in) {
       self->make_sink(
         in,
         [=](unit_t&) {
           // nop
         },
-        [=](unit_t&, const_table_slice_ptr x) {
+        [=](unit_t&, const_table_slice_handle x) {
           using caf::get;
           auto event_id = x->offset();
           for (size_t row = 0; row < x->rows(); ++row) {

--- a/libvast/test/system/indexer.cpp
+++ b/libvast/test/system/indexer.cpp
@@ -18,9 +18,11 @@
 #include "vast/concept/printable/vast/error.hpp"
 #include "vast/concept/printable/vast/event.hpp"
 #include "vast/concept/printable/vast/expression.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/default_table_slice.hpp"
 #include "vast/detail/spawn_container_source.hpp"
 #include "vast/table_slice.hpp"
+#include "vast/table_slice_handle.hpp"
 
 #include "vast/system/indexer.hpp"
 
@@ -39,7 +41,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     run_exhaustively();
   }
 
-  void init(std::vector<const_table_slice_ptr> slices) {
+  void init(std::vector<const_table_slice_handle> slices) {
     VAST_ASSERT(slices.size() > 0);
     init(slices[0]->layout());
     vast::detail::spawn_container_source(sys, std::move(slices), indexer);

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -24,6 +24,7 @@
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/type.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/default_table_slice.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/spawn_container_source.hpp"
@@ -31,6 +32,7 @@
 #include "vast/ids.hpp"
 #include "vast/system/indexer.hpp"
 #include "vast/table_slice.hpp"
+#include "vast/table_slice_handle.hpp"
 
 #include "fixtures/actor_system_and_events.hpp"
 
@@ -186,7 +188,7 @@ TEST(integer rows lookup) {
   record_type layout{{"value", col_type}};
   auto rows = make_rows(1, 2, 3, 1, 2, 3, 1, 2, 3);
   auto slice = default_table_slice::make(layout, rows);
-  std::vector<const_table_slice_ptr> slices{slice};
+  std::vector<const_table_slice_handle> slices{slice};
   detail::spawn_container_source(sys, std::move(slices),
                                  put->manager().get_or_add(layout).first);
   run_exhaustively();

--- a/libvast/test/system/source.cpp
+++ b/libvast/test/system/source.cpp
@@ -31,7 +31,7 @@ using namespace vast::system;
 namespace {
 
 struct test_sink_state {
-  std::vector<table_slice_ptr> slices;
+  std::vector<table_slice_handle> slices;
   inline static constexpr const char* name = "test-sink";
 };
 
@@ -40,13 +40,13 @@ using test_sink_type = caf::stateful_actor<test_sink_state>;
 caf::behavior test_sink(test_sink_type* self, caf::actor src) {
   self->send(src, sink_atom::value, self);
   return {
-    [=](caf::stream<table_slice_ptr> in) {
+    [=](caf::stream<table_slice_handle> in) {
       return self->make_sink(
         in,
         [](caf::unit_t&) {
           // nop
         },
-        [=](caf::unit_t&, table_slice_ptr ptr) {
+        [=](caf::unit_t&, table_slice_handle ptr) {
           self->state.slices.emplace_back(std::move(ptr));
         },
         [=](caf::unit_t&, const error&) {

--- a/libvast/test/table_index.cpp
+++ b/libvast/test/table_index.cpp
@@ -24,8 +24,10 @@
 #include "vast/concept/printable/vast/error.hpp"
 #include "vast/concept/printable/vast/event.hpp"
 #include "vast/concept/printable/vast/expression.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/default_table_slice.hpp"
 #include "vast/table_index.hpp"
+#include "vast/table_slice_handle.hpp"
 
 using namespace vast;
 
@@ -53,7 +55,7 @@ struct fixture : fixtures::events, fixtures::filesystem {
     reset(std::move(*new_tbl));
   }
 
-  void add(const_table_slice_ptr x) {
+  void add(const_table_slice_handle x) {
     auto err = tbl->add(x);
     if (err)
       FAIL("error: " << err);

--- a/libvast/vast/column_index.hpp
+++ b/libvast/vast/column_index.hpp
@@ -61,7 +61,7 @@ public:
 
   /// Adds an event to the index.
   /// @pre `init()` was called previously.
-  virtual void add(const const_table_slice_ptr& x) = 0;
+  virtual void add(const const_table_slice_handle& x) = 0;
 
   /// Queries event IDs that fulfill the given predicate.
   /// @pre `init()` was called previously.

--- a/libvast/vast/const_table_slice_handle.hpp
+++ b/libvast/vast/const_table_slice_handle.hpp
@@ -34,6 +34,8 @@ public:
 
   using super::super;
 
+  const_table_slice_handle(const table_slice_handle& other);
+
   ~const_table_slice_handle() override;
 };
 

--- a/libvast/vast/default_table_slice.hpp
+++ b/libvast/vast/default_table_slice.hpp
@@ -36,7 +36,7 @@ public:
 
   // -- factory functions ------------------------------------------------------
 
-  table_slice_ptr clone() const final;
+  table_slice_handle clone() const final;
 
   // -- persistence ------------------------------------------------------------
 
@@ -51,8 +51,8 @@ public:
   /// @returns The builder instance.
   static table_slice_builder_ptr make_builder(record_type layout);
 
-  static table_slice_ptr make(record_type layout,
-                              const std::vector<vector>& rows);
+  static table_slice_handle make(record_type layout,
+                                 const std::vector<vector>& rows);
 
   // -- properties -------------------------------------------------------------
 

--- a/libvast/vast/default_table_slice_builder.hpp
+++ b/libvast/vast/default_table_slice_builder.hpp
@@ -32,7 +32,7 @@ public:
 
   bool add(data_view x) final;
 
-  table_slice_ptr finish() final;
+  table_slice_handle finish() final;
 
   size_t rows() const noexcept final;
 

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -22,6 +22,7 @@ namespace vast {
 class abstract_type;
 class address;
 class column_index;
+class const_table_slice_handle;
 class data;
 class default_table_slice;
 class default_table_slice_builder;
@@ -38,6 +39,7 @@ class subnet;
 class table_index;
 class table_slice;
 class table_slice_builder;
+class table_slice_handle;
 class type;
 class value;
 

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -50,11 +50,11 @@ public:
 
   // -- properties -------------------------------------------------------------
 
-  /// @returns the synopsis for a partition if present, returns `none` 
+  /// @returns the synopsis for a partition if present, returns `none`
   ///          otherwise.
   caf::optional<partition_synopsis> operator[](const uuid& partition) const;
 
-  void add(const uuid& partition, const const_table_slice_ptr& slice);
+  void add(const uuid& partition, const const_table_slice_handle& slice);
 
   /// Retrieves the list of partition IDs for a given expression.
   std::vector<uuid> lookup(const expression& expr) const;

--- a/libvast/vast/ptr_handle.hpp
+++ b/libvast/vast/ptr_handle.hpp
@@ -70,6 +70,11 @@ public:
     return ptr_.get();
   }
 
+  /// @returns the stored smart pointer.
+  const caf::intrusive_ptr<T>& ptr() const noexcept {
+    return ptr_;
+  }
+
   // -- comparison -------------------------------------------------------------
 
   /// @returns `get() - other.get()` for total ordering of handles by comparing

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -36,7 +36,7 @@ struct archive_state {
 
 /// @relates archive
 using archive_type = caf::typed_actor<
-  caf::reacts_to<caf::stream<const_table_slice_ptr>>,
+  caf::reacts_to<caf::stream<const_table_slice_handle>>,
   caf::reacts_to<std::vector<event>>,
   caf::replies_to<ids>::with<std::vector<event>>
 >;

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -34,10 +34,10 @@ struct importer_state {
   // -- member types -----------------------------------------------------------
 
   /// Type of incoming stream elements.
-  using input_type = table_slice_ptr;
+  using input_type = table_slice_handle;
 
   /// Type of outgoing stream elements.
-  using output_type = const_table_slice_ptr;
+  using output_type = const_table_slice_handle;
 
   /// Stream object for managing downstream actors.
   using downstream_manager = caf::broadcast_downstream_manager<output_type>;

--- a/libvast/vast/system/indexer_stage_driver.hpp
+++ b/libvast/vast/system/indexer_stage_driver.hpp
@@ -16,6 +16,7 @@
 #include <caf/broadcast_downstream_manager.hpp>
 #include <caf/stream_stage_driver.hpp>
 
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/type.hpp"
 
@@ -31,7 +32,7 @@ using indexer_stage_filter = type;
 /// Selects an INDEXER actor based on its filter.
 struct indexer_stage_selector {
   inline bool operator()(const indexer_stage_filter& f,
-                         const const_table_slice_ptr& x) const {
+                         const const_table_slice_handle& x) const {
     return f == x->layout();
   }
 };
@@ -39,19 +40,19 @@ struct indexer_stage_selector {
 /// @relates indexer_stage_driver
 /// A downstream manager type for dispatching data to INDEXER actors.
 using indexer_downstream_manager
-  = caf::broadcast_downstream_manager<const_table_slice_ptr,
+  = caf::broadcast_downstream_manager<const_table_slice_handle,
                                       indexer_stage_filter,
                                       indexer_stage_selector>;
 
 /// A stream stage for dispatching slices to INDEXER actors. One set of INDEXER
 /// actors is used per partition.
 class indexer_stage_driver
-  : public caf::stream_stage_driver<const_table_slice_ptr,
+  : public caf::stream_stage_driver<const_table_slice_handle,
                                     indexer_downstream_manager> {
 public:
   // -- member types -----------------------------------------------------------
 
-  using super = caf::stream_stage_driver<const_table_slice_ptr,
+  using super = caf::stream_stage_driver<const_table_slice_handle,
                                          indexer_downstream_manager>;
 
   using partition_factory = std::function<partition_ptr()>;

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -29,6 +29,7 @@
 #include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/vast/error.hpp"
 #include "vast/concept/printable/vast/expression.hpp"
+#include "vast/const_table_slice_handle.hpp"
 #include "vast/default_table_slice.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/assert.hpp"
@@ -42,6 +43,7 @@
 #include "vast/system/atoms.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder.hpp"
+#include "vast/table_slice_handle.hpp"
 
 namespace vast::system {
 
@@ -68,7 +70,8 @@ struct source_state {
 
   using factory_type = table_slice_builder_ptr (*)(record_type);
 
-  using downstream_manager = caf::broadcast_downstream_manager<table_slice_ptr>;
+  using downstream_manager
+    = caf::broadcast_downstream_manager<table_slice_handle>;
 
   // -- member variables -------------------------------------------------------
 
@@ -160,7 +163,7 @@ caf::behavior source(caf::stateful_actor<source_state<Reader>>* self,
       self->send(self->state.accountant, "source.start", now);
     },
     // get next element
-    [=](bool& done, downstream<table_slice_ptr>& out, size_t num) {
+    [=](bool& done, downstream<table_slice_handle>& out, size_t num) {
       auto& st = self->state;
       // Extract events until the source has exhausted its input or until
       // we have completed a batch.

--- a/libvast/vast/table.hpp
+++ b/libvast/vast/table.hpp
@@ -31,7 +31,7 @@ public:
 
   using size_type = uint64_t;
 
-  using value_type = std::pair<id, const_table_slice_ptr>;
+  using value_type = std::pair<id, const_table_slice_handle>;
 
   // -- constructors, destructors, and assignment operators --------------------
 
@@ -43,7 +43,7 @@ public:
 
   /// Adds a slice to the table.
   /// @returns A failure if the layout is not compatible with
-  bool add(const_table_slice_ptr slice);
+  bool add(const_table_slice_handle slice);
 
   /// Retrieves the table layout.
   inline const record_type& layout() const noexcept {

--- a/libvast/vast/table_index.hpp
+++ b/libvast/vast/table_index.hpp
@@ -130,7 +130,7 @@ public:
   }
 
   /// @returns the column for data at given index and creates it lazily from the
-  ///          factory in case it doesn't yet exist. 
+  ///          factory in case it doesn't yet exist.
   /// @pre `column_size < num_columns()`
   template <class Factory, class Continuation>
   auto with_data_column(size_t column_index, Factory factory, Continuation f) {
@@ -174,7 +174,7 @@ public:
 
   /// Indexes a slice for all columns.
   /// @param x Table slice for ingestion.
-  caf::error add(const const_table_slice_ptr& x);
+  caf::error add(const const_table_slice_handle& x);
 
   /// Queries event IDs that fulfill the given predicate on any column.
   /// @pre `init()` was called previously.

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -151,11 +151,3 @@ using table_slice_ptr = caf::intrusive_ptr<table_slice>;
 using const_table_slice_ptr = caf::intrusive_ptr<const table_slice>;
 
 } // namespace vast
-
-CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::table_slice_ptr)
-
-CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::vector<vast::table_slice_ptr>)
-
-CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::const_table_slice_ptr)
-
-CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::vector<vast::const_table_slice_ptr>)

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -51,12 +51,12 @@ public:
   // -- factory functions ------------------------------------------------------
 
   /// Makes a copy of this slice.
-  virtual table_slice_ptr clone() const = 0;
+  virtual table_slice_handle clone() const = 0;
 
   /// @returns a handle holding an instance of type `impl` with given layout if
   ///          `impl` is a registered type in `sys`, otherwise `nullptr`.
-  static table_slice_ptr make(record_type layout, caf::actor_system& sys,
-                              caf::atom_value impl);
+  static table_slice_ptr make_ptr(record_type layout, caf::actor_system& sys,
+                                  caf::atom_value impl);
 
   // -- persistence ------------------------------------------------------------
 

--- a/libvast/vast/table_slice_builder.hpp
+++ b/libvast/vast/table_slice_builder.hpp
@@ -46,7 +46,7 @@ public:
   /// such that subsequent calls to add will restart with a new table_slice.
   /// @returns A table slice from the accumulated calls to add or `nullptr` on
   ///          failure.
-  virtual table_slice_ptr finish() = 0;
+  virtual table_slice_handle finish() = 0;
 
   /// @returns the current number of rows in the table slice.
   virtual size_t rows() const noexcept = 0;


### PR DESCRIPTION
Mostly replacing `table_slice_{ptr => handle}` and adding includes with three small exceptions:

- rename `table_slice::make` to `table_slice::make_ptr` to distinguish it from `default_table_slice::make` that returns a `table_slice_handle` now
- use `swap` in `default_table_slice_builder::finish` instead of copy-assign-and-then-reset
- allow constructing a `const_table_slice_handle` from a `table_slice_handle` to mimic general `const` rules