### PR TITLE
Fix mmapbuf::resize() and re-enable aligned resize test

### DIFF
--- a/libvast/src/detail/mmapbuf.cpp
+++ b/libvast/src/detail/mmapbuf.cpp
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <cstring>
 
+#include "vast/config.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/detail/mmapbuf.hpp"
 #include "vast/detail/system.hpp"
@@ -105,7 +106,7 @@ bool mmapbuf::resize(size_t new_size) {
   // Resize the underlying file, if available.
   if (fd_ != -1 && ftruncate(fd_, new_size) < 0)
     return false;
-#if VAST_LINUX
+#ifdef VAST_LINUX
   int flags = MREMAP_MAYMOVE;
   auto map = mremap(map_, size_, new_size, flags);
   if (map == MAP_FAILED) {

--- a/libvast/src/detail/mmapbuf.cpp
+++ b/libvast/src/detail/mmapbuf.cpp
@@ -137,7 +137,6 @@ bool mmapbuf::resize(size_t new_size) {
       reset();
       return false;
     }
-    std::memcpy(map, map_, size_);
     if (munmap(map_, size_) < 0) {
       reset();
       return false;

--- a/libvast/src/detail/mmapbuf.cpp
+++ b/libvast/src/detail/mmapbuf.cpp
@@ -95,7 +95,7 @@ size_t mmapbuf::size() const {
 bool mmapbuf::resize(size_t new_size) {
   // Also fail if we created a private mapping of a file not opened RW.
   // For now, users cannot control these aspects.
-  if (!map_ || offset_ > new_size)
+  if (!map_)
     return false;
   if (new_size == size())
     return true;
@@ -131,7 +131,7 @@ bool mmapbuf::resize(size_t new_size) {
     // If the current mapping is a multiple of the page size, we can try (1).
     if (size_ % page_size() == 0) {
       auto flags = flags_ | MAP_FIXED;
-      auto map = mmap(map_ + size_, new_size - size_, prot_, flags, fd_, 0);
+      auto map = mmap(map_ + size_, new_size - size_, prot_, flags, fd_, offset_ + size_);
       if (map != MAP_FAILED) {
         remap = false; // It worked!
       } else if (errno != ENOMEM) {

--- a/libvast/test/mmapbuf.cpp
+++ b/libvast/test/mmapbuf.cpp
@@ -61,6 +61,8 @@ TEST(memory-mapped streambuffer) {
   CHECK_EQUAL(cur, sb.size()); // we're at the end!
 }
 
+namespace {
+
 void aligned_resize_test_impl(const vast::path& filename, size_t size) {
   detail::mmapbuf sb{filename.str(), size};
   REQUIRE(sb.data() != nullptr);
@@ -69,7 +71,7 @@ void aligned_resize_test_impl(const vast::path& filename, size_t size) {
   // Aligned resizing.
   REQUIRE(sb.resize(size * 2));
   CHECK_EQUAL(sb.size(), size * 2);
-  CHECK_EQUAL(std::string(sb.data()+3, 9), "e be cont");
+  CHECK_EQUAL(std::string(sb.data() + 3, 9), "e be cont");
   // Seek in the middle and perform a random write.
   sb.pubseekpos(size, std::ios::out);
   sb.sputc('x');
@@ -78,9 +80,11 @@ void aligned_resize_test_impl(const vast::path& filename, size_t size) {
   CHECK_EQUAL(sb.size(), size / 2);
   REQUIRE(sb.resize(sb.size() * 8));
   CHECK_EQUAL(sb.size(), size * 4);
-  CHECK_EQUAL(std::string(sb.data()+3, 9), "e be cont");
+  CHECK_EQUAL(std::string(sb.data() + 3, 9), "e be cont");
   sb.pubseekpos(size * 3, std::ios::out);
   sb.sputc('x');
+}
+
 }
 
 TEST(memory-mapped streambuffer aligned resize) {
@@ -91,7 +95,7 @@ TEST(memory-mapped streambuffer aligned resize) {
 TEST(memory-mapped streambuffer aligned resize large) {
   auto filename = directory / "aligned_large";
   auto page_size = detail::page_size();
-  auto hundred_mb = (100 * (1 << 20));
+  auto hundred_mb = size_t{100 * (1 << 20)};
   auto size = hundred_mb - (hundred_mb % page_size);
   aligned_resize_test_impl(filename, size);
 }

--- a/libvast/test/mmapbuf.cpp
+++ b/libvast/test/mmapbuf.cpp
@@ -61,7 +61,7 @@ TEST(memory-mapped streambuffer) {
   CHECK_EQUAL(cur, sb.size()); // we're at the end!
 }
 
-TEST_DISABLED(memory-mapped streambuffer aligned resize) {
+TEST(memory-mapped streambuffer aligned resize) {
   auto filename = directory / "aligned";
   auto page_size = detail::page_size();
   detail::mmapbuf sb{filename.str(), page_size};

--- a/libvast/test/mmapbuf.cpp
+++ b/libvast/test/mmapbuf.cpp
@@ -61,25 +61,39 @@ TEST(memory-mapped streambuffer) {
   CHECK_EQUAL(cur, sb.size()); // we're at the end!
 }
 
-TEST(memory-mapped streambuffer aligned resize) {
-  auto filename = directory / "aligned";
-  auto page_size = detail::page_size();
-  detail::mmapbuf sb{filename.str(), page_size};
+void aligned_resize_test_impl(const vast::path& filename, size_t size) {
+  detail::mmapbuf sb{filename.str(), size};
   REQUIRE(sb.data() != nullptr);
-  CHECK_EQUAL(sb.size(), page_size);
+  CHECK_EQUAL(sb.size(), size);
+  sb.sputn("Here be content", 15);
   // Aligned resizing.
-  REQUIRE(sb.resize(page_size * 2));
-  CHECK_EQUAL(sb.size(), page_size * 2);
+  REQUIRE(sb.resize(size * 2));
+  CHECK_EQUAL(sb.size(), size * 2);
+  CHECK_EQUAL(std::string(sb.data()+3, 9), "e be cont");
   // Seek in the middle and perform a random write.
-  sb.pubseekpos(page_size, std::ios::out);
+  sb.pubseekpos(size, std::ios::out);
   sb.sputc('x');
   // Unaligned resizing.
-  REQUIRE(sb.resize(page_size / 2));
-  CHECK_EQUAL(sb.size(), page_size / 2);
+  REQUIRE(sb.resize(size / 2));
+  CHECK_EQUAL(sb.size(), size / 2);
   REQUIRE(sb.resize(sb.size() * 8));
-  CHECK_EQUAL(sb.size(), page_size * 4);
-  sb.pubseekpos(page_size * 3, std::ios::out);
+  CHECK_EQUAL(sb.size(), size * 4);
+  CHECK_EQUAL(std::string(sb.data()+3, 9), "e be cont");
+  sb.pubseekpos(size * 3, std::ios::out);
   sb.sputc('x');
+}
+
+TEST(memory-mapped streambuffer aligned resize) {
+  auto filename = directory / "aligned";
+  aligned_resize_test_impl(filename, detail::page_size());
+}
+
+TEST(memory-mapped streambuffer aligned resize large) {
+  auto filename = directory / "aligned_large";
+  auto page_size = detail::page_size();
+  auto hundred_mb = (100 * (1 << 20));
+  auto size = hundred_mb - (hundred_mb % page_size);
+  aligned_resize_test_impl(filename, size);
 }
 
 FIXTURE_SCOPE_END()


### PR DESCRIPTION
The algorithm to expand a mmaped region is buggy and has already triggered segfaults on linux systems.