### PR TITLE
Add --more-warnings config option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,42 @@ if (NOT CMAKE_CXX_FLAGS)
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -fno-omit-frame-pointer")
 endif ()
 
+# Enable more (most) warnings when requested by the user.
+if (MORE_WARNINGS)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(WFLAGS "-Weverything -Wno-c++98-compat -Wno-padded "
+               "-Wno-documentation-unknown-command -Wno-exit-time-destructors "
+               "-Wno-global-constructors -Wno-missing-prototypes "
+               "-Wno-c++98-compat-pedantic -Wno-unused-member-function "
+               "-Wno-unused-const-variable -Wno-switch-enum "
+               "-Wno-abstract-vbase-init "
+               "-Wno-missing-noreturn -Wno-covered-switch-default")
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set(WFLAGS "-Waddress -Wall -Warray-bounds "
+               "-Wattributes -Wbuiltin-macro-redefined -Wcast-align "
+               "-Wcast-qual -Wchar-subscripts -Wclobbered -Wcomment "
+               "-Wconversion -Wconversion-null -Wcoverage-mismatch "
+               "-Wcpp -Wdelete-non-virtual-dtor -Wdeprecated "
+               "-Wdeprecated-declarations -Wdiv-by-zero -Wdouble-promotion "
+               "-Wempty-body -Wendif-labels -Wenum-compare -Wextra "
+               "-Wfloat-equal -Wformat -Wfree-nonheap-object "
+               "-Wignored-qualifiers -Winit-self "
+               "-Winline -Wint-to-pointer-cast -Winvalid-memory-model "
+               "-Winvalid-offsetof -Wlogical-op -Wmain -Wmaybe-uninitialized "
+               "-Wmissing-braces -Wmultichar "
+               "-Wnarrowing -Wnoexcept -Wnon-template-friend "
+               "-Wnon-virtual-dtor -Wnonnull -Woverflow "
+               "-Woverlength-strings -Wparentheses "
+               "-Wpmf-conversions -Wpointer-arith -Wreorder "
+               "-Wreturn-type -Wsequence-point "
+               "-Wsign-compare -Wswitch -Wtype-limits -Wundef "
+               "-Wuninitialized -Wunused -Wvla -Wwrite-strings")
+  endif()
+  # convert CMake list to a single string, erasing the ";" separators
+  string(REPLACE ";" "" WFLAGS_STR ${WFLAGS})
+  set(EXTRA_FLAGS "${EXTRA_FLAGS} ${WFLAGS_STR}")
+endif()
+
 # Requirement checks
 try_run(program_result
         compilation_succeeded

--- a/configure
+++ b/configure
@@ -29,6 +29,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --build-dir=DIR         directory where to perform build [build]
     --show-time-report      show where the compiler spends its time
     --no-auto-libc++        do not automatically use libc++ with Clang
+    --more-warnings         enables most warnings on GCC and Clang
 
   Debugging:
     --log-level=LEVEL       maximum compile-time log level [debug]
@@ -139,6 +140,9 @@ while [ $# -ne 0 ]; do
     --no-auto-libc++)
       append_cache_entry NO_AUTO_LIBCPP BOOL yes
       ;;
+    --more-warnings)
+        append_cache_entry MORE_WARNINGS BOOL yes
+        ;;
     --log-level=*)
       append_cache_entry VAST_LOG_LEVEL INTEGER $(levelize $optarg)
       ;;

--- a/configure
+++ b/configure
@@ -49,6 +49,10 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --with-perftools=PATH   path to gperftools install root
     --with-doxygen=PATH     path to Doxygen install root
 
+  Convenience options:
+    --dev-mode              sets --build-type=debug, --log-level=trace,
+                            and --enable-asan
+
   Influential Environment Variables (only on first invocation):
     CXX                     C++ compiler command
     CXXFLAGS                C++ compiler flags
@@ -172,6 +176,13 @@ while [ $# -ne 0 ]; do
       ;;
     --with-doxygen=*)
       append_cache_entry Doxygen_ROOT_DIR PATH "$optarg"
+      ;;
+    --dev-mode)
+      append_cache_entry CMAKE_BUILD_TYPE STRING Debug
+      append_cache_entry VAST_LOG_LEVEL INTEGER 4
+      append_cache_entry ENABLE_ADDRESS_SANITIZER BOOL true
+      # TODO: eventually, we also want to enable --more-warnings
+      # append_cache_entry MORE_WARNINGS BOOL yes
       ;;
     *)
       echo "Invalid option '$1'.  Try $0 --help to see available options."


### PR DESCRIPTION
Mid-term, we want to make the most of our tool chain and enable most diagnostics modern compilers have to offer. I currently cannot recommend enabling this option for daily work, as it *will* flood your terminal.