### PR TITLE
Reduce mmap size for large streambuf resize test

### DIFF
--- a/libvast/test/mmapbuf.cpp
+++ b/libvast/test/mmapbuf.cpp
@@ -95,8 +95,8 @@ TEST(memory-mapped streambuffer aligned resize) {
 TEST(memory-mapped streambuffer aligned resize large) {
   auto filename = directory / "aligned_large";
   auto page_size = detail::page_size();
-  auto hundred_mb = size_t{100 * (1 << 20)};
-  auto size = hundred_mb - (hundred_mb % page_size);
+  auto ten_mb = size_t{10 * (1 << 20)};
+  auto size = ten_mb - (ten_mb % page_size);
   aligned_resize_test_impl(filename, size);
 }
 


### PR DESCRIPTION
Sometimes resizing the mmap to 800 MB is too much for the Jenkins host, so this should reduce peak usage to 80 MB.