### PR TITLE
Remove map file if it was created with the mapping

### DIFF
--- a/libvast/src/detail/mmapbuf.cpp
+++ b/libvast/src/detail/mmapbuf.cpp
@@ -57,6 +57,8 @@ mmapbuf::mmapbuf(const path& filename, size_t size, size_t offset)
     file_size = st.st_size;
   else if (result < 0 && errno != ENOENT)
     return;
+  else
+    is_file_owner_ = true;
   // Open/create file and resize if the mapping is larger than the file.
   auto fd = open(filename.str().c_str(), O_RDWR | O_CREAT, 0644);
   if (fd == -1)
@@ -83,6 +85,8 @@ mmapbuf::~mmapbuf() {
     munmap(map_, size_);
   if (fd_ != -1)
     close(fd_);
+  if (is_file_owner_)
+    std::remove(filename_.str().c_str());
 }
 
 const mmapbuf::char_type* mmapbuf::data() const {

--- a/libvast/test/mmapbuf.cpp
+++ b/libvast/test/mmapbuf.cpp
@@ -11,8 +11,13 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
+#include <fcntl.h>
+#include <unistd.h>
+
 #include <fstream>
 #include <string>
+
+#include <cstdio>
 
 #include "vast/detail/mmapbuf.hpp"
 #include "vast/detail/system.hpp"
@@ -34,31 +39,36 @@ TEST(memory-mapped streambuffer) {
   ofs << data;
   ofs.close();
   MESSAGE("performing streambuffer tests");
-  detail::mmapbuf sb{filename.str()};
-  CHECK_EQUAL(sb.size(), data.size());
-  CHECK_EQUAL(sb.in_avail(), static_cast<std::streamsize>(sb.size()));
-  std::string buf;
-  buf.resize(3);
-  auto n = sb.sgetn(&buf[0], 3);
-  CHECK_EQUAL(n, 3);
-  CHECK_EQUAL(buf, "foo");
-  CHECK_EQUAL(sb.in_avail(), 9);
-  buf.resize(data.size());
-  n = sb.sgetn(&buf[3], 100);
-  CHECK_EQUAL(n, 9);
-  CHECK_EQUAL(buf, data);
-  CHECK_EQUAL(sb.in_avail(), 0);
-  // Seek back to beginning.
-  sb.pubseekpos(0, std::ios::in);
-  CHECK_EQUAL(sb.in_avail(), static_cast<std::streamsize>(sb.size()));
-  data = "corge ";
-  n = sb.sputn(data.data(), data.size());
-  CHECK_EQUAL(n, static_cast<std::streamsize>(data.size()));
-  CHECK_EQUAL(std::string(sb.data(), sb.size()), "corge bazqux");
-  CHECK(sb.resize(data.size() - 1));
-  // Figure out current position.
-  size_t cur = sb.pubseekoff(0, std::ios::cur, std::ios::out);
-  CHECK_EQUAL(cur, sb.size()); // we're at the end!
+  auto fd = open(filename.str().c_str(), O_RDWR);
+  {
+    detail::mmapbuf sb{fd};
+    CHECK_EQUAL(sb.size(), data.size());
+    CHECK_EQUAL(sb.in_avail(), static_cast<std::streamsize>(sb.size()));
+    std::string buf;
+    buf.resize(3);
+    auto n = sb.sgetn(&buf[0], 3);
+    CHECK_EQUAL(n, 3);
+    CHECK_EQUAL(buf, "foo");
+    CHECK_EQUAL(sb.in_avail(), 9);
+    buf.resize(data.size());
+    n = sb.sgetn(&buf[3], 100);
+    CHECK_EQUAL(n, 9);
+    CHECK_EQUAL(buf, data);
+    CHECK_EQUAL(sb.in_avail(), 0);
+    // Seek back to beginning.
+    sb.pubseekpos(0, std::ios::in);
+    CHECK_EQUAL(sb.in_avail(), static_cast<std::streamsize>(sb.size()));
+    data = "corge ";
+    n = sb.sputn(data.data(), data.size());
+    CHECK_EQUAL(n, static_cast<std::streamsize>(data.size()));
+    CHECK_EQUAL(std::string(sb.data(), sb.size()), "corge bazqux");
+    CHECK(sb.resize(data.size() - 1));
+    // Figure out current position.
+    size_t cur = sb.pubseekoff(0, std::ios::cur, std::ios::out);
+    CHECK_EQUAL(cur, sb.size()); // we're at the end!
+  }
+  close(fd);
+  std::remove(filename.str().c_str());
 }
 
 namespace {

--- a/libvast/vast/detail/mmapbuf.hpp
+++ b/libvast/vast/detail/mmapbuf.hpp
@@ -87,6 +87,7 @@ private:
   void reset();
 
   path filename_;
+  bool is_file_owner_ = false;
   int fd_ = -1;
   size_t size_ = 0;
   size_t offset_ = 0;

--- a/libvast/vast/detail/mmapbuf.hpp
+++ b/libvast/vast/detail/mmapbuf.hpp
@@ -34,10 +34,18 @@ public:
   /// @pre `size > 0`
   explicit mmapbuf(size_t size);
 
-  /// Constructs a file-backed memory-mapped stream buffer.
+  /// Constructs a file-backed memory-mapped stream buffer on an existing file
+  /// @param the descriptor for the file to be used for mapping
+  /// @param size The size of the file in bytes. If 0, the current size of the
+  ///             file pointed to by fd will be used. Otherwise the file will
+  ///             be resized to size.
+  /// @param offset The offset where to begin mapping; same as in `mmap(2)`.
+  explicit mmapbuf(const int fd, const size_t size = 0,
+                   const size_t offset = 0);
+
+  /// Constructs a file-backed memory-mapped stream buffer on a new file.
   /// @param filename The path to the file to open.
-  /// @param size The size of the file in bytes. If 0, figure out file size
-  ///             automatically.
+  /// @param size The size of the file in bytes.
   /// @param offset The offset where to begin mapping; same as in `mmap(2)`.
   explicit mmapbuf(const path& filename, size_t size = 0,
                    size_t offset = 0);
@@ -87,8 +95,8 @@ private:
   void reset();
 
   path filename_;
-  bool is_file_owner_ = false;
   int fd_ = -1;
+  bool is_file_owner_ = false;
   size_t size_ = 0;
   size_t offset_ = 0;
   int prot_ = 0;
@@ -97,4 +105,3 @@ private:
 };
 
 } // namespace vast::detail
-


### PR DESCRIPTION
The behavior mmapbuf should be symmetric, i.e. if the underlying file did not exist before creating the memory map, the file should be deleted when the mapping is removed.