### PR TITLE
Remove default name for schema file

### DIFF
--- a/libvast/src/defaults.cpp
+++ b/libvast/src/defaults.cpp
@@ -26,7 +26,6 @@ const char* directory = "vast";
 const char* endpoint = ":42000";
 const char* id = "";
 const char* read_path = "-";
-const char* schema_path = "-";
 const char* write_path = "-";
 int64_t pseudo_realtime_factor = 0;
 size_t cutoff = std::numeric_limits<size_t>::max();

--- a/libvast/vast/system/reader_command.hpp
+++ b/libvast/vast/system/reader_command.hpp
@@ -63,10 +63,9 @@ protected:
     Reader reader{std::move(*in)};
     auto src = self->spawn(default_source<Reader>, std::move(reader));
     // Supply an alternate schema, if requested.
-    auto schema_file = get_or(options, "schema",
-                              defaults::command::schema_path);
-    if (!schema_file.empty()) {
-      auto str = load_contents(schema_file);
+    auto schema_file = caf::get_if<std::string>(&options, "schema");
+    if (schema_file && !schema_file->empty()) {
+      auto str = load_contents(*schema_file);
       if (!str)
         return str.error();
       auto sch = to<schema>(*str);


### PR DESCRIPTION
The default schemas are hardcoded at the moment, and stdin is used for data input.