### PR TITLE
Clean up configuration constructor

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -236,6 +236,7 @@ set(tests
   test/expression_evaluation.cpp
   test/expression_parseable.cpp
   test/filesystem.cpp
+  test/fixtures/actor_system.cpp
   test/fixtures/events.cpp
   test/format/bro.cpp
   test/format/mrt.cpp

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -55,9 +55,8 @@ using namespace caf;
 namespace vast::system {
 
 configuration::configuration() {
-  // -- CAF configuration ------------------------------------------------------
-  // Consider only VAST's log messages by default.
-  set("logger.component-filter", "vast");
+  // Load I/O module.
+  load<io::middleman>();
   // Use 'vast.ini' instead of generic 'caf-application.ini'.
   config_file_path = "vast.ini";
   // Register VAST's custom types.
@@ -117,18 +116,6 @@ configuration::configuration() {
   load<opencl::manager>();
   add_message_type<std::vector<uint32_t>>("std::vector<uint32_t>");
 #endif
-}
-
-configuration::configuration(bool load_middleman, bool allow_ssl_module)
-  : configuration() {
-  if (load_middleman) {
-    load<io::middleman>();
-    set("middleman.enable-automatic-connections", true);
-#ifdef VAST_USE_OPENSSL
-  if (allow_ssl_module)
-    load<openssl::manager>();
-#endif
-  }
 }
 
 configuration& configuration::parse(int argc, char** argv) {

--- a/libvast/test/fixtures/actor_system.cpp
+++ b/libvast/test/fixtures/actor_system.cpp
@@ -1,0 +1,76 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "fixtures/actor_system.hpp"
+
+#include <caf/io/middleman.hpp>
+
+#include "vast/system/atoms.hpp"
+#include "vast/system/profiler.hpp"
+
+#include "vast/detail/assert.hpp"
+
+namespace fixtures {
+
+/// Configures the actor system of a fixture with default settings for unit
+/// testing.
+test_configuration::test_configuration() {
+  load<caf::io::middleman>();
+  std::string log_file = "vast-unit-test.log";
+  set("logger.file-name", log_file);
+  // Always begin with an empy log file.
+  if (vast::exists(log_file))
+    vast::rm(log_file);
+}
+
+/// A fixture with an actor system that uses the default work-stealing
+/// scheduler.
+actor_system::actor_system() : system(config), self(system, true) {
+  // Clean up state from previous executions.
+  if (vast::exists(directory))
+    vast::rm(directory);
+  // Start profiler.
+  if (vast::test::config.count("gperftools") > 0)
+    enable_profiler();
+}
+
+actor_system::~actor_system() {
+  // Stop profiler.
+  using vast::system::stop_atom;
+  using vast::system::heap_atom;
+  using vast::system::cpu_atom;
+  if (profiler) {
+    self->send(profiler, stop_atom::value, cpu_atom::value);
+    self->send(profiler, stop_atom::value, heap_atom::value);
+  }
+}
+
+void actor_system::enable_profiler() {
+  VAST_ASSERT(!profiler);
+  using vast::system::start_atom;
+  using vast::system::heap_atom;
+  using vast::system::cpu_atom;
+  profiler = self->spawn(vast::system::profiler, directory / "profiler",
+                         std::chrono::seconds(1));
+  self->send(profiler, start_atom::value, cpu_atom::value);
+  self->send(profiler, start_atom::value, heap_atom::value);
+}
+
+deterministic_actor_system::deterministic_actor_system() {
+  // Clean up state from previous executions.
+  if (vast::exists(directory))
+    vast::rm(directory);
+}
+
+} // namespace fixtures
+

--- a/libvast/test/fixtures/actor_system.hpp
+++ b/libvast/test/fixtures/actor_system.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <caf/all.hpp>
+#include <caf/io/middleman.hpp>
 #include <caf/test/dsl.hpp>
 
 #include "vast/system/atoms.hpp"
@@ -30,9 +31,8 @@ namespace fixtures {
 /// Configures the actor system of a fixture with default settings for unit
 /// testing.
 struct test_configuration : vast::system::configuration {
-  using super = vast::system::configuration;
-
-  test_configuration(bool enable_mm = true) : super(enable_mm) {
+  test_configuration() {
+    load<caf::io::middleman>();
     std::string log_file = "vast-unit-test.log";
     set("logger.file-name", log_file);
     set("logger.component-filter", "");
@@ -45,10 +45,7 @@ struct test_configuration : vast::system::configuration {
 /// A fixture with an actor system that uses the default work-stealing
 /// scheduler.
 struct actor_system : filesystem {
-  actor_system(bool enable_mm = true)
-    : config(enable_mm),
-      system(config),
-      self(system, true) {
+  actor_system() : system(config), self(system, true) {
     // Clean up state from previous executions.
     if (vast::exists(directory))
       vast::rm(directory);
@@ -97,7 +94,7 @@ struct deterministic_actor_system
 
   using super = test_coordinator_fixture<test_configuration>;
 
-  deterministic_actor_system(bool enable_mm = true) : super(enable_mm) {
+  deterministic_actor_system() {
     // Clean up state from previous executions.
     if (vast::exists(directory))
       vast::rm(directory);

--- a/libvast/test/fixtures/actor_system.hpp
+++ b/libvast/test/fixtures/actor_system.hpp
@@ -40,7 +40,7 @@ struct actor_system : filesystem {
 
   void enable_profiler();
 
-  inline auto error_handler() {
+  auto error_handler() {
     return [&](const caf::error& e) { FAIL(system.render(e)); };
   }
 
@@ -58,7 +58,7 @@ struct deterministic_actor_system
 
   deterministic_actor_system();
 
-  inline auto error_handler() {
+  auto error_handler() {
     return [&](const caf::error& e) { FAIL(sys.render(e)); };
   }
 };

--- a/libvast/test/fixtures/actor_system.hpp
+++ b/libvast/test/fixtures/actor_system.hpp
@@ -13,70 +13,34 @@
 
 #pragma once
 
-#include <caf/all.hpp>
-#include <caf/io/middleman.hpp>
+#include <caf/actor.hpp>
+#include <caf/actor_system.hpp>
+#include <caf/scoped_actor.hpp>
 #include <caf/test/dsl.hpp>
 
-#include "vast/system/atoms.hpp"
 #include "vast/system/configuration.hpp"
-#include "vast/system/profiler.hpp"
 
-#include "vast/detail/assert.hpp"
-
-#include "test.hpp"
 #include "fixtures/filesystem.hpp"
+#include "test.hpp"
 
 namespace fixtures {
 
 /// Configures the actor system of a fixture with default settings for unit
 /// testing.
 struct test_configuration : vast::system::configuration {
-  test_configuration() {
-    load<caf::io::middleman>();
-    std::string log_file = "vast-unit-test.log";
-    set("logger.file-name", log_file);
-    set("logger.component-filter", "");
-    // Always begin with an empy log file.
-    if (vast::exists(log_file))
-      vast::rm(log_file);
-  }
+  test_configuration();
 };
 
 /// A fixture with an actor system that uses the default work-stealing
 /// scheduler.
 struct actor_system : filesystem {
-  actor_system() : system(config), self(system, true) {
-    // Clean up state from previous executions.
-    if (vast::exists(directory))
-      vast::rm(directory);
-    // Start profiler.
-    if (vast::test::config.count("gperftools") > 0)
-      enable_profiler();
-  }
+  actor_system();
 
-  ~actor_system() {
-    // Stop profiler.
-    using vast::system::stop_atom;
-    using vast::system::heap_atom;
-    using vast::system::cpu_atom;
-    if (profiler) {
-      self->send(profiler, stop_atom::value, cpu_atom::value);
-      self->send(profiler, stop_atom::value, heap_atom::value);
-    }
-  }
+  ~actor_system();
 
-  void enable_profiler() {
-    VAST_ASSERT(!profiler);
-    using vast::system::start_atom;
-    using vast::system::heap_atom;
-    using vast::system::cpu_atom;
-    profiler = self->spawn(vast::system::profiler, directory / "profiler",
-                           std::chrono::seconds(1));
-    self->send(profiler, start_atom::value, cpu_atom::value);
-    self->send(profiler, start_atom::value, heap_atom::value);
-  }
+  void enable_profiler();
 
-  auto error_handler() {
+  inline auto error_handler() {
     return [&](const caf::error& e) { FAIL(system.render(e)); };
   }
 
@@ -92,15 +56,9 @@ struct deterministic_actor_system
   : test_coordinator_fixture<test_configuration>,
     filesystem {
 
-  using super = test_coordinator_fixture<test_configuration>;
+  deterministic_actor_system();
 
-  deterministic_actor_system() {
-    // Clean up state from previous executions.
-    if (vast::exists(directory))
-      vast::rm(directory);
-  }
-
-  auto error_handler() {
+  inline auto error_handler() {
     return [&](const caf::error& e) { FAIL(sys.render(e)); };
   }
 };

--- a/libvast/test/fixtures/actor_system_and_events.hpp
+++ b/libvast/test/fixtures/actor_system_and_events.hpp
@@ -21,21 +21,14 @@ namespace fixtures {
 /// A fixture with an actor system that uses the default work-stealing
 /// scheduler and test data (events).
 struct actor_system_and_events : actor_system, events {
-  template <class... Ts>
-  actor_system_and_events(Ts&&... xs) : actor_system(std::forward<Ts>(xs)...) {
-    // nop
-  }
+  // nop
 };
 
 /// A fixture with an actor system that uses the test coordinator for
 /// determinstic testing of actors and test data (events).
 struct deterministic_actor_system_and_events : deterministic_actor_system,
                                                events {
-  template <class... Ts>
-  deterministic_actor_system_and_events(Ts&&... xs)
-    : deterministic_actor_system(std::forward<Ts>(xs)...) {
-    // nop
-  }
+  // nop
 };
 
 } // namespace fixtures

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -40,7 +40,7 @@ namespace {
 using fixture_base = fixtures::deterministic_actor_system_and_events;
 
 struct fixture : fixture_base {
-  fixture() : fixture_base(false) {
+  fixture() {
     expr = unbox(to<expression>("service == \"http\" "
                                 "&& :addr == 212.227.96.110"));
   }

--- a/libvast/vast/access.hpp
+++ b/libvast/vast/access.hpp
@@ -70,19 +70,19 @@ struct has_access_converter {
 } // namespace detail
 
 template <class T>
-inline constexpr bool has_access_state_v
+constexpr bool has_access_state_v
   = decltype(detail::has_access_state::test<T>(0))::value;
 
 template <class T>
-inline constexpr bool has_access_parser_v
+constexpr bool has_access_parser_v
   = decltype(detail::has_access_parser::test<T>(0))::value;
 
 template <class T>
-inline constexpr bool has_access_printer_v
+constexpr bool has_access_printer_v
   = decltype(detail::has_access_printer::test<T>(0))::value;
 
 template <class T>
-inline constexpr bool has_access_converter_v
+constexpr bool has_access_converter_v
   = decltype(detail::has_access_converter::test<T>(0))::value;
 
 } // namespace vast

--- a/libvast/vast/column_index.hpp
+++ b/libvast/vast/column_index.hpp
@@ -68,7 +68,7 @@ public:
   caf::expected<bitmap> lookup(const predicate& pred);
 
   /// @returns the file name for loading and storing the index.
-  inline const path& filename() const {
+  const path& filename() const {
     return filename_;
   }
 
@@ -80,7 +80,7 @@ public:
   }
 
   /// @returns the type of this column.
-  inline const type& index_type() const {
+  const type& index_type() const {
     return index_type_;
   }
 

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -74,17 +74,17 @@ public:
   std::string full_name() const;
 
   /// Queries whether this command has no parent.
-  inline bool is_root() const noexcept {
+  bool is_root() const noexcept {
     return parent_ == nullptr;
   }
 
   /// @returns the root command.
-  inline command& root() noexcept {
+  command& root() noexcept {
     return is_root() ? *this : parent_->root();
   }
 
   /// @returns the managed command name.
-  inline std::string_view name() const noexcept {
+  std::string_view name() const noexcept {
     return name_;
   }
 

--- a/libvast/vast/concept/hashable/hash_append.hpp
+++ b/libvast/vast/concept/hashable/hash_append.hpp
@@ -128,7 +128,7 @@ struct is_contiguously_hashable<T[N], Hasher>
     > {};
 
 template <class T, class Hasher>
-inline constexpr bool is_contiguously_hashable_v
+constexpr bool is_contiguously_hashable_v
   = is_contiguously_hashable<T, Hasher>::value;
 
 } // namespace detail

--- a/libvast/vast/concept/parseable/core/choice.hpp
+++ b/libvast/vast/concept/parseable/core/choice.hpp
@@ -32,7 +32,7 @@ template <class Lhs, class Rhs>
 struct is_choice_parser<choice_parser<Lhs, Rhs>> : std::true_type {};
 
 template <class T>
-inline constexpr bool is_choice_parser_v = is_choice_parser<T>::value;
+constexpr bool is_choice_parser_v = is_choice_parser<T>::value;
 
 /// Attempts to parse either LHS or RHS.
 template <class Lhs, class Rhs>

--- a/libvast/vast/concept/parseable/core/parser.hpp
+++ b/libvast/vast/concept/parseable/core/parser.hpp
@@ -116,12 +116,12 @@ struct has_parser {
 
 /// Checks whether the parser registry has a given type registered.
 template <class T>
-inline constexpr bool has_parser_v
+constexpr bool has_parser_v
   = decltype(detail::has_parser::test<T>(0))::value;
 
 /// Checks whether a given type is-a parser, i.e., derived from ::vast::parser.
 template <class T>
-inline constexpr bool is_parser_v = std::is_base_of<parser<T>, T>::value;
+constexpr bool is_parser_v = std::is_base_of<parser<T>, T>::value;
 
 } // namespace vast
 

--- a/libvast/vast/concept/parseable/core/sequence.hpp
+++ b/libvast/vast/concept/parseable/core/sequence.hpp
@@ -32,7 +32,7 @@ template <class... Ts>
 struct is_sequence_parser<sequence_parser<Ts...>> : std::true_type {};
 
 template <class T>
-inline constexpr bool is_sequence_parser_v = is_sequence_parser<T>::value;
+constexpr bool is_sequence_parser_v = is_sequence_parser<T>::value;
 
 template <class Lhs, class Rhs>
 class sequence_parser : public parser<sequence_parser<Lhs, Rhs>> {

--- a/libvast/vast/concept/parseable/detail/as_parser.hpp
+++ b/libvast/vast/concept/parseable/detail/as_parser.hpp
@@ -50,12 +50,12 @@ auto as_parser(T x) -> std::enable_if_t<is_parser_v<T>, T> {
 // -- binary ------------------------------------------------------------------
 
 template <class T>
-inline constexpr bool is_convertible_to_unary_parser_v
+constexpr bool is_convertible_to_unary_parser_v
   = std::is_convertible_v<T, std::string>
     || (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>);
 
 template <class T, class U>
-inline constexpr bool is_convertible_to_binary_parser_v =
+constexpr bool is_convertible_to_binary_parser_v =
     (is_parser_v<T> && is_parser_v<U>)
     || (is_parser_v<T> && is_convertible_to_unary_parser_v<U>)
     || (is_convertible_to_unary_parser_v<T> && is_parser_v<U>) ;

--- a/libvast/vast/concept/parseable/detail/container.hpp
+++ b/libvast/vast/concept/parseable/detail/container.hpp
@@ -28,7 +28,7 @@ template <class T, class U>
 struct is_pair<std::pair<T, U>> : std::true_type {};
 
 template <class T>
-inline constexpr bool is_pair_v = is_pair<T>::value;
+constexpr bool is_pair_v = is_pair<T>::value;
 
 template <class Elem>
 struct container {

--- a/libvast/vast/concept/parseable/parse.hpp
+++ b/libvast/vast/concept/parseable/parse.hpp
@@ -70,7 +70,7 @@ struct is_parseable {
 } // namespace detail
 
 template <class I, class T>
-inline constexpr bool is_parseable_v
+constexpr bool is_parseable_v
   = decltype(detail::is_parseable::test<I, T>(0, 0, 0))::value;
 
 } // namespace vast

--- a/libvast/vast/concept/printable/core/choice.hpp
+++ b/libvast/vast/concept/printable/core/choice.hpp
@@ -30,7 +30,7 @@ template <class Lhs, class Rhs>
 struct is_choice_printer<choice_printer<Lhs, Rhs>> : std::true_type {};
 
 template <class T>
-inline constexpr bool is_choice_printer_v = is_choice_printer<T>::value;
+constexpr bool is_choice_printer_v = is_choice_printer<T>::value;
 
 /// Attempts to print either LHS or RHS.
 template <class Lhs, class Rhs>

--- a/libvast/vast/concept/printable/core/printer.hpp
+++ b/libvast/vast/concept/printable/core/printer.hpp
@@ -103,13 +103,13 @@ struct has_printer {
 
 /// Checks whether the printer registry has a given type registered.
 template <class T>
-inline constexpr bool has_printer_v
+constexpr bool has_printer_v
   = decltype(detail::has_printer::test<T>(0))::value;
 
 /// Checks whether a given type is-a printer, i.e., derived from
 /// ::vast::printer.
 template <class T>
-inline constexpr bool is_printer_v = std::is_base_of_v<printer<T>, T>;
+constexpr bool is_printer_v = std::is_base_of_v<printer<T>, T>;
 
 } // namespace vast
 

--- a/libvast/vast/concept/printable/core/sequence.hpp
+++ b/libvast/vast/concept/printable/core/sequence.hpp
@@ -33,7 +33,7 @@ template <class... Ts>
 struct is_sequence_printer<sequence_printer<Ts...>> : std::true_type {};
 
 template <class T>
-inline constexpr bool is_sequence_printer_v = is_sequence_printer<T>::value;
+constexpr bool is_sequence_printer_v = is_sequence_printer<T>::value;
 
 // TODO: factor helper functions shared among sequence printer and parser.
 

--- a/libvast/vast/concept/printable/detail/as_printer.hpp
+++ b/libvast/vast/concept/printable/detail/as_printer.hpp
@@ -50,7 +50,7 @@ auto as_printer(T x) -> std::enable_if_t<is_printer_v<T>, T> {
 // -- binary ------------------------------------------------------------------
 
 template <class T>
-inline constexpr bool is_convertible_to_unary_printer_v =
+constexpr bool is_convertible_to_unary_printer_v =
   std::is_convertible_v<T, std::string>
   || (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>);
 
@@ -64,7 +64,7 @@ using is_convertible_to_binary_printer =
   >;
 
 template <class T, class U>
-inline constexpr bool is_convertible_to_binary_printer_v
+constexpr bool is_convertible_to_binary_printer_v
   = is_convertible_to_binary_printer<T, U>::value;
 
 template <

--- a/libvast/vast/concept/printable/print.hpp
+++ b/libvast/vast/concept/printable/print.hpp
@@ -70,7 +70,7 @@ struct is_printable {
 } // namespace detail
 
 template <class I, class T>
-inline constexpr bool is_printable_v
+constexpr bool is_printable_v
   = decltype(detail::is_printable::test<I, T>(0, 0))::value;
 
 } // namespace vast

--- a/libvast/vast/detail/math.hpp
+++ b/libvast/vast/detail/math.hpp
@@ -43,7 +43,7 @@ template <int exp, class T>
 constexpr T pow(T base);
 
 template <int exp, class T>
-inline constexpr T pow_impl(T base, uint64_t result = 1) {
+constexpr T pow_impl(T base, uint64_t result = 1) {
   return exp
     ? (exp & 1
        ? pow_impl<(exp >> 1)>(base * base, base * result)
@@ -70,7 +70,7 @@ constexpr int max_pot_exp(int result = 1) {
 template <int base, class T, int i = max_pot_exp<T, base>()>
 constexpr int ilog_helper(T n, int x = 0) {
   // binary search
-  return i 
+  return i
     ? ilog_helper<base, T, i / 2>(
         n >= pow<i, T>(base) ? n / pow<i, T>(base) : n,
         n >= pow<i, T>(base) ? x + i : x)

--- a/libvast/vast/detail/radix_tree.hpp
+++ b/libvast/vast/detail/radix_tree.hpp
@@ -490,7 +490,7 @@ private:
     }
   };
 
-  static inline const unsigned char* as_key_data(const std::string& key) {
+  static const unsigned char* as_key_data(const std::string& key) {
     return reinterpret_cast<const unsigned char*>(key.data());
   }
 

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -45,7 +45,7 @@ template <class... Ts>
 struct is_tuple<std::tuple<Ts...>> : std::true_type {};
 
 template <class T>
-inline constexpr bool is_tuple_v = is_tuple<T>::value;
+constexpr bool is_tuple_v = is_tuple<T>::value;
 
 /// Checks whether a type derives from `basic_streambuf<Char>`.
 template <class T, class U = void>
@@ -60,7 +60,7 @@ struct is_streambuf<
 > : std::true_type {};
 
 template <class T>
-inline constexpr bool is_streambuf_v = is_streambuf<T>::value;
+constexpr bool is_streambuf_v = is_streambuf<T>::value;
 
 
 /// Checks whether a type is container which consists of contiguous bytes.
@@ -78,14 +78,14 @@ struct is_contiguous_byte_container<
 > : std::true_type {};
 
 template <class T>
-inline constexpr bool is_contiguous_byte_container_v
+constexpr bool is_contiguous_byte_container_v
   = is_contiguous_byte_container<T>::value;
 
 // -- SFINAE helpers ---------------------------------------------------------
 // http://bit.ly/uref-copy.
 
 template <class A, class B>
-inline constexpr bool is_same_or_derived_v
+constexpr bool is_same_or_derived_v
   = std::is_base_of_v<A, std::remove_reference_t<B>>;
 
 template <bool B, class T = void>
@@ -110,10 +110,10 @@ using disable_if_same = disable_if_t<std::is_same_v<T, U>, R>;
 // -- traits -----------------------------------------------------------------
 
 template <class T, class... Ts>
-inline constexpr bool is_any_v = (std::is_same_v<T, Ts> || ...);
+constexpr bool is_any_v = (std::is_same_v<T, Ts> || ...);
 
 template <class T, class... Ts>
-inline constexpr bool are_same_v = (std::is_same_v<T, Ts> && ...);
+constexpr bool are_same_v = (std::is_same_v<T, Ts> && ...);
 
 // Utility for usage in `static_assert`. For example:
 //
@@ -190,7 +190,7 @@ struct detector<Default, void_t<Op<Args...>>, Op, Args...> {
 } // namespace <anonymous>
 
 template <template <class...> class Op, class... Args>
-inline constexpr bool is_detected_v
+constexpr bool is_detected_v
   = detector<nonesuch, void, Op, Args...>::value_t::value;
 
 template <template <class...> class Op, class... Args>

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -59,19 +59,19 @@ public:
   /// Retrieves the list of partition IDs for a given expression.
   std::vector<uuid> lookup(const expression& expr) const;
 
-  inline size_t size() const noexcept {
+  size_t size() const noexcept {
     return partitions_.size();
   }
 
-  inline const_iterator begin() const noexcept {
+  const_iterator begin() const noexcept {
     return partitions_.begin();
   }
 
-  inline const_iterator end() const noexcept {
+  const_iterator end() const noexcept {
     return partitions_.end();
   }
 
-  inline const map_type& partitions() const noexcept {
+  const map_type& partitions() const noexcept {
     return partitions_;
   }
 

--- a/libvast/vast/system/configuration.hpp
+++ b/libvast/vast/system/configuration.hpp
@@ -24,13 +24,10 @@ class application;
 
 /// Bundles all configuration parameters of a VAST system.
 class configuration : public caf::actor_system_config {
-  friend application;
-
 public:
-  /// Default-constructs a configuration.
-  configuration();
+  // -- constructors, destructors, and assignment operators --------------------
 
-  explicit configuration(bool load_middleman, bool allow_ssl_module = false);
+  configuration();
 
   // -- modifiers --------------------------------------------------------------
 

--- a/libvast/vast/system/default_application.hpp
+++ b/libvast/vast/system/default_application.hpp
@@ -29,12 +29,12 @@ class default_application : public application {
 public:
   default_application();
 
-  inline import_command& import_cmd() {
+  import_command& import_cmd() {
     VAST_ASSERT(import_ != nullptr);
     return *import_;
   }
 
-  inline export_command& export_cmd() {
+  export_command& export_cmd() {
     VAST_ASSERT(export_ != nullptr);
     return *export_;
   }

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -53,17 +53,17 @@ struct importer_state {
     /// The first unavailable ID.
     id last;
 
-    inline id_generator(id from, id to) : i(from), last(to) {
+    id_generator(id from, id to) : i(from), last(to) {
       // nop
     }
 
     /// @returns whether this generator is exhausted.
-    inline bool at_end() const noexcept {
+    bool at_end() const noexcept {
       return i == last;
     }
 
     /// @returns the next ID and advances the position in the range.
-    inline id next(size_t num = 1) noexcept {
+    id next(size_t num = 1) noexcept {
       VAST_ASSERT(static_cast<size_t>(remaining()) >= num);
       auto result = i;
       i += num;
@@ -71,7 +71,7 @@ struct importer_state {
     }
 
     /// @returns how many more times `next` returns a valid ID.
-    inline int32_t remaining() const noexcept {
+    int32_t remaining() const noexcept {
       return static_cast<int32_t>(last - i);
     }
   };

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -42,7 +42,7 @@ struct index_state {
   /// Looks up partitions in the LRU cache by UUID.
   class partition_lookup {
   public:
-    inline auto operator()(const uuid& id) const {
+    auto operator()(const uuid& id) const {
       return [&](const partition_ptr& ptr) {
         return ptr->id() == id;
       };
@@ -52,7 +52,7 @@ struct index_state {
   /// Loads partitions from disk by UUID.
   class partition_factory {
   public:
-    inline partition_factory(index_state* st) : st_(st) {
+    partition_factory(index_state* st) : st_(st) {
       // nop
     }
 

--- a/libvast/vast/system/indexer_manager.hpp
+++ b/libvast/vast/system/indexer_manager.hpp
@@ -62,7 +62,7 @@ public:
   }
 
   /// @returns the number of INDEXER actors.
-  inline size_t indexer_count() const {
+  size_t indexer_count() const {
     return indexers_.size();
   }
 

--- a/libvast/vast/system/indexer_stage_driver.hpp
+++ b/libvast/vast/system/indexer_stage_driver.hpp
@@ -31,8 +31,8 @@ using indexer_stage_filter = type;
 /// @relates indexer_stage_driver
 /// Selects an INDEXER actor based on its filter.
 struct indexer_stage_selector {
-  inline bool operator()(const indexer_stage_filter& f,
-                         const const_table_slice_handle& x) const {
+  bool operator()(const indexer_stage_filter& f,
+                  const const_table_slice_handle& x) const {
     return f == x->layout();
   }
 };

--- a/libvast/vast/system/partition.hpp
+++ b/libvast/vast/system/partition.hpp
@@ -76,16 +76,16 @@ public:
   }
 
   /// @returns whether the meta data was changed.
-  inline bool dirty() const noexcept {
+  bool dirty() const noexcept {
     return meta_data_.dirty;
   }
 
   /// @returns the working directory of the partition.
-  inline const path& dir() const noexcept {
+  const path& dir() const noexcept {
     return dir_;
   }
   /// @returns the unique ID of the partition.
-  inline const uuid& id() const noexcept {
+  const uuid& id() const noexcept {
     return id_;
   }
 
@@ -118,7 +118,7 @@ public:
 private:
   /// Called from the INDEXER manager whenever a new layout gets added during
   /// ingestion.
-  inline void add_layout(const std::string& digest, const record_type& t) {
+  void add_layout(const std::string& digest, const record_type& t) {
     if (meta_data_.types.emplace(digest, t).second && !meta_data_.dirty)
       meta_data_.dirty = true;
   }

--- a/libvast/vast/table.hpp
+++ b/libvast/vast/table.hpp
@@ -46,17 +46,17 @@ public:
   bool add(const_table_slice_handle slice);
 
   /// Retrieves the table layout.
-  inline const record_type& layout() const noexcept {
+  const record_type& layout() const noexcept {
     return layout_;
   }
 
   /// @returns the number of rows in the table.
-  inline size_type rows() const {
+  size_type rows() const {
     return slices_.size();
   }
 
   /// @returns the number of rows in the table.
-  inline size_type columns() const {
+  size_type columns() const {
     return columns_;
   }
 

--- a/libvast/vast/table_index.hpp
+++ b/libvast/vast/table_index.hpp
@@ -74,28 +74,28 @@ public:
   /// -- properties ------------------------------------------------------------
 
   /// @returns the colums for storing meta information.
-  inline columns_range meta_columns() {
+  columns_range meta_columns() {
     auto first = columns_.begin();
     return {first, first + meta_column_count};
   }
 
   /// @returns the columns for storing data.
-  inline columns_range data_columns() {
+  columns_range data_columns() {
     return {columns_.begin() + meta_column_count, columns_.end()};
   }
 
   /// @returns the number of columns.
-  inline size_t num_columns() const {
+  size_t num_columns() const {
     return columns_.size();
   }
 
   /// @returns the number of columns for storing meta information.
-  inline size_t num_meta_columns() const {
+  size_t num_meta_columns() const {
     return static_cast<size_t>(meta_column_count);
   }
 
   /// @returns the number of columns for storing data.
-  inline size_t num_data_columns() const {
+  size_t num_data_columns() const {
     return num_columns() - num_meta_columns();
   }
 
@@ -150,19 +150,19 @@ public:
   column_index* by_name(std::string_view column_name);
 
   /// @returns the base directory for all stored column indexes.
-  inline const path& base_dir() const {
+  const path& base_dir() const {
     return base_dir_;
   }
 
   /// @returns the type defining this table's layout.
-  inline const record_type& layout() const {
+  const record_type& layout() const {
     // Always safe, because the only way to construct a table_index is with a
     // record_type.
     return caf::get<record_type>(type_erased_layout_);
   }
 
   /// @returns whether `add` was called at least once.
-  inline bool dirty() const {
+  bool dirty() const {
     return dirty_;
   }
 

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -77,7 +77,7 @@ public:
   // -- properties -------------------------------------------------------------
 
   /// @returns the table layout.
-  inline const record_type& layout() const noexcept {
+  const record_type& layout() const noexcept {
     return layout_;
   }
 
@@ -102,17 +102,17 @@ public:
                                     size_type num_rows = npos) const;
 
   /// @returns the number of rows in the slice.
-  inline size_type rows() const noexcept {
+  size_type rows() const noexcept {
     return rows_;
   }
 
   /// @returns the number of rows in the slice.
-  inline size_type columns() const noexcept {
+  size_type columns() const noexcept {
     return columns_;
   }
 
   /// @returns the offset in the ID space.
-  inline id offset() const noexcept {
+  id offset() const noexcept {
     return offset_;
   }
 

--- a/libvast/vast/word.hpp
+++ b/libvast/vast/word.hpp
@@ -23,7 +23,7 @@
 namespace vast::detail {
 
 template <class T>
-inline constexpr bool is_unsigned_integral_v
+constexpr bool is_unsigned_integral_v
   = std::is_unsigned_v<T> && std::is_integral_v<T>;
 
 // Type alias used for SFINAE of free functions below. If we would simply use

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -15,6 +15,12 @@
 #include <caf/io/middleman.hpp>
 #include <caf/message_builder.hpp>
 
+#include "vast/config.hpp"
+
+#ifdef VAST_USE_OPENSSL
+#include <caf/openssl/manager.hpp>
+#endif
+
 #include "vast/system/default_application.hpp"
 
 using namespace vast;

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -12,6 +12,7 @@
  ******************************************************************************/
 
 #include <caf/actor_system.hpp>
+#include <caf/io/middleman.hpp>
 #include <caf/message_builder.hpp>
 
 #include "vast/system/default_application.hpp"
@@ -19,9 +20,25 @@
 using namespace vast;
 using namespace vast::system;
 
+namespace {
+
+struct config : configuration {
+  config() {
+    // Consider only VAST's log messages by default.
+    set("logger.component-filter", "vast");
+    load<caf::io::middleman>();
+    set("middleman.enable-automatic-connections", true);
+#ifdef VAST_USE_OPENSSL
+    load<openssl::manager>();
+#endif
+  }
+};
+
+} // namespace <anonymous>
+
 int main(int argc, char** argv) {
   // Scaffold
-  configuration cfg{true, true};
+  config cfg;
   cfg.parse(argc, argv);
   cfg.set("logger.console", caf::atom("COLORED"));
   caf::actor_system sys{cfg};

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -29,7 +29,7 @@ struct config : configuration {
     load<caf::io::middleman>();
     set("middleman.enable-automatic-connections", true);
 #ifdef VAST_USE_OPENSSL
-    load<openssl::manager>();
+    load<caf::openssl::manager>();
 #endif
   }
 };


### PR DESCRIPTION
Remove boolean flags for the constructor of `configuration` that were introduced as hotfix.