### PR TITLE
Allow disabling of exceptions and hook code coverage into CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,11 @@ if (ENABLE_ADDRESS_SANITIZER)
   endif()
 endif ()
 
+# set -fno-exception if requested
+if (NO_EXCEPTIONS)
+  set(EXTRA_FLAGS "${EXTRA_FLAGS} -fno-exceptions")
+endif()
+
 if (ENABLE_GCOV)
   # Locate gcov and gcovr.
   find_package(GCOV)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,7 +172,7 @@ pipeline {
         DYLD_LIBRARY_PATH = "$WORKSPACE/vast-sources/build/lib;" +
                             "$WORKSPACE/caf-install/lib"
         PrettyJobBaseName = env.JOB_BASE_NAME.replace('%2F', '/')
-        PrettyJobName = "CAF build #${env.BUILD_NUMBER} for $PrettyJobBaseName"
+        PrettyJobName = "VAST build #${env.BUILD_NUMBER} for $PrettyJobBaseName"
     }
     stages {
         // Checkout all involved repositories.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,50 +2,19 @@
 
 // Default CMake flags for most builds (except coverage).
 defaultBuildFlags = [
-  caf: [
-    'CAF_NO_TOOLS:BOOL=yes',
-    'CAF_NO_EXAMPLES:BOOL=yes',
-    'CAF_NO_PYTHON:BOOL=yes',
-    'CAF_NO_OPENCL:BOOL=yes',
-  ],
-  vast: [
-  ],
 ]
 
 // CMake flags for release builds.
-releaseBuildFlags = [
-    caf: defaultBuildFlags['caf'] + [
-        'CAF_ENABLE_RUNTIME_CHECKS:BOOL=yes',
-    ],
-    vast: defaultBuildFlags['vast'] + [
-    ],
+releaseBuildFlags = defaultBuildFlags + [
 ]
 
 // CMake flags for debug builds.
-debugBuildFlags = [
-    caf: defaultBuildFlags['caf'] + [
-        'CAF_ENABLE_RUNTIME_CHECKS:BOOL=yes',
-        'CAF_ENABLE_ADDRESS_SANITIZER:BOOL=yes',
-        'CAF_LOG_LEVEL:STRING=4',
-    ],
-    vast: defaultBuildFlags['vast'] + [
-        'ENABLE_ADDRESS_SANITIZER:BOOL=yes',
-    ],
+debugBuildFlags =  defaultBuildFlags + [
+    'ENABLE_ADDRESS_SANITIZER:BOOL=yes',
 ]
 
 // Our build matrix. Keys are the operating system labels and values are build configurations.
 buildMatrix = [
-    // Release builds for various OS/tool combinations.
-    [ 'Linux', [
-        builds: ['release'],
-        tools: ['gcc8'],
-        cmakeArgs: releaseBuildFlags,
-    ]],
-    [ 'macOS', [
-        builds: ['release'],
-        tools: ['clang'],
-        cmakeArgs: releaseBuildFlags,
-    ]],
     // Debug builds with ASAN + trace logs.
     [ 'Linux', [
         builds: ['debug'],
@@ -57,28 +26,27 @@ buildMatrix = [
         tools: ['clang'],
         cmakeArgs: debugBuildFlags,
     ]],
+    // Release builds for various OS/tool combinations.
+    [ 'Linux', [
+        builds: ['release'],
+        tools: ['gcc8'],
+        cmakeArgs: releaseBuildFlags,
+    ]],
+    [ 'macOS', [
+        builds: ['release'],
+        tools: ['clang'],
+        cmakeArgs: releaseBuildFlags,
+    ]],
     // One Additional build for coverage reports.
-    ['unix', [
+    ['Linux', [
         builds: ['debug'],
         tools: ['gcc8 && gcovr'],
         extraSteps: ['coverageReport'],
-        cmakeArgs: [
-            caf: defaultBuildFlags['caf'] + [
-                'CAF_ENABLE_GCOV:BOOL=yes',
-                'CAF_NO_EXCEPTIONS:BOOL=yes',
-                'CAF_FORCE_NO_EXCEPTIONS:BOOL=yes',
-            ],
-            vast: defaultBuildFlags['vast'] + [
-                'ENABLE_GCOV:BOOL=yes',
-                'NO_EXCEPTIONS:BOOL=yes',
-            ],
+        cmakeArgs: defaultBuildFlags + [
+            'ENABLE_GCOV:BOOL=yes',
+            'NO_EXCEPTIONS:BOOL=yes',
         ],
     ]],
-]
-
-// Repositories of dependencies.
-repositories = [
-    caf: 'https://github.com/actor-framework/actor-framework.git',
 ]
 
 // Optional environment variables for combinations of labels.
@@ -87,9 +55,9 @@ buildEnvironments = [
 ]
 
 // Creates coverage reports via the Cobertura plugin.
-def coverageReport(buildType) {
-    dir("vast-$buildType") {
-        sh 'gcovr -e vast -e tools -e libvast/tests -x -r .. > coverage.xml'
+def coverageReport() {
+    dir("vast-sources") {
+        sh 'gcovr -e vast -e tools -e ".*/test/.*" -x -r . > coverage.xml'
         archiveArtifacts '**/coverage.xml'
         cobertura([
           autoUpdateHealth: false,
@@ -108,82 +76,66 @@ def coverageReport(buildType) {
     }
 }
 
-// Clones the repository `name` and stashes the sources in `$name-sources`.
-def gitSteps(name, branch = 'master') {
-    def sourceDir = "$name-sources"
-    deleteDir()
-    // Checkout in subdirectory.
-    dir("$sourceDir") {
-        git([
-            url: repositories[name],
-            branch: branch,
+// Compiles, installs and tests via CMake.
+def cmakeSteps(buildType, cmakeArgs, buildId) {
+    def cafInstallDir = "$WORKSPACE/caf-install"
+    def cafLibraryDir = "$WORKSPACE/caf-install/lib"
+    def vastInstallDir = "$WORKSPACE/$buildId"
+    dir('vast-sources') {
+        // Configure and build.
+        cmakeBuild([
+            buildDir: 'build',
+            buildType: buildType,
+            cmakeArgs: (cmakeArgs + [
+              "CAF_ROOT_DIR=\"$cafInstallDir\"",
+              "CMAKE_INSTALL_PREFIX=\"$vastInstallDir\"",
+            ]).collect { x -> '-D' + x }.join(' '),
+            installation: 'cmake in search path',
+            sourceDir: '.',
+            steps: [[
+                args: '--target install',
+                withCmake: true,
+            ]],
+        ])
+        // Run unit tests.
+        ctest([
+            arguments: '--output-on-failure',
+            installation: 'cmake in search path',
+            workingDir: 'build',
         ])
     }
-    // Make sources available for later stages.
-    stash includes: "$sourceDir/**", name: "$sourceDir"
-}
-
-// Builds `name` with CMake and runs the unit tests.
-def buildSteps(name, buildType, cmakeArgs) {
-    def sourceDir = "$name-sources"
-    def installDir = "$WORKSPACE/$name-$buildType-install"
-    // Make sure no old junk is laying around.
-    dir("$installDir") {
-        deleteDir()
-    }
-    echo "cmakeArgs: $cmakeArgs"
-    // Separate builds by build type on the file system.
-    dir("$name-$buildType") {
-        // Make sure no old junk is laying around.
-        deleteDir()
-        // Get sources from previous stage.
-        unstash "$sourceDir"
-        // Build in subdirectory and run unit tests.
-        dir("$sourceDir") {
-            cmakeBuild([
-                buildDir: 'build',
-                buildType: "$buildType",
-                cleanBuild: true,
-                sourceDir: '.',
-                installation: 'cmake in search path',
-                cmakeArgs: "-DCMAKE_INSTALL_PREFIX=\"$installDir\" $cmakeArgs " +
-                           "-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl " +
-                           "-DOPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include",
-                steps: [[args: 'all install']],
-            ])
-            // We could think of moving testing to a different stage. However,
-            // this is currently not feasible because 1) the vast-test binary
-            // isn't available from the installation directory, and 2) the unit
-            // tests currently have hard-wired paths to the test data.
-            withEnv([
-                "LD_LIBRARY_PATH=$WORKSPACE/caf-$buildType-install/lib;"
-                + "$WORKSPACE/vast-$buildType-install/lib",
-                "DYLD_LIBRARY_PATH=$WORKSPACE/caf-$buildType-install/lib;"
-                + "$WORKSPACE/vast-$buildType-install/lib"
-            ]) {
-                ctest([
-                    arguments: '--output-on-failure',
-                    installation: 'cmake in search path',
-                    workingDir: 'build',
-                ])
-            }
-        }
+    // Only generate artifacts for the master branch.
+    if (PrettyJobBaseName == 'master') {
+        zip([
+            archive: true,
+            dir: buildId,
+            zipFile: "${buildId}.zip",
+        ])
     }
 }
 
-// Concatenates CMake flags into a single string.
-def makeFlags(xs) {
-    xs.collect { x -> '-D' + x }.join(' ')
-}
-
-// Builds all targets.
-def buildAll(buildType, settings) {
-    def cmakeArgs = settings['cmakeArgs']
-    buildSteps('caf', buildType, makeFlags(cmakeArgs['caf']))
-    buildSteps('vast', buildType, makeFlags(cmakeArgs['vast'] + [
-        "CAF_ROOT_DIR=\"$WORKSPACE/caf-$buildType-install\"",
-    ]))
-    (settings['extraSteps'] ?: []).each { fun -> "$fun"(buildType) }
+// Runs all build steps.
+def buildSteps(buildType, cmakeArgs, buildId) {
+    echo "prepare build steps on stage $STAGE_NAME"
+    deleteDir()
+    dir(buildId) {
+      // Create directory.
+    }
+    echo "get latest CAF master build for $buildId"
+    dir('caf-import') {
+        copyArtifacts([
+            filter: "${buildId}.zip",
+            projectName: 'CAF/actor-framework/master/',
+        ])
+    }
+    unzip([
+        zipFile: "caf-import/${buildId}.zip",
+        dir: 'caf-install',
+        quiet: true,
+    ])
+    echo 'get sources from previous stage and run CMake'
+    unstash 'vast-sources'
+    cmakeSteps(buildType, cmakeArgs, buildId)
 }
 
 // Builds a stage for given builds. Results in a parallel stage if `builds.size() > 1`.
@@ -194,9 +146,16 @@ def makeBuildStages(matrixIndex, builds, lblExpr, settings) {
             (id):
             {
                 node(lblExpr) {
-                    echo "Trigger build on $NODE_NAME"
-                    withEnv(buildEnvironments[lblExpr] ?: []) {
-                        buildAll(buildType, settings)
+                    stage(id) {
+                        try {
+                            def buildId = "$lblExpr && $buildType"
+                            withEnv(buildEnvironments[lblExpr] ?: []) {
+                              buildSteps(buildType, settings['cmakeArgs'], buildId)
+                              (settings['extraSteps'] ?: []).each { fun -> "$fun"() }
+                            }
+                        } finally {
+                          cleanWs()
+                        }
                     }
                 }
             }
@@ -204,33 +163,29 @@ def makeBuildStages(matrixIndex, builds, lblExpr, settings) {
     }
 }
 
+// Declarative pipeline for triggering all stages.
 pipeline {
     agent none
+    environment {
+        LD_LIBRARY_PATH = "$WORKSPACE/vast-sources/build/lib;" +
+                          "$WORKSPACE/caf-install/lib"
+        DYLD_LIBRARY_PATH = "$WORKSPACE/vast-sources/build/lib;" +
+                            "$WORKSPACE/caf-install/lib"
+        PrettyJobBaseName = env.JOB_BASE_NAME.replace('%2F', '/')
+        PrettyJobName = "CAF build #${env.BUILD_NUMBER} for $PrettyJobBaseName"
+    }
     stages {
         // Checkout all involved repositories.
-        stage('Checkouts') {
-            parallel {
-                // Checkout the main repository via default SCM.
-                stage('VAST') {
-                    agent { label 'master' }
-                    steps {
-                        deleteDir()
-                        dir('vast-sources') {
-                          checkout scm
-                        }
-                        stash includes: 'vast-sources/**', name: 'vast-sources'
-                    }
+        stage('Git Checkout') {
+            agent { label 'master' }
+            steps {
+                deleteDir()
+                dir('vast-sources') {
+                  checkout scm
                 }
-                // Checkout dependencies via Git.
-                stage('CAF') {
-                    agent { label 'master' }
-                    steps {
-                        gitSteps('caf')
-                    }
-                }
+                stash includes: 'vast-sources/**', name: 'vast-sources'
             }
         }
-        // Start builds.
         stage('Builds') {
             agent { label 'master' }
             steps {
@@ -255,14 +210,14 @@ pipeline {
     post {
         success {
             emailext(
-                subject: "✅ VAST build #${env.BUILD_NUMBER} succeeded for job ${env.JOB_NAME}",
+                subject: "✅ $PrettyJobName succeeded",
                 recipientProviders: [culprits(), developers(), requestor(), upstreamDevelopers()],
                 body: "Check console output at ${env.BUILD_URL}.",
             )
         }
         failure {
             emailext(
-                subject: "⛔️ VAST build #${env.BUILD_NUMBER} failed for job ${env.JOB_NAME}",
+                subject: "⛔️ $PrettyJobName failed",
                 attachLog: true,
                 compressLog: true,
                 recipientProviders: [culprits(), developers(), requestor(), upstreamDevelopers()],

--- a/configure
+++ b/configure
@@ -33,6 +33,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
   Debugging:
     --log-level=LEVEL       maximum compile-time log level [debug]
     --disable-assertions    disable assertions
+    --disable-exceptions    disable C++ exceptions
     --enable-asan           enable AddressSanitizer
     --enable-gcov           enable GCOV
 
@@ -144,6 +145,9 @@ while [ $# -ne 0 ]; do
       ;;
     --disable-assertions)
       append_cache_entry VAST_ENABLE_ASSERTIONS BOOL false
+      ;;
+    --disable-exceptions)
+      append_cache_entry NO_EXCEPTIONS BOOL true
       ;;
     --enable-asan)
       append_cache_entry ENABLE_ADDRESS_SANITIZER BOOL true

--- a/libvast/src/batch.cpp
+++ b/libvast/src/batch.cpp
@@ -170,7 +170,9 @@ expected<event> batch::reader::materialize() {
   if (available_ == 0)
     return make_error(ec::end_of_input);
   --available_;
+#ifndef VAST_NO_EXCEPTIONS
   try {
+#endif // VAST_NO_EXCEPTIONS
     // Read type.
     uint32_t type_id;
     deserializer_ >> type_id;
@@ -192,9 +194,11 @@ expected<event> batch::reader::materialize() {
     }
     e.timestamp(ts);
     return e;
+#ifndef VAST_NO_EXCEPTIONS
   } catch (const std::runtime_error& e) {
     return make_error(ec::unspecified, e.what());
   }
+#endif // VAST_NO_EXCEPTIONS
 }
 
 } // namespace vast

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -197,7 +197,7 @@ bool poll(int fd, int usec) {
   if (rc < 0) {
     switch (rc) {
       default:
-        VAST_RAISE_ERROR("unhandled select() error");
+        VAST_RAISE_ERROR(std::logic_error, "unhandled select() error");
       case EINTR:
       case ENOMEM:
         return false;

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -25,6 +25,7 @@
 #include "vast/config.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/detail/posix.hpp"
+#include "vast/detail/raise_error.hpp"
 
 namespace vast {
 namespace detail {
@@ -196,7 +197,7 @@ bool poll(int fd, int usec) {
   if (rc < 0) {
     switch (rc) {
       default:
-        throw std::logic_error("unhandled select() error");
+        VAST_RAISE_ERROR("unhandled select() error");
       case EINTR:
       case ENOMEM:
         return false;

--- a/libvast/src/value_index.cpp
+++ b/libvast/src/value_index.cpp
@@ -590,7 +590,7 @@ void serialize(caf::deserializer& source, sequence_index& idx) {
     [&] { return source.end_sequence(); }
   );
   if (e)
-    throw std::runtime_error{to_string(e)};
+    VAST_RAISE_ERROR("cannot serialize sequence index");
 }
 
 } // namespace vast

--- a/libvast/test/vector_map.cpp
+++ b/libvast/test/vector_map.cpp
@@ -12,6 +12,7 @@
  ******************************************************************************/
 
 #include <string>
+#include <string_view>
 
 #include "vast/detail/steady_map.hpp"
 
@@ -20,7 +21,7 @@
 
 #include "vast/config.hpp"
 
-using namespace std::string_literals;
+using namespace std::string_view_literals;
 using namespace vast;
 
 namespace {
@@ -56,7 +57,7 @@ TEST(steady_map at) {
   } catch (std::out_of_range& e) {
     exception = std::move(e);
   }
-  CHECK_EQUAL(exception.what(), "vast::detail::vector_map::at"s);
+  CHECK_EQUAL(exception.what(), "vast::detail::vector_map::at out of range"sv);
 }
 #endif // VAST_NO_EXCEPTIONS
 

--- a/libvast/test/vector_map.cpp
+++ b/libvast/test/vector_map.cpp
@@ -18,6 +18,8 @@
 #define SUITE detail
 #include "test.hpp"
 
+#include "vast/config.hpp"
+
 using namespace std::string_literals;
 using namespace vast;
 
@@ -45,6 +47,7 @@ TEST(steady_map membership) {
   CHECK_EQUAL(xs.count("baz"), 1u);
 }
 
+#ifndef VAST_NO_EXCEPTIONS
 TEST(steady_map at) {
   CHECK_EQUAL(xs.at("foo"), 42);
   auto exception = std::out_of_range{""};
@@ -55,6 +58,7 @@ TEST(steady_map at) {
   }
   CHECK_EQUAL(exception.what(), "vast::detail::vector_map::at"s);
 }
+#endif // VAST_NO_EXCEPTIONS
 
 TEST(steady_map insert) {
   auto i = xs.insert({"qux", 1});

--- a/libvast/vast/bitvector.hpp
+++ b/libvast/vast/bitvector.hpp
@@ -21,8 +21,9 @@
 
 #include "vast/bits.hpp"
 #include "vast/detail/assert.hpp"
-#include "vast/detail/operators.hpp"
 #include "vast/detail/iterator.hpp"
+#include "vast/detail/operators.hpp"
+#include "vast/detail/raise_error.hpp"
 #include "vast/detail/range.hpp"
 #include "vast/word.hpp"
 
@@ -540,7 +541,7 @@ template <class Block, class Allocator>
 typename bitvector<Block, Allocator>::reference
 bitvector<Block, Allocator>::at(size_type i) {
   if (i >= size_)
-    throw std::out_of_range("bitvector");
+    VAST_RAISE_ERROR("bitvector out of range");
   return (*this)[i];
 }
 
@@ -548,7 +549,7 @@ template <class Block, class Allocator>
 typename bitvector<Block, Allocator>::const_reference
 bitvector<Block, Allocator>::at(size_type i) const {
   if (i >= size_)
-    throw std::out_of_range("bitvector");
+    VAST_RAISE_ERROR("bitvector out of range");
   return (*this)[i];
 }
 

--- a/libvast/vast/bitvector.hpp
+++ b/libvast/vast/bitvector.hpp
@@ -541,7 +541,7 @@ template <class Block, class Allocator>
 typename bitvector<Block, Allocator>::reference
 bitvector<Block, Allocator>::at(size_type i) {
   if (i >= size_)
-    VAST_RAISE_ERROR("bitvector out of range");
+    VAST_RAISE_ERROR(std::out_of_range, "bitvector out of range");
   return (*this)[i];
 }
 
@@ -549,7 +549,7 @@ template <class Block, class Allocator>
 typename bitvector<Block, Allocator>::const_reference
 bitvector<Block, Allocator>::at(size_type i) const {
   if (i >= size_)
-    VAST_RAISE_ERROR("bitvector out of range");
+    VAST_RAISE_ERROR(std::out_of_range, "bitvector out of range");
   return (*this)[i];
 }
 

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -28,6 +28,7 @@
 #include "vast/data.hpp"
 #include "vast/error.hpp"
 
+#include "vast/detail/raise_error.hpp"
 #include "vast/detail/steady_map.hpp"
 #include "vast/detail/string.hpp"
 
@@ -97,7 +98,7 @@ public:
     auto result = ptr.get();
     if (!nested_.emplace(name, std::move(ptr)).second) {
       // FIXME: do not use exceptions.
-      throw std::invalid_argument("name already exists");
+      VAST_RAISE_ERROR("name already exists in command");
     }
     return result;
   }

--- a/libvast/vast/config.hpp.in
+++ b/libvast/vast/config.hpp.in
@@ -47,6 +47,10 @@
 #  define VAST_POSIX
 #endif
 
+#ifdef CAF_NO_EXCEPTIONS
+#define VAST_NO_EXCEPTIONS
+#endif
+
 // Convenience macros
 #define VAST_IGNORE_UNUSED(x) CAF_IGNORE_UNUSED(x)
 

--- a/libvast/vast/detail/narrow.hpp
+++ b/libvast/vast/detail/narrow.hpp
@@ -23,8 +23,10 @@
 
 #pragma once
 
-#include <exception>
 #include <type_traits>
+
+#include "vast/config.hpp"
+#include "vast/detail/raise_error.hpp"
 
 namespace vast::detail {
 
@@ -33,9 +35,6 @@ template <class T, class U>
 constexpr T narrow_cast(U&& u) noexcept {
   return static_cast<T>(std::forward<U>(u));
 }
-
-/// @relates narrow
-struct narrowing_error : public std::exception {};
 
 template <class T, class U>
 struct is_same_signedness
@@ -47,9 +46,9 @@ template <class T, class U>
 T narrow(U y) {
   T x = narrow_cast<T>(y);
   if (static_cast<U>(x) != y)
-    throw narrowing_error{};
+    VAST_RAISE_ERROR("narrowing error");
   if (!is_same_signedness<T, U>::value && ((x < T{}) != (y < U{})))
-    throw narrowing_error{};
+    VAST_RAISE_ERROR("narrowing error");
   return x;
 }
 

--- a/libvast/vast/detail/narrow.hpp
+++ b/libvast/vast/detail/narrow.hpp
@@ -30,6 +30,14 @@
 
 namespace vast::detail {
 
+#ifndef VAST_NO_EXCEPTIONS
+/// @relates narrow
+struct narrowing_error : std::runtime_error {
+  using super = std::runtime_error;
+  using super::super;
+};
+#endif // VAST_NO_EXCEPTIONS
+
 /// A searchable way to do narrowing casts of values.
 template <class T, class U>
 constexpr T narrow_cast(U&& u) noexcept {
@@ -46,9 +54,9 @@ template <class T, class U>
 T narrow(U y) {
   T x = narrow_cast<T>(y);
   if (static_cast<U>(x) != y)
-    VAST_RAISE_ERROR("narrowing error");
+    VAST_RAISE_ERROR(narrowing_error, "narrowing error");
   if (!is_same_signedness<T, U>::value && ((x < T{}) != (y < U{})))
-    VAST_RAISE_ERROR("narrowing error");
+    VAST_RAISE_ERROR(narrowing_error, "narrowing error");
   return x;
 }
 

--- a/libvast/vast/detail/raise_error.hpp
+++ b/libvast/vast/detail/raise_error.hpp
@@ -1,0 +1,21 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "caf/raise_error.hpp"
+
+/// Throws an exception with string `msg` or terminates the application when
+/// compiling exceptions disabled.
+#define VAST_RAISE_ERROR(...) CAF_RAISE_ERROR(__VA_ARGS__)
+

--- a/libvast/vast/detail/vector_map.hpp
+++ b/libvast/vast/detail/vector_map.hpp
@@ -15,10 +15,10 @@
 
 #include <algorithm>
 #include <functional>
-#include <stdexcept>
 #include <vector>
 
 #include "vast/detail/operators.hpp"
+#include "vast/detail/raise_error.hpp"
 
 namespace vast::detail {
 
@@ -177,14 +177,14 @@ public:
   mapped_type& at(const key_type& key) {
     auto i = find(key);
     if (i == end())
-      throw std::out_of_range{"vast::detail::vector_map::at"};
+      VAST_RAISE_ERROR("vast::detail::vector_map::at out of range");
     return i->second;
   }
 
   const mapped_type& at(const key_type& key) const {
     auto i = find(key);
     if (i == end())
-      throw std::out_of_range{"vast::detail::vector_map::at"};
+      VAST_RAISE_ERROR("vast::detail::vector_map::at out of range");
     return i->second;
   }
 

--- a/libvast/vast/detail/vector_map.hpp
+++ b/libvast/vast/detail/vector_map.hpp
@@ -177,14 +177,16 @@ public:
   mapped_type& at(const key_type& key) {
     auto i = find(key);
     if (i == end())
-      VAST_RAISE_ERROR("vast::detail::vector_map::at out of range");
+      VAST_RAISE_ERROR(std::out_of_range,
+                       "vast::detail::vector_map::at out of range");
     return i->second;
   }
 
   const mapped_type& at(const key_type& key) const {
     auto i = find(key);
     if (i == end())
-      VAST_RAISE_ERROR("vast::detail::vector_map::at out of range");
+      VAST_RAISE_ERROR(std::out_of_range,
+                       "vast::detail::vector_map::at out of range");
     return i->second;
   }
 

--- a/libvast/vast/format/mrt.hpp
+++ b/libvast/vast/format/mrt.hpp
@@ -527,7 +527,7 @@ struct message_parser : parser<message_parser> {
     auto skip = parsers::eps ->* [&] {
       static auto header_length = 16 + 2 + 1;
       if (x.header.length < header_length || x.header.length > 4096)
-        throw std::runtime_error{"cannot parse RFC-violoating records"};
+        VAST_RAISE_ERROR("cannot parse RFC-violoating records");
       f += std::min(static_cast<size_t>(l - f),
                     static_cast<size_t>(x.header.length - header_length));
     };

--- a/libvast/vast/load.hpp
+++ b/libvast/vast/load.hpp
@@ -38,7 +38,9 @@ expected<void> load(Source&& in, Ts&&... xs) {
   static_assert(sizeof...(Ts) > 0);
   using source_type = std::decay_t<Source>;
   if constexpr (detail::is_streambuf_v<source_type>) {
+#ifndef VAST_NO_EXCEPTIONS
     try {
+#endif // VAST_NO_EXCEPTIONS
       if (Method == compression::null) {
         caf::stream_deserializer<source_type&> s{in};
         detail::read(s, std::forward<Ts>(xs)...);
@@ -47,9 +49,11 @@ expected<void> load(Source&& in, Ts&&... xs) {
         caf::stream_deserializer<detail::compressedbuf&> s{compressed};
         detail::read(s, std::forward<Ts>(xs)...);
       }
+#ifndef VAST_NO_EXCEPTIONS
     } catch (const std::exception& e) {
       return make_error(ec::unspecified, e.what());
     }
+#endif // VAST_NO_EXCEPTIONS
     return {};
   } else if constexpr (std::is_base_of_v<std::istream, source_type>) {
     auto sb = in.rdbuf();

--- a/libvast/vast/save.hpp
+++ b/libvast/vast/save.hpp
@@ -37,7 +37,9 @@ expected<void> save(Sink&& out, Ts&&... xs) {
   static_assert(sizeof...(Ts) > 0);
   using sink_type = std::decay_t<Sink>;
   if constexpr (detail::is_streambuf_v<sink_type>) {
+#ifndef VAST_NO_EXCEPTIONS
     try {
+#endif // VAST_NO_EXCEPTIONS
       if (Method == compression::null) {
         caf::stream_serializer<sink_type&> s{out};
         detail::write(s, std::forward<Ts>(xs)...);
@@ -47,9 +49,11 @@ expected<void> save(Sink&& out, Ts&&... xs) {
         detail::write(s, std::forward<Ts>(xs)...);
         compressed.pubsync();
       }
+#ifndef VAST_NO_EXCEPTIONS
     } catch (std::exception& e) {
       return make_error(ec::unspecified, e.what());
     }
+#endif // VAST_NO_EXCEPTIONS
     return {};
   } else if constexpr (std::is_base_of_v<std::ostream, sink_type>) {
     auto sb = out.rdbuf();


### PR DESCRIPTION
Support VAST builds with exceptions disabled. The primary use case for such builds is coverage reporting. Otherwise, each function call to a potentially throwing function will reduce in a branch and thus make the branch coverage report pretty much useless.

Additionally, add coverage reporting to `Jenkinsfile` and close [ch857].