### PR TITLE
Fix performance issue in handle_batch of the EXPORTER

### DIFF
--- a/libvast/src/ewah_bitmap.cpp
+++ b/libvast/src/ewah_bitmap.cpp
@@ -106,8 +106,8 @@ void ewah_bitmap::append_bits(bool bit, size_type n) {
       marker = word_type::marker_num_dirty(marker, 0);
     auto markers = clean_blocks / word_type::marker_clean_max;
     auto last = clean_blocks % word_type::marker_clean_max;
-    while (markers --> 0)
-      blocks_.push_back(word_type::marker_type(word_type::marker_clean_mask, bit));
+    blocks_.resize(blocks_.size() + markers,
+                   word_type::marker_type(word_type::marker_clean_mask, bit));
     if (last > 0)
       blocks_.push_back(
         word_type::marker_type(word_type::marker_num_clean(0, last), bit));

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -166,15 +166,16 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
         checker = std::move(*x);
         VAST_DEBUG(self, "tailored AST to", candidate.type() << ':', checker);
       }
+      // Append ID to our bitmap mask.
+      if (sender == self->state.archive) {
+        mask.append_bits(false, candidate.id() - mask.size());
+        mask.append_bit(true);
+      }
       // Perform candidate check and keep event as result on success.
       if (caf::visit(event_evaluator{candidate}, checker))
         self->state.results.push_back(std::move(candidate));
       else
         VAST_DEBUG(self, "ignores false positive:", candidate);
-      if (sender == self->state.archive) {
-        mask.append_bits(false, candidate.id() - mask.size());
-        mask.append_bit(true);
-      }
     }
     self->state.stats.processed += candidates.size();
     if (sender == self->state.archive)

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -145,6 +145,10 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
   );
   auto handle_batch = [=](std::vector<event>& candidates) {
     VAST_DEBUG(self, "got batch of", candidates.size(), "events");
+    // Events can arrive in any order: sort them by ID first. Otherwise, we
+    // can't compute the bitmap mask as easily.
+    std::sort(candidates.begin(), candidates.end(),
+              [](auto& x, auto& y) { return x.id() < y.id(); });
     bitmap mask;
     auto sender = self->current_sender();
     for (auto& candidate : candidates) {


### PR DESCRIPTION
Events can arrive in any order from the archive (pre table-slices it seems this wasn't the case). However, the loop in the exporter's `handle_batch` function builds a bitmap mask with the presumption that IDs are ascending. To leave the bitmap mask computation as-is (simple and append-only), we thus need to sort the candidates before entering the loop.