### PR TITLE
Fix deprecation warnings

### DIFF
--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -39,7 +39,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   template <class T>
   void push_to_archive(std::vector<T> xs) {
     vast::detail::spawn_container_source(sys, std::move(xs), a);
-    run_exhaustively();
+    run();
   }
 
   std::vector<event> query(std::initializer_list<id_range> ranges) {
@@ -54,7 +54,7 @@ FIXTURE_SCOPE(archive_tests, fixture)
 
 TEST(bro conn log vector) {
   self->send(a, bro_conn_log);
-  run_exhaustively();
+  run();
   auto result = query({{100, 150}});
   CHECK_EQUAL(result.size(), 50u);
 }

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -50,7 +50,7 @@ struct fixture : fixture_base {
       self->send_exit(hdl, exit_reason::user_shutdown);
     self->send_exit(archive, exit_reason::user_shutdown);
     self->send_exit(meta_store, exit_reason::user_shutdown);
-    sched.run();
+    run();
   }
 
   void spawn_index() {
@@ -90,11 +90,11 @@ struct fixture : fixture_base {
     if (!meta_store)
       spawn_meta_store();
     send(consensus, system::run_atom::value);
-    sched.run();
+    run();
     send(importer, archive);
     send(importer, system::index_atom::value, index);
     send(importer, meta_store);
-    sched.run();
+    run();
   }
 
   void exporter_setup(query_options opts) {
@@ -104,7 +104,7 @@ struct fixture : fixture_base {
     send(exporter, system::sink_atom::value, self);
     send(exporter, system::run_atom::value);
     send(exporter, system::extract_atom::value);
-    run_exhaustively();
+    run();
   }
 
   template <class Hdl, class... Ts>
@@ -146,11 +146,11 @@ TEST(historical query without importer) {
   MESSAGE("spawn index and archive");
   spawn_index();
   spawn_archive();
-  sched.run();
+  run();
   MESSAGE("ingest conn.log into archive and index");
   vast::detail::spawn_container_source(sys, const_bro_conn_log_slices, index,
                                        archive);
-  run_exhaustively();
+  run();
   MESSAGE("spawn exporter for historical query");
   exporter_setup(historical);
   MESSAGE("fetch results");
@@ -170,7 +170,7 @@ TEST(historical query with importer) {
   // IDs to the slices it received and we mustn't mess our static test data.
   vast::detail::spawn_container_source(sys, copy(bro_conn_log_slices),
                                        importer);
-  run_exhaustively();
+  run();
   MESSAGE("spawn exporter for historical query");
   exporter_setup(historical);
   MESSAGE("fetch results");
@@ -187,11 +187,11 @@ TEST(continuous query with exporter only) {
   spawn_exporter(continuous);
   send(exporter, system::sink_atom::value, self);
   send(exporter, system::extract_atom::value);
-  sched.run();
+  run();
   MESSAGE("send conn.log directly to exporter");
   vast::detail::spawn_container_source(sys, const_bro_conn_log_slices,
                                        exporter);
-  run_exhaustively();
+  run();
   MESSAGE("fetch results");
   auto results = fetch_results();
   REQUIRE_EQUAL(results.size(), 28u);
@@ -211,7 +211,7 @@ TEST(continuous query with importer) {
   // Again: copy because we musn't mutate static test data.
   vast::detail::spawn_container_source(sys, copy(bro_conn_log_slices),
                                        importer);
-  run_exhaustively();
+  run();
   MESSAGE("fetch results");
   auto results = fetch_results();
   REQUIRE_EQUAL(results.size(), 28u);

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -136,11 +136,11 @@ using deterministic_fixture_base
 struct deterministic_fixture : deterministic_fixture_base {
   deterministic_fixture() : deterministic_fixture_base(100u) {
     MESSAGE(")run initialization code");
-    sched.run();
+    run();
   }
 
   void fetch_ok() override {
-    sched.run();
+    run();
     expect((atom_value), from(_).to(self).with(ok_atom::value));
   }
 
@@ -165,9 +165,9 @@ TEST(deterministic importer with one sink) {
   add_sink();
   MESSAGE("spawn dummy source");
   make_source();
-  sched.run_once();
+  consume_message();
   MESSAGE("loop until importer becomes idle");
-  sched.run_dispatch_loop(credit_round_interval);
+  run();
   MESSAGE("verify results");
   verify(fetch_result(), bro_conn_log);
 }
@@ -176,12 +176,12 @@ TEST(deterministic importer with two sinks) {
   MESSAGE("connect two sinks to importer");
   add_sink();
   add_sink();
-  sched.run();
+  run();
   MESSAGE("spawn dummy source");
   make_source();
-  sched.run_once();
+  consume_message();
   MESSAGE("loop until importer becomes idle");
-  sched.run_dispatch_loop(credit_round_interval);
+  run();
   MESSAGE("verify results");
   auto result = fetch_result();
   auto second_result = fetch_result();
@@ -194,10 +194,10 @@ TEST(deterministic importer with one sink and bro source) {
   add_sink();
   MESSAGE("spawn bro source");
   auto src = make_bro_source();
-  sched.run_once();
+  consume_message();
   self->send(src, system::sink_atom::value, importer);
   MESSAGE("loop until importer becomes idle");
-  sched.run_dispatch_loop(credit_round_interval);
+  run();
   MESSAGE("verify results");
   verify(fetch_result(), bro_conn_log);
 }
@@ -208,10 +208,10 @@ TEST(deterministic importer with two sinks and bro source) {
   add_sink();
   MESSAGE("spawn bro source");
   auto src = make_bro_source();
-  sched.run_once();
+  consume_message();
   self->send(src, system::sink_atom::value, importer);
   MESSAGE("loop until importer becomes idle");
-  sched.run_dispatch_loop(credit_round_interval);
+  run();
   MESSAGE("verify results");
   auto result = fetch_result();
   auto second_result = fetch_result();

--- a/libvast/test/system/indexer.cpp
+++ b/libvast/test/system/indexer.cpp
@@ -38,14 +38,14 @@ namespace {
 struct fixture : fixtures::deterministic_actor_system_and_events {
   void init(record_type layout) {
     indexer = self->spawn(system::indexer, directory, std::move(layout));
-    run_exhaustively();
+    run();
   }
 
   void init(std::vector<const_table_slice_handle> slices) {
     VAST_ASSERT(slices.size() > 0);
     init(slices[0]->layout());
     vast::detail::spawn_container_source(sys, std::move(slices), indexer);
-    run_exhaustively();
+    run();
   }
 
   ids query(std::string_view what) {
@@ -69,7 +69,7 @@ TEST(integer rows) {
     return make_ids({args...}, rows.size());
   };
   init({default_table_slice::make(layout, rows)});
-  sched.run();
+  run();
   MESSAGE("verify table index");
   auto verify = [&] {
     CHECK_EQUAL(query(":int == +1"), res(0, 3, 6));
@@ -83,7 +83,7 @@ TEST(integer rows) {
   verify();
   MESSAGE("kill INDEXER");
   anon_send_exit(indexer, exit_reason::kill);
-  run_exhaustively();
+  run();
   MESSAGE("reload INDEXER from disk");
   init(layout);
   MESSAGE("verify table index again");
@@ -113,7 +113,7 @@ TEST(bro conn logs) {
   verify();
   MESSAGE("kill INDEXER");
   anon_send_exit(indexer, exit_reason::kill);
-  run_exhaustively();
+  run();
   MESSAGE("reload INDEXER from disk");
   init(bro_conn_log_layout());
   MESSAGE("verify table index again");

--- a/libvast/test/system/indexer_stage_driver.cpp
+++ b/libvast/test/system/indexer_stage_driver.cpp
@@ -133,7 +133,7 @@ TEST(spawning sinks automatically) {
   MESSAGE("spawn the source and run");
   auto src = vast::detail::spawn_container_source(self->system(),
                                                   test_slices, stg);
-  run_exhaustively();
+  run();
   CHECK_EQUAL(dummies, num_layouts);
   MESSAGE("check content of the shared buffer");
   REQUIRE_EQUAL(bufs->size(), 1u);
@@ -156,7 +156,7 @@ TEST(creating bro conn log partitions automatically) {
   auto src = vast::detail::spawn_container_source(self->system(),
                                                   const_bro_conn_log_slices,
                                                   stg);
-  run_exhaustively();
+  run();
   CHECK_EQUAL(bufs->size(), const_bro_conn_log_slices.size());
   MESSAGE("flatten all partitions into one buffer");
   event_buffer xs;

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -118,7 +118,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   ids query(std::string_view what) {
     query_state qs;
     sys.spawn(query_actor, &qs, put, unbox(to<expression>(what)));
-    sched.run();
+    run();
     CHECK_EQUAL(qs.expected, qs.received);
     return std::move(qs.result);
   }
@@ -153,7 +153,7 @@ TEST(shutdown indexers in destructor) {
   CHECK_EQUAL(sorted_strings(put->layouts()), sorted_strings(layouts));
   MESSAGE("stop manager (and INDEXER actors)");
   put.reset();
-  sched.run();
+  run();
   REQUIRE_EQUAL(running_indexers(), 0u);
 }
 
@@ -170,14 +170,14 @@ TEST(restore from meta data) {
   CHECK_EQUAL(sorted_strings(put->layouts()), sorted_strings(layouts));
   MESSAGE("stop first manager");
   put.reset();
-  sched.run();
+  run();
   REQUIRE_EQUAL(running_indexers(), 0u);
   MESSAGE("start second manager and expect it to restore its persisted state");
   put = make_dummy_partition();
   REQUIRE_EQUAL(put->dirty(), false);
   REQUIRE_EQUAL(sorted_strings(put->layouts()), sorted_strings(layouts));
   put.reset();
-  sched.run();
+  run();
 }
 
 TEST(integer rows lookup) {
@@ -191,7 +191,7 @@ TEST(integer rows lookup) {
   std::vector<const_table_slice_handle> slices{slice};
   detail::spawn_container_source(sys, std::move(slices),
                                  put->manager().get_or_add(layout).first);
-  run_exhaustively();
+  run();
   MESSAGE("verify partition content");
   auto res = [&](auto... args) {
     return make_ids({args...}, rows.size());
@@ -212,7 +212,7 @@ TEST(single partition bro conn log lookup) {
   auto layout = bro_conn_log_layout();
   auto indexer = put->manager().get_or_add(layout).first;
   detail::spawn_container_source(sys, const_bro_conn_log_slices, indexer);
-  run_exhaustively();
+  run();
   MESSAGE("verify partition content");
   auto res = [&](auto... args) {
     return make_ids({args...}, bro_conn_log.size());
@@ -245,7 +245,7 @@ TEST_DISABLED(multiple partitions bro conn log lookup no messaging) {
     CHECK_EQUAL(exists(ptr->dir()), false);
     CHECK_EQUAL(ptr->dirty(), false);
     auto idx_hdl = ptr->manager().get_or_add(layout).first;
-    sched.run();
+    run();
     auto& idx = deref<indexer_type>(idx_hdl);
     idx.initialize();
     auto& tbl = idx.state.tbl;

--- a/libvast/test/system/source.cpp
+++ b/libvast/test/system/source.cpp
@@ -71,10 +71,10 @@ TEST(bro source) {
   auto src = self->spawn(source<bf::reader>, std::move(reader),
                          default_table_slice::make_builder,
                          100u);
-  sched.run();
+  run();
   MESSAGE("start sink and run exhaustively");
   auto snk = self->spawn(test_sink, src);
-  run_exhaustively();
+  run();
   MESSAGE("get slices");
   const auto& slices = deref<test_sink_type>(snk).state.slices;
   MESSAGE("collect all rows as values");
@@ -97,7 +97,7 @@ TEST(bro source) {
     CHECK_EQUAL(*slices[i], *bro_conn_log_slices[i]);
   MESSAGE("shutdown");
   self->send_exit(src, caf::exit_reason::user_shutdown);
-  sched.run();
+  run();
 }
 
 FIXTURE_SCOPE_END()


### PR DESCRIPTION
Recent CAF master improved and simplified its testing API. However, several functions got deprecated.