### PR TITLE
Add flag to make import command blocking

### DIFF
--- a/libvast/src/system/reader_command_base.cpp
+++ b/libvast/src/system/reader_command_base.cpp
@@ -116,11 +116,10 @@ int reader_command_base::run_impl(caf::actor_system& sys,
         stop = true;
       } else if (msg.source == src) {
         VAST_DEBUG("received DOWN from source");
-        if (caf::get_or(options, "blocking", false)) {
+        if (caf::get_or(options, "blocking", false))
           self->send(importer, subscribe_atom::value, flush_atom::value, self);
-        } else {
+        else
           stop = true;
-        }
       }
     },
     [&](flush_atom) {

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -123,15 +123,20 @@ struct importer_state {
   /// Pointer to the owning actor.
   caf::event_based_actor* self;
 
+  /// List of actors that wait for the next flush event.
+  std::vector<caf::actor> flush_listeners;
+
   /// Name of this actor in log events.
   static inline const char* name = "importer";
 };
+
+using importer_actor = caf::stateful_actor<importer_state>;
 
 /// Spawns an IMPORTER.
 /// @param self The actor handle.
 /// @param dir The directory for persistent state.
 /// @param batch_size The initial number of IDs to request when replenishing.
-caf::behavior importer(caf::stateful_actor<importer_state>* self, path dir,
+caf::behavior importer(importer_actor* self, path dir,
                        size_t max_table_slice_size);
 
 } // namespace vast::system

--- a/libvast/vast/system/reader_command_base.hpp
+++ b/libvast/vast/system/reader_command_base.hpp
@@ -41,7 +41,9 @@ namespace vast::system {
 /// Format-independent implementation for import sub-commands.
 class reader_command_base : public node_command {
 public:
-  using node_command::node_command;
+  using super = node_command;
+
+  reader_command_base(command* parent, std::string_view name);
 
 protected:
   int run_impl(caf::actor_system& sys, const caf::config_value_map& options,


### PR DESCRIPTION
This feature is meant for integration testing and won't work in a distributed setting or when having parallel, high-volume imports.