### PR TITLE
Add Broker source (WIP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,15 @@ if (CAF_LIBRARY_OPENSSL)
 endif ()
 set(CAF_FOUND ${CAF_FOUND_SAVE})
 
+if (NOT BROKER_ROOT_DIR AND VAST_PREFIX)
+  set(BROKER_ROOT_DIR ${VAST_PREFIX})
+endif ()
+find_package(BROKER QUIET)
+if (BROKER_FOUND)
+  set(VAST_HAVE_BROKER true)
+  include_directories(${BROKER_INCLUDE_DIR})
+endif ()
+
 if (NOT SNAPPY_ROOT_DIR AND VAST_PREFIX)
   set(SNAPPY_ROOT_DIR ${VAST_PREFIX})
 endif ()
@@ -467,6 +476,7 @@ else ()
   endif ()
 endif ()
 
+# Figure out whether we point to a build directory or a prefix.
 set(caf_dir ${CAF_LIBRARY_CORE})
 get_filename_component(caf_dir ${caf_dir} PATH)
 if (EXISTS "${caf_dir}/../libcaf_core")
@@ -475,7 +485,19 @@ else ()
   set(caf_dir ${CAF_INCLUDE_DIR_CORE})
 endif ()
 
+# Figure out whether we point to a build directory or a prefix.
+if (BROKER_FOUND)
+  set(broker_dir ${BROKER_LIBRARY})
+  get_filename_component(broker_dir ${broker_dir} PATH)
+  if (EXISTS "${broker_dir}/../broker")
+    get_filename_component(broker_dir ${broker_dir} PATH)
+  else ()
+    set(broker_dir ${BROKER_INCLUDE_DIR})
+  endif ()
+endif ()
+
 display(CAF_FOUND ${caf_dir} caf_summary)
+display(BROKER_FOUND "${broker_dir}" broker_summary)
 display(SNAPPY_FOUND "${SNAPPY_INCLUDE_DIR}" snappy_summary)
 display(PCAP_FOUND "${PCAP_INCLUDE_DIR}" pcap_summary)
 display(GPERFTOOLS_FOUND "${GPERFTOOLS_INCLUDE_DIR}" perftools_summary)
@@ -511,6 +533,7 @@ set(summary
     "\nLDFLAGS:          ${LDFLAGS}"
     "\n"
     "\nCAF:              ${caf_summary}"
+    "\nBroker:           ${broker_summary}"
     "\nSnappy            ${snappy_summary}"
     "\nPCAP:             ${pcap_summary}"
     "\nGperftools:       ${perftools_summary}"

--- a/cmake/FindBroker.cmake
+++ b/cmake/FindBroker.cmake
@@ -1,0 +1,40 @@
+# Tries to find Broker library and headers
+#
+# Usage of this module as follows:
+#
+#     find_package(Broker)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  BROKER_ROOT_DIR           Set this variable to the root installation of
+#                            Broker if the module has problems finding the
+#                            proper installation path.
+#
+# Variables defined by this module:
+#
+#  BROKER_FOUND              System has Broker library
+#  BROKER_LIBRARY            The broker library
+#  BROKER_INCLUDE_DIR        The broker headers
+
+find_library(BROKER_LIBRARY
+  NAMES broker
+  HINTS ${BROKER_ROOT_DIR}/lib
+        ${BROKER_ROOT_DIR})
+
+find_path(BROKER_INCLUDE_DIR
+  NAMES broker/broker.hh
+  HINTS ${BROKER_ROOT_DIR}/include
+        ${BROKER_ROOT_DIR}/..)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Broker
+  DEFAULT_MSG
+  BROKER_LIBRARY
+  BROKER_INCLUDE_DIR)
+
+mark_as_advanced(
+  BROKER_ROOT_DIR
+  BROKER_LIBRARY
+  BROKER_INCLUDE_DIR)

--- a/configure
+++ b/configure
@@ -45,6 +45,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --with-caf=PATH         path to CAF install root or build directory
 
   Optional packages in non-standard locations:
+    --with-broker=PATH      path to Broker install root
     --with-snappy=PATH      path to Snappy install root
     --with-pcap=PATH        path to libpcap install root
     --with-perftools=PATH   path to gperftools install root
@@ -168,6 +169,9 @@ while [ $# -ne 0 ]; do
       ;;
     --with-caf=*)
       append_cache_entry CAF_ROOT_DIR PATH "$optarg"
+      ;;
+    --with-broker=*)
+      append_cache_entry BROKER_ROOT_DIR PATH "$optarg"
       ;;
     --with-snappy=*)
       append_cache_entry SNAPPY_ROOT_DIR PATH "$optarg"

--- a/doc/vast.1.md
+++ b/doc/vast.1.md
@@ -226,6 +226,18 @@ Available *component* values with corresponding *parameters*:
 
 *source* *bro*
 
+*source* *broker*
+  `-e` *endpoint* [*127.0.0.1:9999*]
+    The Broker endpoint to connect to or to listen at.
+  `-l`
+    A flag that puts the Broker endpoint into listing mode. If present, then
+    the source attempts to listen at the provided endpoint. Otherwise it
+    attempts to connect to the provided endpoint.
+  `-t` *topic*
+    The *topic* represents a label that the internal Broker endpoint subscribes
+    to. The source assumes that data published to this topic should be
+    imported.
+
 *source* *bgpdump*
 
 *source* *mrt*

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -121,6 +121,10 @@ if (VAST_ENABLE_ASSERTIONS)
   set(libvast_libs ${libvast_libs} ${Backtrace_LIBRARIES})
 endif ()
 
+if (BROKER_FOUND)
+  set(libvast_libs ${libvast_libs} ${BROKER_LIBRARY})
+endif ()
+
 if (SNAPPY_FOUND)
   set(libvast_libs ${libvast_libs} ${SNAPPY_LIBRARIES})
 endif ()

--- a/libvast/vast/config.hpp.in
+++ b/libvast/vast/config.hpp.in
@@ -1,13 +1,13 @@
 #pragma once
 
 #cmakedefine VAST_ENABLE_ASSERTIONS
+#cmakedefine VAST_HAVE_BROKER
 #cmakedefine VAST_HAVE_GPERFTOOLS
 #cmakedefine VAST_HAVE_PCAP
-#cmakedefine VAST_HAVE_BROCCOLI
 #cmakedefine VAST_HAVE_SNAPPY
-#cmakedefine VAST_USE_TCMALLOC
 #cmakedefine VAST_USE_OPENCL
 #cmakedefine VAST_USE_OPENSSL
+#cmakedefine VAST_USE_TCMALLOC
 
 #include <caf/config.hpp>
 

--- a/libvast/vast/system/atoms.hpp
+++ b/libvast/vast/system/atoms.hpp
@@ -53,6 +53,7 @@ using key_atom = caf::atom_constant<caf::atom("key")>;
 using limit_atom = caf::atom_constant<caf::atom("limit")>;
 using link_atom = caf::atom_constant<caf::atom("link")>;
 using list_atom = caf::atom_constant<caf::atom("list")>;
+using listen_atom = caf::atom_constant<caf::atom("listen")>;
 using load_atom = caf::atom_constant<caf::atom("load")>;
 using peer_atom = caf::atom_constant<caf::atom("peer")>;
 using persist_atom = caf::atom_constant<caf::atom("persist")>;

--- a/libvast/vast/system/broker_source.hpp
+++ b/libvast/vast/system/broker_source.hpp
@@ -1,0 +1,46 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/logger.hpp"
+
+#include <caf/actor_system_config.hpp>
+#include <caf/stateful_actor.hpp>
+
+#include "vast/default_table_slice.hpp"
+#include "vast/defaults.hpp"
+
+namespace vast::system {
+
+struct broker_source_state {
+  // TODO: factor this type from vast::source_state<Reader>.
+  using factory_type = table_slice_builder_ptr (*)(record_type);
+};
+
+/// A Broker event producer.
+/// @param self The actor handle.
+caf::behavior broker_source(caf::stateful_actor<broker_source_state>* self,
+                            broker_source_state::factory_type factory,
+                            size_t tble_slice_size) {
+  return {};
+}
+
+/// An event producer with default table slice settings.
+caf::behavior default_broker_source(caf::stateful_actor<broker_source_state>* self) {
+  auto slice_size = get_or(self->system().config(), "system.table-slice-size",
+                           defaults::system::table_slice_size);
+  return broker_source(self, default_table_slice::make_builder, slice_size);
+}
+
+} // namespace vast::system


### PR DESCRIPTION
This PR adds initial Broker support to VAST in the form of a source that subscribes to a topic to which a Broker endpoint publishes data. The Broker source then transforms the incoming data into table slices.