### PR TITLE
Fix the importer test

### DIFF
--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -94,9 +94,9 @@ struct importer_fixture : Base {
   virtual void fetch_ok() = 0;
 
   auto make_source() {
+    auto slices = this->copy(this->bro_conn_log_slices);
     return vast::detail::spawn_container_source(this->self->system(),
-                                                this->bro_conn_log_slices,
-                                                importer);
+                                                std::move(slices), importer);
   }
 
   auto make_bro_source() {


### PR DESCRIPTION
This only fixes the symptom, the underlying problem is that it is easy to misuse the `events` fixture. But we already have [[3446]](https://app.clubhouse.io/tenzir/story/3446/finish-migration-of-the-unit-tests-to-the-table-slice-api) for that.