### PR TITLE
Enhance usage of user-defined literals

### DIFF
--- a/libvast/src/defaults.cpp
+++ b/libvast/src/defaults.cpp
@@ -15,8 +15,12 @@
 
 #include <limits>
 
+#include "vast/si_literals.hpp"
+
 #include "vast/detail/string.hpp"
 #include "vast/detail/system.hpp"
+
+using namespace vast::si_literals;
 
 namespace vast::defaults {
 
@@ -33,7 +37,7 @@ size_t flow_expiry = 10;
 size_t flush_interval = 10000;
 size_t max_events = 0;
 size_t max_flow_age = 60;
-size_t max_flows = 1u << 20;
+size_t max_flows = 1_Mi;
 std::string node_id = std::string{detail::split(detail::hostname(), ".")[0]};
 
 } // namespace command

--- a/libvast/src/detail/compressedbuf.cpp
+++ b/libvast/src/detail/compressedbuf.cpp
@@ -13,13 +13,20 @@
 
 #include <cstring>
 
+#include "vast/si_literals.hpp"
+
 #include "vast/detail/assert.hpp"
 #include "vast/detail/byte_swap.hpp"
 #include "vast/detail/compressedbuf.hpp"
 #include "vast/detail/varbyte.hpp"
 
 namespace vast {
+
+using namespace binary_byte_literals;
+
 namespace detail {
+
+size_t compressedbuf::default_block_size = 16_MiB;
 
 compressedbuf::compressedbuf(std::streambuf& sb, compression method,
                             size_t block_size)

--- a/libvast/src/format/mrt.cpp
+++ b/libvast/src/format/mrt.cpp
@@ -1,5 +1,7 @@
 #include "vast/format/mrt.hpp"
 
+#include "vast/si_literals.hpp"
+
 #include "vast/detail/assert.hpp"
 #include "vast/detail/byte_swap.hpp"
 
@@ -378,7 +380,8 @@ expected<event> reader::read() {
   auto ptr = reinterpret_cast<const uint32_t*>(buffer_.data() + 8);
   auto message_length = vast::detail::to_host_order(*ptr);
   // TODO: Where does the RFC specify the maximum length?
-  static constexpr size_t max_message_length = 1 << 20;
+  using namespace binary_byte_literals;
+  static constexpr size_t max_message_length = 1_MiB;
   if (message_length > max_message_length)
     return make_error(ec::format_error, "MRT message exceeds maximum length",
                       message_length, max_message_length);

--- a/libvast/src/system/spawn.cpp
+++ b/libvast/src/system/spawn.cpp
@@ -43,6 +43,7 @@ namespace vast {
 namespace system {
 
 expected<actor> spawn_archive(local_actor* self, options& opts) {
+  using namespace vast::binary_byte_literals;
   auto mss = size_t{128};
   auto segments = size_t{10};
   auto r = opts.params.extract_opts({
@@ -52,7 +53,7 @@ expected<actor> spawn_archive(local_actor* self, options& opts) {
   opts.params = r.remainder;
   if (!r.error.empty())
     return make_error(ec::syntax_error, r.error);
-  mss <<= 20; // MB'ify.
+  mss *= 1_MiB;
   auto a = self->spawn(archive, opts.dir / opts.label, segments, mss);
   return actor_cast<actor>(a);
 }
@@ -131,7 +132,8 @@ expected<actor> spawn_importer(stateful_actor<node_state>* self,
 }
 
 expected<actor> spawn_index(local_actor* self, options& opts) {
-  size_t max_events = 1 << 20;
+  using namespace vast::si_literals;
+  size_t max_events = 1_Mi;
   size_t max_parts = 10;
   size_t taste_parts = 5;
   size_t num_collectors = 10;

--- a/libvast/src/system/spawn_source.cpp
+++ b/libvast/src/system/spawn_source.cpp
@@ -23,6 +23,7 @@
 #include "vast/error.hpp"
 #include "vast/expression.hpp"
 #include "vast/query_options.hpp"
+#include "vast/si_literals.hpp"
 
 #include "vast/format/bgpdump.hpp"
 #include "vast/format/mrt.hpp"
@@ -43,6 +44,8 @@ using namespace caf;
 
 namespace vast {
 namespace system {
+
+using namespace si_literals;
 
 expected<actor> spawn_source(local_actor* self, options& opts) {
   if (opts.params.empty())
@@ -67,7 +70,7 @@ expected<actor> spawn_source(local_actor* self, options& opts) {
 #ifndef VAST_HAVE_PCAP
     return make_error(ec::unspecified, "not compiled with pcap support");
 #else
-    auto flow_max = uint64_t{1} << 20;
+    auto flow_max = 1_Mi;
     auto flow_age = 60u;
     auto flow_expiry = 10u;
     auto cutoff = std::numeric_limits<size_t>::max();

--- a/libvast/test/compressedbuf.cpp
+++ b/libvast/test/compressedbuf.cpp
@@ -11,15 +11,18 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include "vast/detail/compressedbuf.hpp"
+#include "vast/si_literals.hpp"
 #include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/vast/compression.hpp"
+
+#include "vast/detail/compressedbuf.hpp"
 
 #define SUITE streambuf
 #include "test.hpp"
 
 using namespace std::string_literals;
 using namespace vast;
+using namespace vast::binary_byte_literals;
 using namespace vast::detail;
 
 TEST(compressedbuf - two blocks) {
@@ -60,7 +63,7 @@ TEST(compressedbuf - iostream interface) {
 #ifdef VAST_HAVE_SNAPPY
   methods.push_back(compression::snappy);
 #endif
-  std::vector<size_t> block_sizes = {1, 2, 64, 256, 1024, 16 << 10};
+  std::vector<size_t> block_sizes = {1, 2, 64, 256, 1_KiB, 16_MiB};
   auto data = "Im Kampf zwischen dir und der Welt sekundiere der Welt."s;
   auto inflation = 1000;
   for (auto block_size : block_sizes) {

--- a/libvast/test/compressedbuf.cpp
+++ b/libvast/test/compressedbuf.cpp
@@ -63,7 +63,7 @@ TEST(compressedbuf - iostream interface) {
 #ifdef VAST_HAVE_SNAPPY
   methods.push_back(compression::snappy);
 #endif
-  std::vector<size_t> block_sizes = {1, 2, 64, 256, 1_KiB, 16_MiB};
+  std::vector<size_t> block_sizes = {1, 2, 64, 256, 1_KiB, 16_KiB};
   auto data = "Im Kampf zwischen dir und der Welt sekundiere der Welt."s;
   auto inflation = 1000;
   for (auto block_size : block_sizes) {

--- a/libvast/test/mmapbuf.cpp
+++ b/libvast/test/mmapbuf.cpp
@@ -11,18 +11,23 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include <fstream>
-#include <string>
-
-#include "vast/detail/mmapbuf.hpp"
-#include "vast/detail/system.hpp"
-
 #define SUITE streambuf
 #include "test.hpp"
 #include "fixtures/filesystem.hpp"
 
+#include "vast/detail/mmapbuf.hpp"
+
+#include <fstream>
+#include <string>
+
+#include "vast/si_literals.hpp"
+
+#include "vast/detail/system.hpp"
+
+
 using namespace std::string_literals;
 using namespace vast;
+using namespace vast::binary_byte_literals;
 
 FIXTURE_SCOPE(fixture_tests, fixtures::filesystem)
 
@@ -95,8 +100,7 @@ TEST(memory-mapped streambuffer aligned resize) {
 TEST(memory-mapped streambuffer aligned resize large) {
   auto filename = directory / "aligned_large";
   auto page_size = detail::page_size();
-  auto ten_mb = size_t{10 * (1 << 20)};
-  auto size = ten_mb - (ten_mb % page_size);
+  auto size = 10_MiB - (10_MiB % page_size);
   aligned_resize_test_impl(filename, size);
 }
 

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -27,8 +27,9 @@
 #define SUITE parseable
 #include "test.hpp"
 
-using namespace vast;
 using namespace std::string_literals;
+using namespace vast;
+using namespace vast::parser_literals;
 
 // -- core --------------------------------------------------------------------
 

--- a/libvast/test/printable.cpp
+++ b/libvast/test/printable.cpp
@@ -25,8 +25,9 @@
 #define SUITE printable
 #include "test.hpp"
 
-using namespace vast;
 using namespace std::string_literals;
+using namespace vast;
+using namespace vast::printer_literals;
 
 // -- numeric -----------------------------------------------------------------
 

--- a/libvast/vast/concept/parseable/core/literal.hpp
+++ b/libvast/vast/concept/parseable/core/literal.hpp
@@ -21,7 +21,7 @@
 #include "vast/concept/parseable/string/char.hpp"
 #include "vast/concept/parseable/string/string.hpp"
 
-namespace vast {
+namespace vast::parser_literals {
 
 inline auto operator"" _p(char c) {
   return ignore(char_parser{c});
@@ -43,5 +43,4 @@ inline auto operator"" _p(long double x) {
   return ignore(string_parser{std::to_string(x)});
 }
 
-} // namespace vast
-
+} // namespace vast::parser_literals

--- a/libvast/vast/concept/parseable/vast/address.hpp
+++ b/libvast/vast/concept/parseable/vast/address.hpp
@@ -66,6 +66,7 @@ struct address_parser : vast::parser<address_parser> {
 
   static auto make_v6() {
     using namespace parsers;
+    using namespace parser_literals;
     auto h16
       = rep<1, 4>(xdigit)
       ;

--- a/libvast/vast/concept/parseable/vast/base.hpp
+++ b/libvast/vast/concept/parseable/vast/base.hpp
@@ -25,6 +25,7 @@ struct base_parser : parser<base_parser> {
 
   template <class Iterator, class Attribute>
   bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
+    using namespace parser_literals;
     auto num = parsers::integral<size_t>;
     auto to_base = [](std::vector<size_t> xs) { return base{xs}; };
     auto to_uniform_base = [](std::tuple<size_t, optional<size_t>> tuple) {

--- a/libvast/vast/concept/parseable/vast/data.hpp
+++ b/libvast/vast/concept/parseable/vast/data.hpp
@@ -35,6 +35,7 @@ struct access::parser<data> : vast::parser<access::parser<data>> {
 
   template <class Iterator>
   static auto make() {
+    using namespace parser_literals;
     rule<Iterator, data> p;
     auto ws = ignore(*parsers::space);
     auto x = ws >> p >> ws;

--- a/libvast/vast/concept/parseable/vast/endpoint.hpp
+++ b/libvast/vast/concept/parseable/vast/endpoint.hpp
@@ -25,8 +25,9 @@ struct endpoint_parser : parser<endpoint_parser> {
 
   template <class Iterator>
   bool parse(Iterator& f, const Iterator& l, endpoint& e) const {
-    using namespace parsers;
     using namespace std::string_literals;
+    using namespace parsers;
+    using namespace parser_literals;
     auto hostname = +(alnum | chr{'-'} | chr{'_'} | chr{'.'});
     auto port = ":"_p >> u16;
     auto p

--- a/libvast/vast/concept/parseable/vast/expression.hpp
+++ b/libvast/vast/concept/parseable/vast/expression.hpp
@@ -28,6 +28,9 @@ struct predicate_parser : parser<predicate_parser> {
   using attribute = predicate;
 
   static auto make() {
+    using parsers::alnum;
+    using parsers::chr;
+    using namespace parser_literals;
     auto to_attr_extractor = [](std::string str) -> predicate::operand {
       return attribute_extractor{std::move(str)};
     };
@@ -43,8 +46,6 @@ struct predicate_parser : parser<predicate_parser> {
       auto key = detail::join(xs, ".");
       return predicate::operand{key_extractor{std::move(key)}};
     };
-    using parsers::alnum;
-    using parsers::chr;
     auto id = +(alnum | chr{'_'} | chr{'-'});
     // A key cannot start with ':', othwise it would be interpreted as a type
     // extractor.
@@ -116,6 +117,7 @@ struct expression_parser : parser<expression_parser> {
 
   template <class Iterator>
   static auto make() {
+    using namespace parser_literals;
     using raw_expr =
       std::tuple<
         expression,

--- a/libvast/vast/concept/parseable/vast/http.hpp
+++ b/libvast/vast/concept/parseable/vast/http.hpp
@@ -30,11 +30,12 @@ struct http_header_parser : parser<http_header_parser> {
   using attribute = http::header;
 
   static auto make() {
+    using namespace parsers;
+    using namespace parser_literals;
     auto to_upper = [](std::string name) {
       std::transform(name.begin(), name.end(), name.begin(), ::toupper);
       return name;
     };
-    using namespace parsers;
     auto name = +(printable - ':') ->* to_upper;
     auto value = +printable;
     auto ws = *' '_p;

--- a/libvast/vast/concept/parseable/vast/json.hpp
+++ b/libvast/vast/concept/parseable/vast/json.hpp
@@ -28,6 +28,7 @@ struct json_parser : parser<json_parser> {
   template <class Iterator>
   bool parse(Iterator& f, const Iterator& l, json& x) const {
     using namespace parsers;
+    using namespace parser_literals;
     rule<Iterator, json> j;
     auto ws = ignore(*parsers::space);
     auto lbracket = ws >> '[' >> ws;

--- a/libvast/vast/concept/parseable/vast/port.hpp
+++ b/libvast/vast/concept/parseable/vast/port.hpp
@@ -25,6 +25,7 @@ struct port_parser : parser<port_parser> {
   template <class Iterator>
   bool parse(Iterator& f, const Iterator& l, unused_type) const {
     using namespace parsers;
+    using namespace parser_literals;
     auto p = u16 >> '/' >> ("?"_p | "tcp" | "udp" | "icmp");
     return p(f, l, unused);
   }
@@ -32,6 +33,7 @@ struct port_parser : parser<port_parser> {
   template <class Iterator>
   bool parse(Iterator& f, const Iterator& l, port& x) const {
     using namespace parsers;
+    using namespace parser_literals;
     static auto p
       =  u16
       >> '/'

--- a/libvast/vast/concept/parseable/vast/time.hpp
+++ b/libvast/vast/concept/parseable/vast/time.hpp
@@ -43,6 +43,7 @@ struct duration_parser : parser<duration_parser<Rep, Period>> {
   template <class Iterator, class Attribute>
   bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     using namespace parsers;
+    using namespace parser_literals;
     auto save = f;
     Rep i;
     if (!make_parser<Rep>{}(f, l, i))
@@ -176,6 +177,7 @@ struct timestamp_parser : parser<timestamp_parser> {
 
   template <class Iterator, class Attribute>
   bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
+    using namespace parser_literals;
     static auto plus = [](timespan span) {
       return timestamp::clock::now() + span;
     };

--- a/libvast/vast/concept/parseable/vast/uri.hpp
+++ b/libvast/vast/concept/parseable/vast/uri.hpp
@@ -31,6 +31,7 @@ struct uri_parser : parser<uri_parser> {
 
   static auto make() {
     using namespace parsers;
+    using namespace parser_literals;
     auto query_unescape = [](std::string str) {
       std::replace(str.begin(), str.end(), '+', ' ');
       return detail::percent_unescape(str);

--- a/libvast/vast/concept/printable/core/literal.hpp
+++ b/libvast/vast/concept/printable/core/literal.hpp
@@ -19,7 +19,7 @@
 
 #include "vast/concept/printable/string/literal.hpp"
 
-namespace vast {
+namespace vast::printer_literals {
 
 inline auto operator"" _P(char c) {
   return literal_printer{c};
@@ -41,5 +41,4 @@ inline auto operator"" _P(long double x) {
   return literal_printer{x};
 }
 
-} // namespace vast
-
+} // namespace vast::printer_literals

--- a/libvast/vast/concept/printable/vast/attribute.hpp
+++ b/libvast/vast/concept/printable/vast/attribute.hpp
@@ -27,6 +27,7 @@ struct attribute_printer : printer<attribute_printer> {
   template <class Iterator>
   bool print(Iterator& out, const vast::attribute& attr) const {
     using namespace printers;
+    using namespace printer_literals;
     auto prepend_eq = [](const std::string& x) { return '=' + x; };
     auto p = '&'_P << str << -(str ->* prepend_eq);
     return p(out, attr.key, attr.value);

--- a/libvast/vast/concept/printable/vast/type.hpp
+++ b/libvast/vast/concept/printable/vast/type.hpp
@@ -36,6 +36,7 @@ struct enumeration_type_printer : printer<enumeration_type_printer> {
   template <class Iterator>
   bool print(Iterator& out, const enumeration_type& e) const {
     using namespace printers;
+    using namespace printer_literals;
     auto p = "enum {"_P << (str % ", ") << '}';
     auto a = detail::make_attr_printer(e);
     return (p << a)(out, e.fields, e.attributes());
@@ -51,9 +52,10 @@ struct printer_registry<enumeration_type> {
   struct TYPE##_printer : printer<TYPE##_printer> {                            \
     using attribute = TYPE;                                                    \
                                                                                \
-    template <class Iterator>                                               \
+    template <class Iterator>                                                  \
     bool print(Iterator& out, const TYPE& t) const {                           \
       using namespace printers;                                                \
+      using namespace printer_literals;                                        \
       auto p = DESC##_P << detail::make_attr_printer(t);                       \
       return p.print(out, t.attributes());                                     \
     }                                                                          \
@@ -83,7 +85,7 @@ VAST_DEFINE_BASIC_TYPE_PRINTER(port_type, "port")
   struct TYPE##_printer : printer<TYPE##_printer> {                            \
     using attribute = TYPE;                                                    \
                                                                                \
-    template <class Iterator>                                               \
+    template <class Iterator>                                                  \
     bool print(Iterator& out, const TYPE&) const;                              \
   };                                                                           \
                                                                                \
@@ -211,6 +213,7 @@ struct printer_registry<record_field> {
 
 template <class Iterator>
 bool record_type_printer::print(Iterator& out, const record_type& t) const {
+  using namespace printer_literals;
   auto p = "record{"_P << (record_field_printer{} % ", ") << '}';
   auto a = detail::make_attr_printer(t);
   return (p << a)(out, t.fields, t.attributes());

--- a/libvast/vast/detail/compressedbuf.hpp
+++ b/libvast/vast/detail/compressedbuf.hpp
@@ -40,7 +40,7 @@ namespace vast::detail {
 class compressedbuf : public std::streambuf {
 public:
   /// The default buffer size in bytes.
-  static constexpr size_t default_block_size = 16 << 10;
+  static size_t default_block_size;
 
   /// Constructs an compressed streambuffer.
   /// @param sb The underlying streambuffer to read from or write to.

--- a/libvast/vast/si_literals.hpp
+++ b/libvast/vast/si_literals.hpp
@@ -1,0 +1,136 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+namespace vast {
+namespace si_literals {
+
+constexpr unsigned long long operator""_k(unsigned long long x) {
+  return x * 1'000;
+}
+
+constexpr unsigned long long operator""_M(unsigned long long x) {
+  return x * 1'000'000;
+}
+
+constexpr unsigned long long operator""_G(unsigned long long x) {
+  return x * 1'000'000'000;
+}
+
+constexpr unsigned long long operator""_T(unsigned long long x) {
+  return x * 1'000'000'000'000;
+}
+
+constexpr unsigned long long operator""_P(unsigned long long x) {
+  return x * 1'000'000'000'000'000;
+}
+
+constexpr unsigned long long operator""_E(unsigned long long x) {
+  return x * 1'000'000'000'000'000'000;
+}
+
+constexpr unsigned long long operator""_Ki(unsigned long long x) {
+  return x << 10;
+}
+
+constexpr unsigned long long operator""_Mi(unsigned long long x) {
+  return x << 20;
+}
+
+constexpr unsigned long long operator""_Gi(unsigned long long x) {
+  return x << 30;
+}
+
+constexpr unsigned long long operator""_Ti(unsigned long long x) {
+  return x << 40;
+}
+
+constexpr unsigned long long operator""_Pi(unsigned long long x) {
+  return x << 50;
+}
+
+constexpr unsigned long long operator""_Ei(unsigned long long x) {
+  return x << 60;
+}
+
+} // namespace si_literals
+
+namespace decimal_byte_literals {
+
+constexpr unsigned long long operator""_kB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_k;
+}
+
+constexpr unsigned long long operator""_MB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_M;
+}
+
+constexpr unsigned long long operator""_GB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_G;
+}
+
+constexpr unsigned long long operator""_TB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_T;
+}
+
+constexpr unsigned long long operator""_PB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_P;
+}
+
+constexpr unsigned long long operator""_EB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_E;
+}
+
+} // namespace decimal_byte_literals
+
+namespace binary_byte_literals {
+
+constexpr unsigned long long operator""_KiB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_Ki;
+}
+
+constexpr unsigned long long operator""_MiB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_Mi;
+}
+
+constexpr unsigned long long operator""_GiB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_Gi;
+}
+
+constexpr unsigned long long operator""_TiB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_Ti;
+}
+
+constexpr unsigned long long operator""_PiB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_Pi;
+}
+
+constexpr unsigned long long operator""_EiB(unsigned long long x) {
+  using namespace si_literals;
+  return x * 1_Ei;
+}
+
+} // namespace byte_literals
+} // namespace vast

--- a/libvast/vast/system/replicated_store.hpp
+++ b/libvast/vast/system/replicated_store.hpp
@@ -263,7 +263,7 @@ replicated_store(
       self->request(consensus, consensus_timeout, statistics_atom::value).then(
         [=](const raft::statistics& stats) {
           using namespace vast::binary_byte_literals;
-          auto low = 64_MiB;
+          auto low = static_cast<uint64_t>(64_MiB);
           auto high = self->state.last_snapshot_size * 4;
           if (stats.log_bytes > std::max(low, high))
             self->anon_send(self, snapshot_atom::value);

--- a/libvast/vast/system/replicated_store.hpp
+++ b/libvast/vast/system/replicated_store.hpp
@@ -22,6 +22,7 @@
 
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
+#include "vast/si_literals.hpp"
 
 #include "vast/system/consensus.hpp"
 #include "vast/system/key_value_store.hpp"
@@ -261,7 +262,8 @@ replicated_store(
       self->state.last_stats_update = now;
       self->request(consensus, consensus_timeout, statistics_atom::value).then(
         [=](const raft::statistics& stats) {
-          auto low = uint64_t{64} << 20;
+          using namespace vast::binary_byte_literals;
+          auto low = 64_MiB;
           auto high = self->state.last_snapshot_size * 4;
           if (stats.log_bytes > std::max(low, high))
             self->anon_send(self, snapshot_atom::value);


### PR DESCRIPTION
This PR does two things:
1. Add a new namespace with user-defined literals for SI units.
2. Move the printer and parser literals into a dedicated namespace.