### PR TITLE
Change API of load()/store() to return errors instead of expected<void>

### DIFF
--- a/libvast/src/column_index.cpp
+++ b/libvast/src/column_index.cpp
@@ -94,10 +94,9 @@ caf::error column_index::init() {
   // Materialize the index when encountering persistent state.
   if (exists(filename_)) {
     detail::value_index_inspect_helper tmp{index_type_, idx_};
-    auto result = load(sys_, filename_, last_flush_, tmp);
-    if (!result) {
-      VAST_ERROR("unable to load value index from disk", result.error());
-      return std::move(result.error());
+    if (auto err = load(sys_, filename_, last_flush_, tmp)) {
+      VAST_ERROR("unable to load value index from disk", sys_.render(err));
+      return err;
     } else {
       VAST_DEBUG("loaded value index with offset", idx_->offset());
     }
@@ -130,10 +129,7 @@ caf::error column_index::flush_to_disk() {
              "new/total bits)");
   last_flush_ = offset;
   detail::value_index_inspect_helper tmp{index_type_, idx_};
-  auto result = save(sys_, filename_, last_flush_, tmp);
-  if (!result)
-    return result.error();
-  return caf::none;
+  return save(sys_, filename_, last_flush_, tmp);
 }
 
 // -- properties -------------------------------------------------------------

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -183,12 +183,11 @@ behavior index(stateful_actor<index_state>* self, const path& dir,
     accountant = actor_cast<accountant_type>(a);
   // Read persistent state.
   if (exists(self->state.dir / "meta")) {
-    auto result = load(self->system(), self->state.dir / "meta",
-                       self->state.part_index);
-    if (!result) {
+    if (auto err = load(self->system(), self->state.dir / "meta",
+                        self->state.part_index)) {
       VAST_ERROR(self, "failed to load partition index:",
-                 self->system().render(result.error()));
-      self->quit(result.error());
+                 self->system().render(err));
+      self->quit(std::move(err));
       return {};
     }
   }

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -45,8 +45,8 @@ partition::partition(caf::actor_system& sys, const path& base_dir, uuid id,
   // If the directory already exists, we must have some state from the past and
   // are pre-loading all INDEXER types we are aware of.
   if (exists(dir_)) {
-    if (auto res = load(sys_, meta_file(), meta_data_); !res) {
-      VAST_ERROR("unable to read partition meta data:", res.error());
+    if (auto err = load(sys_, meta_file(), meta_data_)) {
+      VAST_ERROR("unable to read partition meta data:", sys_.render(err));
     } else {
       for (auto& kvp : meta_data_.types) {
         // We spawn all INDEXER actors immediately. However, the factory spawns
@@ -68,8 +68,8 @@ caf::error partition::flush_to_disk() {
   if (meta_data_.dirty) {
     if (!exists(dir_))
       mkdir(dir_);
-    if (auto res = save(sys_, meta_file(), meta_data_); !res)
-      return std::move(res.error());
+    if (auto err = save(sys_, meta_file(), meta_data_))
+      return err;
     meta_data_.dirty = false;
   }
   return caf::none;

--- a/libvast/test/bitmap_index.cpp
+++ b/libvast/test/bitmap_index.cpp
@@ -285,9 +285,9 @@ TEST(serialization) {
   bmi1.append(-100);
   CHECK_EQUAL(to_string(bmi1.lookup(not_equal, 100)), "11011");
   std::vector<char> buf;
-  save(sys, buf, bmi1);
+  CHECK_EQUAL(save(sys, buf, bmi1), caf::none);
   auto bmi2 = bitmap_index_type{};
-  load(sys, buf, bmi2);
+  CHECK_EQUAL(load(sys, buf, bmi2), caf::none);
   CHECK(bmi1 == bmi2);
   CHECK_EQUAL(to_string(bmi2.lookup(not_equal, 100)), "11011");
 }

--- a/libvast/test/bitvector.cpp
+++ b/libvast/test/bitvector.cpp
@@ -213,8 +213,8 @@ TEST(serializable) {
   x.resize(1024, false);
   x[1000] = true;
   std::vector<char> buf;
-  save(sys, buf, x);
-  load(sys, buf, y);
+  CHECK_EQUAL(save(sys, buf, x), caf::none);
+  CHECK_EQUAL(load(sys, buf, y), caf::none);
   REQUIRE_EQUAL(x, y);
   CHECK(y[1000]);
 }

--- a/libvast/test/cache.cpp
+++ b/libvast/test/cache.cpp
@@ -80,9 +80,9 @@ TEST(LRU cache insertion) {
 
 TEST(cache serialization) {
   std::vector<char> buf;
-  save(sys, buf, xs);
+  CHECK_EQUAL(save(sys, buf, xs), caf::none);
   decltype(xs) ys;
-  load(sys, buf, ys);
+  CHECK_EQUAL(load(sys, buf, ys), caf::none);
   CHECK(xs == ys);
 }
 

--- a/libvast/test/chunk.cpp
+++ b/libvast/test/chunk.cpp
@@ -51,9 +51,9 @@ TEST(serialization) {
   auto x = chunk::make(sizeof(str));
   std::memcpy(x->data(), str, sizeof(str));
   std::vector<char> buf;
-  CHECK(save(sys, buf, x));
+  CHECK_EQUAL(save(sys, buf, x), caf::none);
   chunk_ptr y;
-  CHECK(load(sys, buf, y));
+  CHECK_EQUAL(load(sys, buf, y), caf::none);
   REQUIRE(y);
   CHECK(std::equal(x->begin(), x->end(), y->begin(), y->end()));
 }

--- a/libvast/test/coder.cpp
+++ b/libvast/test/coder.cpp
@@ -340,8 +340,8 @@ TEST(serialization range coder) {
   x.encode(21);
   x.encode(30);
   std::string buf;
-  save(sys, buf, x);
-  load(sys, buf, y);
+  CHECK_EQUAL(save(sys, buf, x), caf::none);
+  CHECK_EQUAL(load(sys, buf, y), caf::none);
   CHECK(x == y);
   CHECK_EQUAL(to_string(y.decode(equal,     21)), "00010");
   CHECK_EQUAL(to_string(y.decode(equal,     30)), "00001");
@@ -369,9 +369,9 @@ TEST(serialization multi-level coder) {
   x.encode(21);
   x.encode(30);
   std::string buf;
-  save(sys, buf, x);
+  CHECK_EQUAL(save(sys, buf, x), caf::none);
   auto y = coder_type{};
-  load(sys, buf, y);
+  CHECK_EQUAL(load(sys, buf, y), caf::none);
   CHECK(x == y);
   CHECK_EQUAL(to_string(y.decode(equal,     21)), "00010");
   CHECK_EQUAL(to_string(y.decode(equal,     30)), "00001");

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -192,9 +192,9 @@ TEST(serialization) {
   xs.emplace(port{8, port::icmp});
   auto x0 = data{xs};
   std::vector<char> buf;
-  save(sys, buf, x0);
+  CHECK_EQUAL(save(sys, buf, x0), caf::none);
   data x1;
-  load(sys, buf, x1);
+  CHECK_EQUAL(load(sys, buf, x1), caf::none);
   CHECK(x0 == x1);
 }
 

--- a/libvast/test/event.cpp
+++ b/libvast/test/event.cpp
@@ -80,9 +80,9 @@ TEST(printable) {
 
 TEST(serialization) {
   std::vector<char> buf;
-  save(sys, buf, e);
+  CHECK_EQUAL(save(sys, buf, e), caf::none);
   event e2;
-  load(sys, buf, e2);
+  CHECK_EQUAL(load(sys, buf, e2), caf::none);
   CHECK_EQUAL(e, e2);
 }
 

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -74,8 +74,8 @@ TEST(construction) {
 TEST(serialization) {
   expression ex0, ex1;
   std::vector<char> buf;
-  save(sys, buf, expr0, expr1);
-  load(sys, buf, ex0, ex1);
+  CHECK_EQUAL(save(sys, buf, expr0, expr1), caf::none);
+  CHECK_EQUAL(load(sys, buf, ex0, ex1), caf::none);
   auto d = caf::get_if<disjunction>(&ex1);
   REQUIRE(d);
   REQUIRE(!d->empty());

--- a/libvast/test/range_map.cpp
+++ b/libvast/test/range_map.cpp
@@ -192,8 +192,8 @@ TEST(range_map serialization) {
   x.insert(80, 90, 'b');
   x.insert(20, 30, 'c');
   std::vector<char> buf;
-  save(sys, buf, x);
-  load(sys, buf, y);
+  CHECK_EQUAL(save(sys, buf, x), caf::none);
+  CHECK_EQUAL(load(sys, buf, y), caf::none);
   REQUIRE_EQUAL(y.size(), 3u);
   auto i = y.lookup(50);
   REQUIRE(i);

--- a/libvast/test/save_load.cpp
+++ b/libvast/test/save_load.cpp
@@ -60,14 +60,13 @@ FIXTURE_SCOPE(serialization_tests, fixtures::deterministic_actor_system)
 
 TEST(variadic) {
   std::string buf;
-  auto m = save<compression::lz4>(sys, buf, 42, 4.2, 1337u, "foo"s);
-  CHECK(!m.error());
+  CHECK_EQUAL(save<compression::lz4>(sys, buf, 42, 4.2, 1337u, "foo"s),
+              caf::none);
   int i;
   double d;
   unsigned u;
   std::string s;
-  m = load<compression::lz4>(sys, buf, i, d, u, s);
-  CHECK(!m.error());
+  CHECK_EQUAL(load<compression::lz4>(sys, buf, i, d, u, s), caf::none);
   CHECK_EQUAL(i, 42);
   CHECK_EQUAL(d, 4.2);
   CHECK_EQUAL(u, 1337u);
@@ -78,9 +77,9 @@ TEST(custom type modeling serializable) {
   std::vector<char> buf;
   foo x;
   x.i = 42;
-  auto m = save(sys, buf, x);
+  CHECK_EQUAL(save(sys, buf, x), caf::none);
   foo y;
-  m = load(sys, buf, y);
+  CHECK_EQUAL(load(sys, buf, y), caf::none);
   CHECK_EQUAL(x.i, y.i);
 }
 
@@ -88,9 +87,9 @@ TEST(custom type modeling state) {
   std::vector<char> buf;
   bar x;
   x.set(42);
-  auto m = save(sys, buf, x);
+  CHECK_EQUAL(save(sys, buf, x), caf::none);
   bar y;
-  m = load(sys, buf, y);
+  CHECK_EQUAL(load(sys, buf, y), caf::none);
   CHECK_EQUAL(x.get(), y.get());
 }
 

--- a/libvast/test/schema.cpp
+++ b/libvast/test/schema.cpp
@@ -96,9 +96,9 @@ TEST(serialization) {
   sch.add(t);
   // Save & load
   std::vector<char> buf;
-  CHECK(save(sys, buf, sch));
+  CHECK_EQUAL(save(sys, buf, sch), caf::none);
   schema sch2;
-  CHECK(load(sys, buf, sch2));
+  CHECK_EQUAL(load(sys, buf, sch2), caf::none);
   // Check integrity
   auto u = sch2.find("foo");
   REQUIRE(u);

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -167,9 +167,9 @@ TEST(serialization) {
   r = r.name("foo");
   std::vector<char> buf;
   auto t0 = type{r};
-  save(sys, buf, t0);
+  CHECK_EQUAL(save(sys, buf, t0), caf::none);
   type t1;
-  load(sys, buf, t1);
+  CHECK_EQUAL(load(sys, buf, t1), caf::none);
   CHECK_EQUAL(t0, t1);
 }
 

--- a/libvast/test/value.cpp
+++ b/libvast/test/value.cpp
@@ -129,8 +129,8 @@ TEST(serialization) {
   value v{s, t};
   value w;
   std::vector<char> buf;
-  save(sys, buf, v);
-  load(sys, buf, w);
+  CHECK_EQUAL(save(sys, buf, v), caf::none);
+  CHECK_EQUAL(load(sys, buf, w), caf::none);
   CHECK(v == w);
   CHECK(to_string(w) == "{80/tcp, 53/udp, 8/icmp}");
 }

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -58,9 +58,9 @@ TEST(boolean) {
   CHECK_EQUAL(to_string(*multi), "11111111");
   MESSAGE("serialization");
   std::string buf;
-  save(sys, buf, idx);
+  CHECK_EQUAL(save(sys, buf, idx), caf::none);
   arithmetic_index<boolean> idx2;
-  load(sys, buf, idx2);
+  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
   t = idx2.lookup(equal, make_data_view(true));
   REQUIRE(t);
   CHECK_EQUAL(to_string(*t), "11010001");
@@ -92,9 +92,9 @@ TEST(integer) {
   CHECK_EQUAL(to_string(*multi), "0101011");
   MESSAGE("serialization");
   std::vector<char> buf;
-  save(sys, buf, idx);
+  CHECK_EQUAL(save(sys, buf, idx), caf::none);
   auto idx2 = arithmetic_index<integer>{};
-  load(sys, buf, idx2);
+  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
   less_than_leet = idx2.lookup(less, make_data_view(31337));
   REQUIRE(less_than_leet);
   CHECK(to_string(*less_than_leet) == "1111011");
@@ -122,9 +122,9 @@ TEST(floating-point with custom binner) {
   CHECK_EQUAL(to_string(*result), "1110111");
   MESSAGE("serialization");
   std::vector<char> buf;
-  save(sys, buf, idx);
+  CHECK_EQUAL(save(sys, buf, idx), caf::none);
   auto idx2 = index_type{};
-  load(sys, buf, idx2);
+  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
   result = idx2.lookup(not_equal, make_data_view(4711.14));
   CHECK_EQUAL(to_string(*result), "1110111");
 }
@@ -188,9 +188,9 @@ TEST(timestamp) {
   CHECK(to_string(*eighteen) == "000101");
   MESSAGE("serialization");
   std::vector<char> buf;
-  save(sys, buf, idx);
+  CHECK_EQUAL(save(sys, buf, idx), caf::none);
   auto idx2 = decltype(idx){};
-  load(sys, buf, idx2);
+  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
   eighteen = idx2.lookup(greater_equal, make_data_view(*t));
   CHECK(to_string(*eighteen) == "000101");
 }
@@ -251,9 +251,9 @@ TEST(string) {
   CHECK_EQUAL(to_string(*result), "1111110000");
   MESSAGE("serialization");
   std::vector<char> buf;
-  save(sys, buf, idx);
+  CHECK_EQUAL(save(sys, buf, idx), caf::none);
   string_index idx2{};
-  load(sys, buf, idx2);
+  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
   result = idx2.lookup(equal, make_data_view("foo"));
   CHECK_EQUAL(to_string(*result), "1001100000");
   result = idx2.lookup(equal, make_data_view("bar"));
@@ -328,9 +328,9 @@ TEST(address) {
   CHECK_EQUAL(idx.lookup(equal, make_data_view(x)), str);
   MESSAGE("serialization");
   std::vector<char> buf;
-  save(sys, buf, idx);
+  CHECK_EQUAL(save(sys, buf, idx), caf::none);
   address_index idx2{};
-  load(sys, buf, idx2);
+  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
   CHECK_EQUAL(idx2.lookup(equal, make_data_view(x)), str);
 }
 
@@ -384,9 +384,9 @@ TEST(subnet) {
   CHECK_EQUAL(to_string(*multi), "111100");
   MESSAGE("serialization");
   std::vector<char> buf;
-  save(sys, buf, idx);
+  CHECK_EQUAL(save(sys, buf, idx), caf::none);
   subnet_index idx2;
-  load(sys, buf, idx2);
+  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
   bm = idx2.lookup(not_equal, make_data_view(s1));
   REQUIRE(bm);
   CHECK_EQUAL(to_string(*bm), "101111");
@@ -420,9 +420,9 @@ TEST(port) {
   CHECK_EQUAL(to_string(*multi), "1010010");
   MESSAGE("serialization");
   std::vector<char> buf;
-  save(sys, buf, idx);
+  CHECK_EQUAL(save(sys, buf, idx), caf::none);
   port_index idx2;
-  load(sys, buf, idx2);
+  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
   bm = idx2.lookup(less_equal, make_data_view(priv));
   REQUIRE(bm);
   CHECK_EQUAL(to_string(*bm), "1111010");
@@ -449,9 +449,9 @@ TEST(container) {
   CHECK_EQUAL(to_string(*idx.lookup(ni, make_data_view(x))), "00000000");
   MESSAGE("serialization");
   std::vector<char> buf;
-  save(sys, buf, idx);
+  CHECK_EQUAL(save(sys, buf, idx), caf::none);
   sequence_index idx2;
-  load(sys, buf, idx2);
+  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
   x = "foo";
   CHECK_EQUAL(to_string(*idx2.lookup(ni, make_data_view(x))), "11000000");
 }
@@ -473,10 +473,11 @@ TEST(polymorphic) {
   CHECK_EQUAL(to_string(*idx->lookup(ni, make_data_view(44))), "0000");
   MESSAGE("serialization");
   std::vector<char> buf;
-  save(sys, buf, detail::value_index_inspect_helper{t, idx});
+  CHECK_EQUAL(save(sys, buf, detail::value_index_inspect_helper{t, idx}),
+              caf::none);
   std::unique_ptr<value_index> idx2;
   detail::value_index_inspect_helper helper{t, idx2};
-  load(sys, buf, helper);
+  CHECK_EQUAL(load(sys, buf, helper), caf::none);
   REQUIRE(idx2);
   CHECK_EQUAL(to_string(*idx2->lookup(ni, make_data_view(42))), "1001");
   MESSAGE("attributes");

--- a/libvast/vast/load.hpp
+++ b/libvast/vast/load.hpp
@@ -34,7 +34,7 @@ namespace vast {
 /// Deserializes a sequence of objects.
 /// @see save
 template <compression Method = compression::null, class Source, class... Ts>
-expected<void> load(caf::actor_system& sys, Source&& in, Ts&... xs) {
+caf::error load(caf::actor_system& sys, Source&& in, Ts&... xs) {
   static_assert(sizeof...(Ts) > 0);
   using source_type = std::decay_t<Source>;
   if constexpr (detail::is_streambuf_v<source_type>) {
@@ -48,7 +48,7 @@ expected<void> load(caf::actor_system& sys, Source&& in, Ts&... xs) {
       if (auto err = s(xs...))
         return err;
     }
-    return {};
+    return caf::none;
   } else if constexpr (std::is_base_of_v<std::istream, source_type>) {
     auto sb = in.rdbuf();
     return load<Method>(sys, *sb, xs...);

--- a/libvast/vast/save.hpp
+++ b/libvast/vast/save.hpp
@@ -33,7 +33,7 @@ namespace vast {
 /// Serializes a sequence of objects into a sink.
 /// @see load
 template <compression Method = compression::null, class Sink, class... Ts>
-expected<void> save(caf::actor_system& sys, Sink&& out, const Ts&... xs) {
+caf::error save(caf::actor_system& sys, Sink&& out, const Ts&... xs) {
   static_assert(sizeof...(Ts) > 0);
   using sink_type = std::decay_t<Sink>;
   if constexpr (detail::is_streambuf_v<sink_type>) {
@@ -48,7 +48,7 @@ expected<void> save(caf::actor_system& sys, Sink&& out, const Ts&... xs) {
         return err;
       compressed.pubsync();
     }
-    return {};
+    return caf::none;
   } else if constexpr (std::is_base_of_v<std::ostream, sink_type>) {
     auto sb = out.rdbuf();
     return save<Method>(sys, *sb, xs...);


### PR DESCRIPTION
Currently, we have lots of blocks that read like this:

```
if (auto res = load(...); !res) { 
  // ... log res.error()
}
```

Switching the result type reduces noise and redundancy:

```
if (auto err = load(...)) { 
  // ... log err
}
```