### PR TITLE
Fix unit test expectations and segment_store::get

### DIFF
--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -85,12 +85,12 @@ caf::expected<std::vector<const_table_slice_handle>>
 segment_store::get(const ids& xs) {
   // Collect candidate segments by seeking through the ID set and
   // probing each ID interval.
-  std::vector<const uuid*> candidates;
+  std::vector<uuid> candidates;
   auto f = [](auto x) { return std::pair{x.left, x.right}; };
   auto g = [&](auto x) {
-    auto ptr = &x.value;
-    if (candidates.empty() || candidates.back() != ptr)
-      candidates.push_back(ptr);
+    auto id = x.value;
+    if (candidates.empty() || candidates.back() != id)
+      candidates.push_back(id);
     return caf::none;
   };
   auto begin = segments_.begin();
@@ -101,7 +101,7 @@ segment_store::get(const ids& xs) {
   std::vector<const_table_slice_handle> result;
   VAST_DEBUG("processing", candidates.size(), "candidates");
   for (auto cand = candidates.rbegin(); cand != candidates.rend(); ++cand) {
-    auto& id = **cand;
+    auto& id = *cand;
     caf::expected<std::vector<const_table_slice_handle>> slices{caf::no_error};
     if (id == builder_.id()) {
       VAST_DEBUG("looking into builder");

--- a/libvast/test/fixtures/events.cpp
+++ b/libvast/test/fixtures/events.cpp
@@ -64,7 +64,7 @@ auto insert_sorted(std::vector<T>& vec, const T& item, Pred pred) {
 
 } // namespace <anonymous>
 
-size_t events::slice_size = 100;
+size_t events::slice_size = 8;
 
 std::vector<event> events::bro_conn_log;
 std::vector<event> events::bro_dns_log;
@@ -201,8 +201,8 @@ events::events() {
   REQUIRE_EQUAL(bgpdump_txt.size(), 100u);
   random = extract(vast::format::test::reader{42, 1000});
   REQUIRE_EQUAL(random.size(), 1000u);
-  ascending_integers = make_ascending_integers(10000);
-  alternating_integers = make_alternating_integers(10000);
+  ascending_integers = make_ascending_integers(250);
+  alternating_integers = make_alternating_integers(250);
   auto allocate_id_block = [i = id{0}](size_t size) mutable {
     auto first = i;
     i += size;

--- a/libvast/test/format/writer.cpp
+++ b/libvast/test/format/writer.cpp
@@ -32,11 +32,11 @@ auto last_bro_http_log_line = R"__(bro::http [2009-11-19+07:17:28.829] [2009-11-
 
 auto first_csv_http_log_line = "type,id,timestamp,ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,trans_depth,method,host,uri,referrer,user_agent,request_body_len,response_body_len,status_code,status_msg,info_code,info_msg,filename,tags,username,password,proxied,mime_type,md5,extraction_file";
 
-auto last_csv_http_log_line = R"__(bro::http,1239,1258615048829955072,2009-11-19+07:17:28.829,"rydI6puScNa",192.168.1.104,1224/?,87.106.66.233,80/?,1,"POST","87.106.66.233","/rpc.html?e=bl",,"SCSDK-6.0.0",1064,96,200,"OK",100,"Continue",,"",,,,"application/octet-stream",,)__";
+auto last_csv_http_log_line = R"__(bro::http,1095,1258615048829955072,2009-11-19+07:17:28.829,"rydI6puScNa",192.168.1.104,1224/?,87.106.66.233,80/?,1,"POST","87.106.66.233","/rpc.html?e=bl",,"SCSDK-6.0.0",1064,96,200,"OK",100,"Continue",,"",,,,"application/octet-stream",,)__";
 
 auto first_ascii_bgpdump_txt_line = R"__(bgpdump::state_change [2018-01-24+11:05:17.0] [2018-01-24+11:05:17.0, 27.111.229.79, 17639, "1", "3"])__";
 
-auto first_json_bgpdump_txt_line = R"__({"id": 1300, "timestamp": 1516791917000000000, "value": {"type": {"name": "bgpdump::state_change", "kind": "record", "structure": {"timestamp": {"name": "", "kind": "timestamp", "structure": null, "attributes": {}}, "source_ip": {"name": "", "kind": "address", "structure": null, "attributes": {}}, "source_as": {"name": "", "kind": "count", "structure": null, "attributes": {}}, "old_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}, "new_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}}, "attributes": {}}, "data": {"timestamp": 1516791917000000000, "source_ip": "27.111.229.79", "source_as": 17639, "old_state": "1", "new_state": "3"}}})__";
+auto first_json_bgpdump_txt_line = R"__({"id": 1096, "timestamp": 1516791917000000000, "value": {"type": {"name": "bgpdump::state_change", "kind": "record", "structure": {"timestamp": {"name": "", "kind": "timestamp", "structure": null, "attributes": {}}, "source_ip": {"name": "", "kind": "address", "structure": null, "attributes": {}}, "source_as": {"name": "", "kind": "count", "structure": null, "attributes": {}}, "old_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}, "new_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}}, "attributes": {}}, "data": {"timestamp": 1516791917000000000, "source_ip": "27.111.229.79", "source_as": 17639, "old_state": "1", "new_state": "3"}}})__";
 
 template <class Writer>
 std::vector<std::string> generate(const std::vector<event>& xs) {

--- a/libvast/test/segment.cpp
+++ b/libvast/test/segment.cpp
@@ -41,13 +41,12 @@ TEST(construction and querying) {
   auto x = *segment;
   CHECK_EQUAL(x->num_slices(), const_bro_conn_log_slices.size());
   MESSAGE("lookup IDs for some segments");
-  auto xs = x->lookup(make_ids({0, 42, 1337, 4711}));
+  auto xs = x->lookup(make_ids({0, 6, 19, 21}));
   REQUIRE(xs);
   auto& slices = *xs;
-  REQUIRE_EQUAL(slices.size(), 3u); // [0,100), [1300,1400), [4700,4800)
+  REQUIRE_EQUAL(slices.size(), 2u); // [0,8), [16,24)
   CHECK_EQUAL(*slices[0], *const_bro_conn_log_slices[0]);
-  CHECK_EQUAL(*slices[1], *const_bro_conn_log_slices[13]);
-  CHECK_EQUAL(*slices[2], *const_bro_conn_log_slices[47]);
+  CHECK_EQUAL(*slices[1], *const_bro_conn_log_slices[2]);
 }
 
 TEST(serialization) {

--- a/libvast/test/segment_store.cpp
+++ b/libvast/test/segment_store.cpp
@@ -36,9 +36,9 @@ TEST(construction and querying) {
   REQUIRE(store);
   for (auto& slice : const_bro_conn_log_slices)
     REQUIRE(!store->put(slice));
-  auto slices = store->get(make_ids({42, 1337, 8401}));
+  auto slices = store->get(make_ids({0, 6, 19, 21}));
   REQUIRE(slices);
-  REQUIRE_EQUAL(slices->size(), 3u);
+  REQUIRE_EQUAL(slices->size(), 2u);
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -68,20 +68,20 @@ TEST(archiving and querying) {
   MESSAGE("import BGP dump logs to archive");
   push_to_archive(const_bgpdump_txt_slices);
   MESSAGE("query events");
-  auto ids = make_ids({{100, 150}, {10150, 10200}});
+  auto ids = make_ids({{24, 56}, {1076, 1096}});
   auto result = request<std::vector<event>>(a, ids);
-  REQUIRE_EQUAL(result.size(), 100u);
+  REQUIRE_EQUAL(result.size(), 52u);
   // We sort because the specific compression algorithm used at the archive
   // determines the order of results.
   std::sort(result.begin(), result.end());
   // We processed the segments in reverse order of arrival (to maximize LRU hit
   // rate). Therefore, the result set contains first the events with higher
   // IDs [10150,10200) and then the ones with lower ID [100,150).
-  CHECK_EQUAL(result[0].id(), 100u);
-  CHECK_EQUAL(result[0].type().name(), "bro::conn");
-  CHECK_EQUAL(result[50].id(), 10150u);
-  CHECK_EQUAL(result[50].type().name(), "bro::dns");
-  CHECK_EQUAL(result[result.size() - 1].id(), 10199u);
+  CHECK_EQUAL(result[0].id(), 24u);
+  CHECK_EQUAL(result[0].type().name(), "bro::dns");
+  CHECK_EQUAL(result[32].id(), 1076u);
+  CHECK_EQUAL(result[32].type().name(), "bro::http");
+  CHECK_EQUAL(result[result.size() - 1].id(), 1095u);
   self->send_exit(a, exit_reason::user_shutdown);
 }
 

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -141,16 +141,16 @@ TEST(ingestion) {
   MESSAGE("verify partition index");
   REQUIRE_EQUAL(state().part_index.size(), slices.size());
   auto intervals = partition_intervals();
-  CHECK_EQUAL(intervals[0], interval(epoch, epoch + 99s));
-  CHECK_EQUAL(intervals[1], interval(epoch + 100s, epoch + 199s));
-  CHECK_EQUAL(intervals[2], interval(epoch + 200s, epoch + 299s));
-  CHECK_EQUAL(intervals[3], interval(epoch + 300s, epoch + 399s));
-  CHECK_EQUAL(intervals[4], interval(epoch + 400s, epoch + 499s));
-  CHECK_EQUAL(intervals[5], interval(epoch + 500s, epoch + 599s));
-  CHECK_EQUAL(intervals[6], interval(epoch + 600s, epoch + 699s));
-  CHECK_EQUAL(intervals[7], interval(epoch + 700s, epoch + 799s));
-  CHECK_EQUAL(intervals[8], interval(epoch + 800s, epoch + 899s));
-  CHECK_EQUAL(intervals[9], interval(epoch + 900s, epoch + 999s));
+  CHECK_EQUAL(intervals[0], interval(epoch, epoch + 7s));
+  CHECK_EQUAL(intervals[1], interval(epoch + 8s, epoch + 15s));
+  CHECK_EQUAL(intervals[2], interval(epoch + 16s, epoch + 23s));
+  CHECK_EQUAL(intervals[3], interval(epoch + 24s, epoch + 31s));
+  CHECK_EQUAL(intervals[4], interval(epoch + 32s, epoch + 39s));
+  CHECK_EQUAL(intervals[5], interval(epoch + 40s, epoch + 47s));
+  CHECK_EQUAL(intervals[6], interval(epoch + 48s, epoch + 55s));
+  CHECK_EQUAL(intervals[7], interval(epoch + 56s, epoch + 63s));
+  CHECK_EQUAL(intervals[8], interval(epoch + 64s, epoch + 71s));
+  CHECK_EQUAL(intervals[9], interval(epoch + 72s, epoch + 79s));
   // ...
 }
 

--- a/libvast/test/system/source.cpp
+++ b/libvast/test/system/source.cpp
@@ -79,9 +79,9 @@ TEST(bro source) {
   MESSAGE("get slices");
   const auto& slices = deref<test_sink_type>(snk).state.slices;
   MESSAGE("collect all rows as values");
-  REQUIRE_EQUAL(slices.size(), 1u);
+  REQUIRE_EQUAL(slices.size(), 3u);
   std::vector<value> row_contents;
-  for (size_t row = 0; row < 1u; ++row) {
+  for (size_t row = 0; row < 3u; ++row) {
     /// The first column is the automagically added timestamp.
     auto xs = subset(*slices[row], 0, table_slice::npos, 1);
     std::move(xs.begin(), xs.end(), std::back_inserter(row_contents));


### PR DESCRIPTION
The slice_size in unit tests is changed from 100 to 8. This had to be done in order to keep the segment store test meaningful.