### PR TITLE
Make table slice sizes configurable

### DIFF
--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -114,6 +114,9 @@ configuration::configuration() {
   load<opencl::manager>();
   add_message_type<std::vector<uint32_t>>("std::vector<uint32_t>");
 #endif
+  opt_group{custom_options_, "vast"}
+  .add<size_t>("table-slice-size",
+               "Maximum size for sources that generate table slices.");
 }
 
 configuration& configuration::parse(int argc, char** argv) {

--- a/libvast/src/system/spawn.cpp
+++ b/libvast/src/system/spawn.cpp
@@ -124,9 +124,10 @@ expected<actor> spawn_importer(node_actor* self, options& opts) {
   if (!r.error.empty())
     return make_error(ec::syntax_error, r.error);
   // FIXME: Notify exporters with a continuous query.
-  // TODO: make table slice size configurable
   return self->spawn(importer, opts.dir / opts.label,
-                     defaults::system::table_slice_size);
+                     caf::get_or(self->system().config(),
+                                 "vast.table-slice-size",
+                                 defaults::system::table_slice_size));
 }
 
 expected<actor> spawn_index(local_actor* self, options& opts) {

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -336,7 +336,7 @@ caf::behavior source(caf::stateful_actor<source_state<Reader>>* self,
 template <class Reader>
 caf::behavior default_source(caf::stateful_actor<source_state<Reader>>* self,
                              Reader reader) {
-  auto slice_size = get_or(self->system().config(), "system.table-slice-size",
+  auto slice_size = get_or(self->system().config(), "vast.table-slice-size",
                            defaults::system::table_slice_size);
   return source(self, std::move(reader), default_table_slice::make_builder,
                 slice_size);


### PR DESCRIPTION
This change allows users to set table slice sizes via `vast.ini` or CLI.