### PR TITLE
Move -b up on level in the command hierarchy

### DIFF
--- a/libvast/src/system/export_command.cpp
+++ b/libvast/src/system/export_command.cpp
@@ -13,18 +13,7 @@
 
 #include "vast/system/export_command.hpp"
 
-#include <iostream>
-
-#include <caf/all.hpp>
-#include <caf/io/all.hpp>
-#ifdef VAST_USE_OPENSSL
-#include <caf/openssl/all.hpp>
-#endif // VAST_USE_OPENSSL
-
 #include "vast/logger.hpp"
-
-#include "vast/system/signal_monitor.hpp"
-#include "vast/system/spawn.hpp"
 
 using namespace caf;
 

--- a/libvast/src/system/import_command.cpp
+++ b/libvast/src/system/import_command.cpp
@@ -13,18 +13,7 @@
 
 #include "vast/system/import_command.hpp"
 
-#include <iostream>
-
-#include <caf/all.hpp>
-#include <caf/io/all.hpp>
-#ifdef VAST_USE_OPENSSL
-#include <caf/openssl/all.hpp>
-#endif // VAST_USE_OPENSSL
-
 #include "vast/logger.hpp"
-
-#include "vast/system/signal_monitor.hpp"
-#include "vast/system/spawn.hpp"
 
 using namespace caf;
 

--- a/libvast/src/system/import_command.cpp
+++ b/libvast/src/system/import_command.cpp
@@ -33,7 +33,7 @@ using namespace std::chrono_literals;
 
 import_command::import_command(command* parent, std::string_view name)
   : node_command{parent, name} {
-  // nop
+  add_opt<bool>("blocking,b", "block until the IMPORTER forwarded all data");
 }
 
 int import_command::run_impl(actor_system&, const caf::config_value_map&,

--- a/libvast/src/system/pcap_reader_command.cpp
+++ b/libvast/src/system/pcap_reader_command.cpp
@@ -13,36 +13,23 @@
 
 #include "vast/system/pcap_reader_command.hpp"
 
-#include <memory>
 #include <string>
-#include <string_view>
 
 #include <caf/scoped_actor.hpp>
-#include <caf/typed_actor.hpp>
-#include <caf/typed_event_based_actor.hpp>
 
-#include "vast/concept/parseable/to.hpp"
-#include "vast/concept/parseable/vast/expression.hpp"
-#include "vast/concept/parseable/vast/schema.hpp"
-#include "vast/detail/make_io_stream.hpp"
-#include "vast/expression.hpp"
-#include "vast/format/pcap.hpp"
-#include "vast/logger.hpp"
 #include "vast/defaults.hpp"
-#include "vast/system/reader_command_base.hpp"
-#include "vast/system/reader_command_base.hpp"
-#include "vast/system/signal_monitor.hpp"
-#include "vast/system/source.hpp"
-#include "vast/system/tracker.hpp"
+#include "vast/logger.hpp"
 
-using std::string;
+#include "vast/format/pcap.hpp"
+
+#include "vast/system/source.hpp"
 
 namespace vast::system {
 
 pcap_reader_command::pcap_reader_command(command* parent, std::string_view name)
   : super(parent, name) {
-  add_opt<string>("read,r", "path to input where to read events from");
-  add_opt<string>("schema,s", "path to alternate schema");
+  add_opt<std::string>("read,r", "path to input where to read events from");
+  add_opt<std::string>("schema,s", "path to alternate schema");
   add_opt<bool>("uds,d", "treat -r as listening UNIX domain socket");
   add_opt<size_t>("cutoff,c", "skip flow packets after this many bytes");
   add_opt<size_t>("flow-max,m", "number of concurrent flows to track");

--- a/libvast/src/system/pcap_writer_command.cpp
+++ b/libvast/src/system/pcap_writer_command.cpp
@@ -13,27 +13,18 @@
 
 #include "vast/system/pcap_writer_command.hpp"
 
-#include <memory>
-#include <string>
-#include <string_view>
-
 #include <caf/scoped_actor.hpp>
-#include <caf/typed_actor.hpp>
-#include <caf/typed_event_based_actor.hpp>
 
 #include "vast/defaults.hpp"
-#include "vast/expression.hpp"
 #include "vast/format/pcap.hpp"
 #include "vast/logger.hpp"
 #include "vast/system/sink.hpp"
-
-using std::string;
 
 namespace vast::system {
 
 pcap_writer_command::pcap_writer_command(command* parent, std::string_view name)
   : super(parent, name) {
-  add_opt<string>("write,w", "path to write events to");
+  add_opt<std::string>("write,w", "path to write events to");
   add_opt<bool>("uds,d", "treat -w as UNIX domain socket to connect to");
   add_opt<size_t>("flush,f", "flush to disk after this many packets");
 }

--- a/libvast/src/system/reader_command_base.cpp
+++ b/libvast/src/system/reader_command_base.cpp
@@ -13,6 +13,8 @@
 
 #include "vast/system/reader_command_base.hpp"
 
+#include <csignal>
+
 #include <caf/scoped_actor.hpp>
 #include <caf/typed_event_based_actor.hpp>
 

--- a/libvast/src/system/reader_command_base.cpp
+++ b/libvast/src/system/reader_command_base.cpp
@@ -14,11 +14,14 @@
 #include "vast/system/reader_command_base.hpp"
 
 #include <caf/scoped_actor.hpp>
+#include <caf/typed_event_based_actor.hpp>
 
 #include "vast/logger.hpp"
 
 #include "vast/system/node_command.hpp"
+#include "vast/system/signal_monitor.hpp"
 #include "vast/system/source.hpp"
+#include "vast/system/tracker.hpp"
 
 namespace vast::system {
 

--- a/libvast/src/system/reader_command_base.cpp
+++ b/libvast/src/system/reader_command_base.cpp
@@ -42,7 +42,7 @@ namespace vast::system {
 
 reader_command_base::reader_command_base(command* parent, std::string_view name)
   : super(parent, name) {
-  add_opt<bool>("blocking,b", "block until the IMPORTER forwarded all data");
+  // nop
 }
 
 int reader_command_base::run_impl(caf::actor_system& sys,

--- a/libvast/src/system/reader_command_base.cpp
+++ b/libvast/src/system/reader_command_base.cpp
@@ -11,32 +11,14 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#ifndef VAST_SYSTEM_RUN_READER_HPP
-#define VAST_SYSTEM_RUN_READER_HPP
-
 #include "vast/system/reader_command_base.hpp"
 
-#include <csignal>
-#include <memory>
-#include <string>
-#include <string_view>
-
 #include <caf/scoped_actor.hpp>
-#include <caf/typed_actor.hpp>
-#include <caf/typed_event_based_actor.hpp>
 
-#include "vast/expression.hpp"
 #include "vast/logger.hpp"
 
 #include "vast/system/node_command.hpp"
-#include "vast/system/signal_monitor.hpp"
 #include "vast/system/source.hpp"
-#include "vast/system/tracker.hpp"
-
-#include "vast/concept/parseable/to.hpp"
-
-#include "vast/concept/parseable/vast/expression.hpp"
-#include "vast/concept/parseable/vast/schema.hpp"
 
 namespace vast::system {
 
@@ -137,5 +119,3 @@ int reader_command_base::run_impl(caf::actor_system& sys,
 }
 
 } // namespace vast::system
-
-#endif

--- a/libvast/src/system/remote_command.cpp
+++ b/libvast/src/system/remote_command.cpp
@@ -13,18 +13,11 @@
 
 #include "vast/system/remote_command.hpp"
 
+#include <caf/scoped_actor.hpp>
+
 #include <iostream>
 
-#include <caf/all.hpp>
-#include <caf/io/all.hpp>
-#ifdef VAST_USE_OPENSSL
-#include <caf/openssl/all.hpp>
-#endif // VAST_USE_OPENSSL
-
 #include "vast/logger.hpp"
-
-#include "vast/system/signal_monitor.hpp"
-#include "vast/system/spawn.hpp"
 
 using namespace caf;
 

--- a/libvast/src/system/writer_command_base.cpp
+++ b/libvast/src/system/writer_command_base.cpp
@@ -11,32 +11,19 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#ifndef VAST_SYSTEM_RUN_writer_HPP
-#define VAST_SYSTEM_RUN_writer_HPP
-
 #include "vast/system/writer_command_base.hpp"
 
 #include <csignal>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <string_view>
 
 #include <caf/scoped_actor.hpp>
-#include <caf/typed_actor.hpp>
-#include <caf/typed_event_based_actor.hpp>
 
-#include "vast/expression.hpp"
 #include "vast/logger.hpp"
 
-#include "vast/system/node_command.hpp"
 #include "vast/system/signal_monitor.hpp"
-#include "vast/system/source.hpp"
-#include "vast/system/tracker.hpp"
-
-#include "vast/concept/parseable/to.hpp"
-
-#include "vast/concept/parseable/vast/expression.hpp"
-#include "vast/concept/parseable/vast/schema.hpp"
 
 using namespace std::chrono_literals;
 using namespace caf;
@@ -136,5 +123,3 @@ int writer_command_base::run_impl(caf::actor_system& sys,
 }
 
 } // namespace vast::system
-
-#endif

--- a/libvast/vast/system/reader_command_base.hpp
+++ b/libvast/vast/system/reader_command_base.hpp
@@ -13,28 +13,13 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
 #include <string_view>
 
-#include <caf/scoped_actor.hpp>
-#include <caf/typed_actor.hpp>
-#include <caf/typed_event_based_actor.hpp>
-
-#include "vast/expression.hpp"
-#include "vast/logger.hpp"
+#include <caf/actor.hpp>
+#include <caf/expected.hpp>
+#include <caf/fwd.hpp>
 
 #include "vast/system/node_command.hpp"
-#include "vast/system/signal_monitor.hpp"
-#include "vast/system/source.hpp"
-#include "vast/system/tracker.hpp"
-
-#include "vast/concept/parseable/to.hpp"
-
-#include "vast/concept/parseable/vast/expression.hpp"
-#include "vast/concept/parseable/vast/schema.hpp"
-
-#include "vast/detail/make_io_stream.hpp"
 
 namespace vast::system {
 
@@ -56,4 +41,3 @@ protected:
 };
 
 } // namespace vast::system
-


### PR DESCRIPTION
This PR moves up the `-b` flag up one level in the command hierarchy, because it is not a format-specific option.