### PR TITLE
Improve logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ list(GET version_numbers 0 VERSION_MAJOR)
 list(GET version_numbers 1 VERSION_MINOR)
 set(VERSION_MAJ_MIN "${VERSION_MAJOR}.${VERSION_MINOR}")
 
+if (NOT VAST_LOG_LEVEL)
+  set(VAST_LOG_LEVEL "-1")
+endif ()
+
 #------------------------------------------------------------------------------
 #                               Compiler Setup
 #------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,8 @@ list(GET version_numbers 0 VERSION_MAJOR)
 list(GET version_numbers 1 VERSION_MINOR)
 set(VERSION_MAJ_MIN "${VERSION_MAJOR}.${VERSION_MINOR}")
 
-if (NOT VAST_LOG_LEVEL)
-  set(VAST_LOG_LEVEL "-1")
-endif ()
+set(VAST_LOG_LEVEL "2" CACHE STRING
+    "maximum log level that can be set during runtime execution")
 
 #------------------------------------------------------------------------------
 #                               Compiler Setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,6 +313,47 @@ Template Metaprogramming
   constexpr auto my_trait_v = my_trait<T>::value;
   ```
 
+Logging
+-------
+
+- Available log levels are *ERROR*, *WARNING*, *INFO*, *DEBUG* and *TRACE*.
+
+- Messages can be sent by using the VAST_<level> and VAST_<level>_ANON macros.
+
+- The VAST_<level> macros are intended to be used with a subject as the fist
+  argument. Use them to create a sentence of the form 'subject verb object'.
+  For example:
+  ```cpp
+  VAST_WARNING(self, "got a request for unknown query ID", query_id);
+  ```
+
+  Which gets printed as:
+  ```sh
+  index got a request for unkown query ID <181f5b1f-c673-4e98-acd2-ef762fe567a2>
+  ```
+
+- The VAST_<level>_ANON macros are available for situations where **n**o
+  **s**ubject is suitable for the first argument to the other macro variant.
+  They can either be used to inject a subject manually, or create a message
+  in the *gerund* form. For example:
+  ```cpp
+  VAST_DEBUG_ANON(__func__, "creating directory", dir);
+  ```
+
+- By default, use the VAST_<level> variants.
+
+- Try to restrict usage of the VAST_INFO message type to the main actors.
+  Info is the chattiest level that most users will see, so it should require
+  no or only little understanding of VASTs system architecture for the
+  reader to understand.
+
+- Messages sent at the trace level add the additional effect of writing a
+  second message at the exit of the current scope. The trace level can be
+  used to create a trace of the call stack with fine grained control over
+  its depth. Omit trace messages from helper functions and generic / general
+  purpose algorithm implementations.
+
+
 Comments
 --------
 

--- a/libvast/src/column_index.cpp
+++ b/libvast/src/column_index.cpp
@@ -99,7 +99,7 @@ caf::error column_index::init() {
   if (exists(filename_)) {
     detail::value_index_inspect_helper tmp{index_type_, idx_};
     if (auto err = load(sys_, filename_, last_flush_, tmp)) {
-      VAST_ERROR(this, "unable to load value index from disk", sys_.render(err));
+      VAST_ERROR(this, "failed to load value index from disk", sys_.render(err));
       return err;
     } else {
       VAST_DEBUG(this, "loaded value index with offset", idx_->offset());
@@ -122,7 +122,7 @@ caf::error column_index::flush_to_disk() {
   auto offset = idx_->offset();
   if (offset == last_flush_)
     return caf::none;
-  VAST_DEBUG(this, "flush index (" << (offset - last_flush_) << '/' << offset,
+  VAST_DEBUG(this, "flushes index (" << (offset - last_flush_) << '/' << offset,
              "new/total bits)");
   last_flush_ = offset;
   detail::value_index_inspect_helper tmp{index_type_, idx_};

--- a/libvast/src/column_index.cpp
+++ b/libvast/src/column_index.cpp
@@ -99,20 +99,20 @@ caf::error column_index::init() {
   if (exists(filename_)) {
     detail::value_index_inspect_helper tmp{index_type_, idx_};
     if (auto err = load(sys_, filename_, last_flush_, tmp)) {
-      VAST_ERROR("unable to load value index from disk", sys_.render(err));
+      VAST_ERROR(this, "unable to load value index from disk", sys_.render(err));
       return err;
     } else {
-      VAST_DEBUG("loaded value index with offset", idx_->offset());
+      VAST_DEBUG(this, "loaded value index with offset", idx_->offset());
     }
     return caf::none;
   }
   // Otherwise construct a new one.
   idx_ = value_index::make(index_type_);
   if (idx_ == nullptr) {
-    VAST_ERROR("failed to construct index");
+    VAST_ERROR(this, "failed to construct index");
     return make_error(ec::unspecified, "failed to construct index");
   }
-  VAST_DEBUG("constructed new value index");
+  VAST_DEBUG(this, "constructed new value index");
   return caf::none;
 }
 
@@ -122,7 +122,7 @@ caf::error column_index::flush_to_disk() {
   auto offset = idx_->offset();
   if (offset == last_flush_)
     return caf::none;
-  VAST_DEBUG("flush index (" << (offset - last_flush_) << '/' << offset,
+  VAST_DEBUG(this, "flush index (" << (offset - last_flush_) << '/' << offset,
              "new/total bits)");
   last_flush_ = offset;
   detail::value_index_inspect_helper tmp{index_type_, idx_};
@@ -135,7 +135,7 @@ caf::expected<bitmap> column_index::lookup(const predicate& pred) {
   VAST_TRACE(VAST_ARG(pred));
   VAST_ASSERT(idx_ != nullptr);
   auto result = idx_->lookup(pred.op, make_data_view(caf::get<data>(pred.rhs)));
-  VAST_DEBUG(VAST_ARG(result));
+  VAST_DEBUG(this, VAST_ARG(result));
   return result;
 }
 

--- a/libvast/src/defaults.cpp
+++ b/libvast/src/defaults.cpp
@@ -38,7 +38,7 @@ size_t flush_interval = 10000;
 size_t max_events = 0;
 size_t max_flow_age = 60;
 size_t max_flows = 1_Mi;
-std::string node_id = std::string{detail::split(detail::hostname(), ".")[0]};
+const char* node_id = "node";
 
 } // namespace command
 

--- a/libvast/src/format/bro.cpp
+++ b/libvast/src/format/bro.cpp
@@ -465,7 +465,7 @@ expected<void> reader::parse_header() {
     size_t i = 0;
     for (auto& f : record_.fields) {
       if (caf::holds_alternative<timestamp_type>(f.type)) {
-        VAST_INFO(this, "auto-detected field", i, "as event timestamp");
+        VAST_DEBUG(this, "auto-detected field", i, "as event timestamp");
         timestamp_field_ = static_cast<int>(i);
         break;
       }

--- a/libvast/src/format/bro.cpp
+++ b/libvast/src/format/bro.cpp
@@ -288,7 +288,7 @@ expected<event> reader::read() {
   auto s = detail::split(lines_->get(), separator_);
   if (s.size() > 0 && !s[0].empty() && s[0].front() == '#') {
     if (detail::starts_with(s[0], "#separator")) {
-      VAST_DEBUG(name(), "restarts with new log");
+      VAST_DEBUG(this, "restarts with new log");
       timestamp_field_ = -1;
       separator_.clear();
       auto t = parse_header();
@@ -299,13 +299,13 @@ expected<event> reader::read() {
         return make_error(ec::end_of_input, "input exhausted");
       s = detail::split(lines_->get(), separator_);
     } else {
-      VAST_DEBUG(name(), "ignores comment at line",
+      VAST_DEBUG(this, "ignores comment at line",
                  lines_->line_number() << ':', lines_->get());
       return no_error;
     }
   }
   if (s.size() != parsers_.size()) {
-    VAST_WARNING(name(), "ignores invalid record at line",
+    VAST_WARNING(this, "ignores invalid record at line",
                  lines_->line_number() << ':', "got", s.size(),
                  "fields but need", parsers_.size());
     return no_error;
@@ -439,15 +439,15 @@ expected<void> reader::parse_header() {
   record_ = std::move(record_fields);
   type_ = unflatten(record_);
   type_ = type_.name("bro::" + path);
-  VAST_DEBUG(name(), "parsed bro header:");
-  VAST_DEBUG(name(), "    #separator", separator_);
-  VAST_DEBUG(name(), "    #set_separator", set_separator_);
-  VAST_DEBUG(name(), "    #empty_field", empty_field_);
-  VAST_DEBUG(name(), "    #unset_field", unset_field_);
-  VAST_DEBUG(name(), "    #path", path);
-  VAST_DEBUG(name(), "    #fields:");
+  VAST_DEBUG(this, "parsed bro header:");
+  VAST_DEBUG(this, "    #separator", separator_);
+  VAST_DEBUG(this, "    #set_separator", set_separator_);
+  VAST_DEBUG(this, "    #empty_field", empty_field_);
+  VAST_DEBUG(this, "    #unset_field", unset_field_);
+  VAST_DEBUG(this, "    #path", path);
+  VAST_DEBUG(this, "    #fields:");
   for (auto i = 0u; i < record_.fields.size(); ++i)
-    VAST_DEBUG(name(), "     ", i << ')',
+    VAST_DEBUG(this, "     ", i << ')',
                record_.fields[i].name << ':', record_.fields[i].type);
   // If a congruent type exists in the schema, we give the schema type
   // precedence.
@@ -460,12 +460,12 @@ expected<void> reader::parse_header() {
     }
   // Determine the timestamp field.
   if (timestamp_field_ > -1) {
-    VAST_DEBUG(name(), "uses event timestamp from field", timestamp_field_);
+    VAST_DEBUG(this, "uses event timestamp from field", timestamp_field_);
   } else {
     size_t i = 0;
     for (auto& f : record_.fields) {
       if (caf::holds_alternative<timestamp_type>(f.type)) {
-        VAST_INFO(name(), "auto-detected field", i, "as event timestamp");
+        VAST_INFO(this, "auto-detected field", i, "as event timestamp");
         timestamp_field_ = static_cast<int>(i);
         break;
       }
@@ -502,7 +502,7 @@ expected<void> writer::write(const event& e) {
   std::ostream* os = nullptr;
   if (dir_.empty()) {
     if (streams_.empty()) {
-      VAST_DEBUG(name(), "creates a new stream for STDOUT");
+      VAST_DEBUG(this, "creates a new stream for STDOUT");
       auto sb = std::make_unique<detail::fdoutbuf>(1);
       auto out = std::make_unique<std::ostream>(sb.release());
       auto i = streams_.emplace("", std::move(out));
@@ -515,7 +515,7 @@ expected<void> writer::write(const event& e) {
       os = i->second.get();
       VAST_ASSERT(os != nullptr);
     } else {
-      VAST_DEBUG(name(), "creates new stream for event", e.type().name());
+      VAST_DEBUG(this, "creates new stream for event", e.type().name());
       if (!exists(dir_)) {
         auto d = mkdir(dir_);
         if (!d)

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -82,9 +82,9 @@ expected<event> reader::read() {
         }
         if (pseudo_realtime_ > 0) {
           pseudo_realtime_ = 0;
-          VAST_WARNING(name(), "ignores pseudo-realtime in live mode");
+          VAST_WARNING(this, "ignores pseudo-realtime in live mode");
         }
-        VAST_INFO(name(), "listens on interface " << i->name);
+        VAST_INFO(this, "listens on interface " << i->name);
         break;
       }
     ::pcap_freealldevs(iface);
@@ -102,15 +102,15 @@ expected<event> reader::read() {
         return make_error(ec::format_error, "failed to open pcap file ",
                           input_, ": ", std::string{buf});
       }
-      VAST_INFO(name(), "reads trace from", input_);
+      VAST_INFO(this, "reads trace from", input_);
       if (pseudo_realtime_ > 0)
-        VAST_INFO(name(), "uses pseudo-realtime factor 1/" << pseudo_realtime_);
+        VAST_INFO(this, "uses pseudo-realtime factor 1/" << pseudo_realtime_);
     }
-    VAST_INFO(name(), "cuts off flows after", cutoff_,
+    VAST_INFO(this, "cuts off flows after", cutoff_,
                     "bytes in each direction");
-    VAST_INFO(name(), "keeps at most", max_flows_, "concurrent flows");
-    VAST_INFO(name(), "evicts flows after", max_age_ << "s of inactivity");
-    VAST_INFO(name(), "expires flow table every", expire_interval_ << "s");
+    VAST_INFO(this, "keeps at most", max_flows_, "concurrent flows");
+    VAST_INFO(this, "evicts flows after", max_age_ << "s of inactivity");
+    VAST_INFO(this, "expires flow table every", expire_interval_ << "s");
   }
   const uint8_t* data;
   pcap_pkthdr* header;
@@ -259,7 +259,7 @@ expected<event> reader::read() {
 #endif
   if (pseudo_realtime_ > 0) {
     if (ts < last_timestamp_) {
-      VAST_WARNING(name(), "encountered non-monotonic packet timestamps:",
+      VAST_WARNING(this, "encountered non-monotonic packet timestamps:",
                    ts.time_since_epoch().count(), '<',
                    last_timestamp_.time_since_epoch().count());
     }
@@ -347,7 +347,7 @@ expected<void> writer::write(const event& e) {
 expected<void> writer::flush() {
   if (!dumper_)
     return make_error(ec::format_error, "pcap dumper not open");
-  VAST_DEBUG(name(), "flushes at packet", total_packets_);
+  VAST_DEBUG(this, "flushes at packet", total_packets_);
   if (::pcap_dump_flush(dumper_) == -1)
     return make_error(ec::format_error, "failed to flush");
   return no_error;

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -84,7 +84,7 @@ expected<event> reader::read() {
           pseudo_realtime_ = 0;
           VAST_WARNING(this, "ignores pseudo-realtime in live mode");
         }
-        VAST_INFO(this, "listens on interface " << i->name);
+        VAST_DEBUG(this, "listens on interface " << i->name);
         break;
       }
     ::pcap_freealldevs(iface);
@@ -102,15 +102,15 @@ expected<event> reader::read() {
         return make_error(ec::format_error, "failed to open pcap file ",
                           input_, ": ", std::string{buf});
       }
-      VAST_INFO(this, "reads trace from", input_);
+      VAST_DEBUG(this, "reads trace from", input_);
       if (pseudo_realtime_ > 0)
-        VAST_INFO(this, "uses pseudo-realtime factor 1/" << pseudo_realtime_);
+        VAST_DEBUG(this, "uses pseudo-realtime factor 1/" << pseudo_realtime_);
     }
-    VAST_INFO(this, "cuts off flows after", cutoff_,
+    VAST_DEBUG(this, "cuts off flows after", cutoff_,
                     "bytes in each direction");
-    VAST_INFO(this, "keeps at most", max_flows_, "concurrent flows");
-    VAST_INFO(this, "evicts flows after", max_age_ << "s of inactivity");
-    VAST_INFO(this, "expires flow table every", expire_interval_ << "s");
+    VAST_DEBUG(this, "keeps at most", max_flows_, "concurrent flows");
+    VAST_DEBUG(this, "evicts flows after", max_age_ << "s of inactivity");
+    VAST_DEBUG(this, "expires flow table every", expire_interval_ << "s");
   }
   const uint8_t* data;
   pcap_pkthdr* header;

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -49,11 +49,12 @@ operator[](const uuid& partition) const {
 void meta_index::add(const uuid& partition,
                      const const_table_slice_handle& slice) {
   auto& rng = partitions_[partition].range;
+  VAST_DEBUG(this, "meta_index got table slice:", slice);
   // The first column always contains the timestamp.
   for (size_t row = 0; row < slice->rows(); ++row) {
     auto element = slice->at(row, 0);
     if (!element) {
-      VAST_ERROR("cannot access element 0 in row", row);
+      VAST_ERROR(this, "cannot access element 0 in row", row);
       continue;
     }
     if (auto tsv = caf::get_if<view<timestamp>>(&(*element))) {

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -49,7 +49,7 @@ operator[](const uuid& partition) const {
 void meta_index::add(const uuid& partition,
                      const const_table_slice_handle& slice) {
   auto& rng = partitions_[partition].range;
-  VAST_DEBUG(this, "meta_index got table slice:", slice);
+  VAST_DEBUG(this, "got table slice:", slice);
   // The first column always contains the timestamp.
   for (size_t row = 0; row < slice->rows(); ++row) {
     auto element = slice->at(row, 0);

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -10,7 +10,6 @@
  * copied, modified, propagated, or distributed except according to the terms *
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
-
 #include "vast/bitmap_algorithms.hpp"
 #include "vast/error.hpp"
 #include "vast/event.hpp"
@@ -42,9 +41,9 @@ segment_store_ptr segment_store::make(caf::actor_system& sys, path dir,
     sys, std::move(dir), max_segment_size, in_memory_segments);
   // Materialize meta data of existing segments.
   if (exists(x->meta_path())) {
-    VAST_DEBUG_(__func__, "loading segment meta data from", x->meta_path());
+    VAST_DEBUG_ANON(__func__, "loads segment meta data from", x->meta_path());
     if (auto err = load(sys, x->meta_path(), x->segments_)) {
-      VAST_ERROR_(__func__, "failed to unarchive meta data:", sys.render(err));
+      VAST_ERROR_ANON(__func__, "failed to unarchive meta data:", sys.render(err));
       return nullptr;
     }
   }
@@ -57,7 +56,7 @@ segment_store::~segment_store() {
 
 caf::error segment_store::put(const_table_slice_handle xs) {
   VAST_TRACE(VAST_ARG(xs));
-  VAST_DEBUG(this, "adding a table slice");
+  VAST_DEBUG(this, "adds a table slice");
   if (auto error = builder_.add(xs))
     return error;
   if (!segments_.inject(xs->offset(), xs->offset() + xs->rows(), builder_.id()))
@@ -79,7 +78,7 @@ caf::error segment_store::flush() {
   // Keep new segment in the cache.
   cache_.emplace(seg_ptr->id(), seg_ptr);
   VAST_DEBUG(this, "wrote new segment to", filename.trim(-3));
-  VAST_DEBUG(this, "saving segment meta data");
+  VAST_DEBUG(this, "saves segment meta data");
   return save(sys_, meta_path(), segments_);
 }
 
@@ -88,7 +87,7 @@ segment_store::get(const ids& xs) {
   VAST_TRACE(VAST_ARG(xs));
   // Collect candidate segments by seeking through the ID set and
   // probing each ID interval.
-  VAST_DEBUG(this, "getting table slices with ids");
+  VAST_DEBUG(this, "retrieves table slices with requested ids");
   std::vector<uuid> candidates;
   auto f = [](auto x) { return std::pair{x.left, x.right}; };
   auto g = [&](auto x) {
@@ -103,12 +102,12 @@ segment_store::get(const ids& xs) {
     return error;
   // Process candidates in reverse order for maximum LRU cache hits.
   std::vector<const_table_slice_handle> result;
-  VAST_DEBUG(this, "processing", candidates.size(), "candidates");
+  VAST_DEBUG(this, "processes", candidates.size(), "candidates");
   for (auto cand = candidates.rbegin(); cand != candidates.rend(); ++cand) {
     auto& id = *cand;
     caf::expected<std::vector<const_table_slice_handle>> slices{caf::no_error};
     if (id == builder_.id()) {
-      VAST_DEBUG(this, "looking into builder");
+      VAST_DEBUG(this, "looks into the active segement");
       slices = builder_.lookup(xs);
     } else {
       segment_ptr seg_ptr = nullptr;

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -63,7 +63,7 @@ application::root_command::proceed(caf::actor_system& sys,
     std::cout << VAST_VERSION << std::endl;
     return stop_successful;
   }
-  std::cerr << banner() << "\n\n";
+  std::cerr << '\n' << banner() << "\n\n";
   return command::proceed_ok;
 }
 

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -42,6 +42,7 @@ archive(archive_type::stateful_pointer<archive_state> self,
   // probably makes sense to pass a unique_ptr<stor> directory to the spawn
   // arguments of the actor. This way, users can provide their own store
   // implementation conveniently.
+  VAST_INFO(self, "spawned:", VAST_ARG(capacity), VAST_ARG(max_segment_size));
   self->state.store = segment_store::make(
     self->system(), dir, max_segment_size, capacity);
   VAST_ASSERT(self->state.store != nullptr);

--- a/libvast/src/system/export_command.cpp
+++ b/libvast/src/system/export_command.cpp
@@ -30,7 +30,7 @@ export_command::export_command(command* parent, std::string_view name)
 
 int export_command::run_impl(actor_system&, const caf::config_value_map&,
                              argument_iterator, argument_iterator) {
-  VAST_ERROR("export_command::run_impl called");
+  VAST_ERROR(this, "::run_impl called");
   return EXIT_FAILURE;
 }
 

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -42,9 +42,11 @@ namespace system {
 namespace {
 
 void ship_results(stateful_actor<exporter_state>* self) {
-  if (self->state.results.empty() || self->state.stats.requested == 0)
+  VAST_TRACE("");
+  if (self->state.results.empty() || self->state.stats.requested == 0) {
     return;
-  VAST_DEBUG(self, "relays", self->state.results.size(), "events");
+  }
+  VAST_INFO(self, "relays", self->state.results.size(), "events");
   message msg;
   if (self->state.results.size() <= self->state.stats.requested) {
     self->state.stats.requested -= self->state.results.size();
@@ -69,7 +71,7 @@ void ship_results(stateful_actor<exporter_state>* self) {
 void report_statistics(stateful_actor<exporter_state>* self) {
   timespan runtime = steady_clock::now() - self->state.start;
   self->state.stats.runtime = runtime;
-  VAST_DEBUG(self, "completed in", runtime);
+  VAST_INFO(self, "completed in", runtime);
   self->send(self->state.sink, self->state.id, self->state.stats);
   if (self->state.accountant) {
     auto hits = rank(self->state.hits);

--- a/libvast/src/system/import_command.cpp
+++ b/libvast/src/system/import_command.cpp
@@ -27,7 +27,7 @@ import_command::import_command(command* parent, std::string_view name)
 
 int import_command::run_impl(actor_system&, const caf::config_value_map&,
                              argument_iterator, argument_iterator) {
-  VAST_ERROR("import_command::run_impl called");
+  VAST_ERROR(this, "::run_impl called");
   return EXIT_FAILURE;
 }
 

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -192,7 +192,7 @@ public:
     VAST_ASSERT(max_credit >= 0);
     if (max_credit <= desired) {
       // Get more IDs if we're running out.
-      VAST_DEBUG("had to limit acquired credit to", max_credit);
+      VAST_DEBUG(self_, "had to limit acquired credit to", max_credit);
       replenish(self_);
       st.in_flight_slices += max_credit;
       return max_credit;
@@ -299,22 +299,22 @@ behavior importer(stateful_actor<importer_state>* self, path dir,
     [=](stream<importer_state::input_type>& in) {
       auto& st = self->state;
       if (!st.meta_store) {
-        VAST_ERROR("no meta store configured for importer");
+        VAST_ERROR(self, "has no meta store configured");
         return;
       }
-      VAST_INFO("add a new source to the importer");
+      VAST_INFO(self, "adds a new source");
       st.stg->add_inbound_path(in);
     },
     [=](add_atom, const actor& subscriber) {
       auto& st = self->state;
-      VAST_INFO("add a new sink to the importer");
+      VAST_INFO(self, "adds a new sink");
       st.stg->add_outbound_path(subscriber);
     },
     [=](subscribe_atom, flush_atom, actor& listener) {
       VAST_INFO(self, "adds a new 'flush' subscriber");
       auto& st = self->state;
       if (st.stg->inbound_paths().empty() && st.stg->out().clean()) {
-        VAST_DEBUG("all outbound paths clean, send 'flush' immediately");
+        VAST_DEBUG(self, "sends 'flush' immediately");
         self->send(listener, flush_atom::value);
       } else {
         st.flush_listeners.emplace_back(std::move(listener));

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -50,6 +50,7 @@ namespace {
 /// Maps partition IDs to INDEXER actors for resolving a query.
 using query_map = caf::detail::unordered_flat_map<uuid, std::vector<actor>>;
 
+[[maybe_unused]]
 auto get_ids(query_map& xs) {
   std::vector<uuid> ys;
   ys.reserve(xs.size());
@@ -206,7 +207,7 @@ caf::error index_state::flush_to_disk() {
     VAST_ERROR(self, "was unable to save meta index:", VAST_ARG(err));
     return err;
   } else {
-    VAST_INFO(self, "persistet meta index with", part_index.size(), "entries");
+    VAST_INFO(self, "persisted meta index with", part_index.size(), "entries");
   }
   return caf::none;
 }
@@ -230,8 +231,8 @@ behavior index(stateful_actor<index_state>* self, const path& dir,
                size_t taste_partitions, size_t num_workers) {
   VAST_ASSERT(partition_size > 0);
   VAST_ASSERT(in_mem_partitions > 0);
-  VAST_DEBUG(self, "caps partitions at", partition_size, "events");
-  VAST_DEBUG(self, "keeps at most", in_mem_partitions, "partitions in memory");
+  VAST_INFO(self, "spawned:", VAST_ARG(partition_size),
+            VAST_ARG(in_mem_partitions), VAST_ARG(taste_partitions));
   if (auto err = self->state.init(self, dir, partition_size, in_mem_partitions,
                                   taste_partitions)) {
     self->quit(std::move(err));

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -11,6 +11,7 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
+#include <chrono>
 #include <deque>
 #include <unordered_set>
 
@@ -193,7 +194,7 @@ caf::error index_state::load_from_disk() {
                  self->system().render(err));
       return err;
     }
-    VAST_DEBUG(self, "loaded a meta index with", part_index.size(), "entries");
+    VAST_INFO(self, "loaded a meta index with", part_index.size(), "entries");
   }
   return caf::none;
 }
@@ -205,7 +206,7 @@ caf::error index_state::flush_to_disk() {
     VAST_ERROR(self, "was unable to save meta index:", VAST_ARG(err));
     return err;
   } else {
-    VAST_DEBUG(self, "persistet meta index with", part_index.size(), "entries");
+    VAST_INFO(self, "persistet meta index with", part_index.size(), "entries");
   }
   return caf::none;
 }

--- a/libvast/src/system/indexer_stage_driver.cpp
+++ b/libvast/src/system/indexer_stage_driver.cpp
@@ -52,7 +52,7 @@ void indexer_stage_driver::process(downstream_type& out, batch_type& slices) {
     auto& layout = slice->layout();
     if (auto [hdl, added] = partition_->manager().get_or_add(layout); added) {
       auto slot = out_.parent()->add_unchecked_outbound_path<output_type>(hdl);
-      VAST_DEBUG("spawned new INDEXER at slot", slot);
+      VAST_DEBUG(this, "spawned new INDEXER at slot", slot);
       out_.set_filter(slot, layout);
     }
     // Ship event to the INDEXER actors.
@@ -60,7 +60,8 @@ void indexer_stage_driver::process(downstream_type& out, batch_type& slices) {
     out.push(std::move(slice));
     // Reset the manager and all outbound paths when finalizing a partition.
     if (remaining_in_partition_ <= slice_size) {
-      VAST_DEBUG("partition full, close slots", out_.open_path_slots());
+      VAST_DEBUG(this, "closes slots on full partition",
+                 out_.open_path_slots());
       VAST_ASSERT(out_.buf().size() != 0);
       out_.fan_out_flush();
       VAST_ASSERT(out_.buf().size() == 0);

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -306,7 +306,7 @@ caf::behavior node(node_ptr self, std::string id, path dir) {
         send(self, args);
       } else {
         auto e = make_error(ec::unspecified, "invalid command", cmd);
-        VAST_INFO(self, self->system().render(e));
+        VAST_WARNING(self, self->system().render(e));
         self->make_response_promise().deliver(std::move(e));
       }
     },
@@ -327,7 +327,7 @@ caf::behavior node(node_ptr self, std::string id, path dir) {
     },
     [=](signal_atom, int signal) {
       VAST_IGNORE_UNUSED(signal);
-      VAST_INFO(self, "got signal", ::strsignal(signal));
+      VAST_WARNING(self, "got signal", ::strsignal(signal));
     }
   };
 }

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -306,7 +306,7 @@ caf::behavior node(node_ptr self, std::string id, path dir) {
         send(self, args);
       } else {
         auto e = make_error(ec::unspecified, "invalid command", cmd);
-        VAST_WARNING(self, self->system().render(e));
+        VAST_WARNING(self, "failed to parse command:", self->system().render(e));
         self->make_response_promise().deliver(std::move(e));
       }
     },

--- a/libvast/src/system/node_command.cpp
+++ b/libvast/src/system/node_command.cpp
@@ -78,7 +78,7 @@ expected<actor> node_command::spawn_node(scoped_actor& self,
     spawn_component("importer")
   );
   if (err) {
-    VAST_ERROR(&self, self->system().render(err));
+    VAST_ERROR(self, self->system().render(err));
     cleanup(node);
     return err;
   }
@@ -99,7 +99,7 @@ node_command::connect_to_node(scoped_actor& self,
     err += endpoint_str;
     return make_error(sec::invalid_argument, std::move(err));
   }
-  VAST_DEBUG(&self, "connect to remote node:", id);
+  VAST_DEBUG(self, "connects to remote node:", id);
   auto& sys_cfg = self->system().config();
   auto use_encryption = !sys_cfg.openssl_certificate.empty()
                         || !sys_cfg.openssl_key.empty()
@@ -109,7 +109,7 @@ node_command::connect_to_node(scoped_actor& self,
   auto host = node_endpoint.host;
   if (node_endpoint.host.empty())
     node_endpoint.host = "127.0.0.1";
-  VAST_INFO(&self, "connecting to", node_endpoint.host << ':' << node_endpoint.port);
+  VAST_INFO(self, "connects to", node_endpoint.host << ':' << node_endpoint.port);
   if (use_encryption) {
 #ifdef VAST_USE_OPENSSL
     return openssl::remote_actor(self->system(), node_endpoint.host,

--- a/libvast/src/system/node_command.cpp
+++ b/libvast/src/system/node_command.cpp
@@ -56,7 +56,7 @@ expected<actor> node_command::spawn_node(scoped_actor& self,
   auto id = get_or(opts, "id", defaults::command::node_id);
   auto dir = get_or(opts, "dir", defaults::command::directory);
   auto abs_dir = path{dir}.complete();
-  VAST_INFO("spawning local node:", id);
+  VAST_INFO(this, "spawning local node:", id);
   // Pointer to the root command to system::node.
   auto node = self->spawn(system::node, id, abs_dir);
   node_spawned_ = true;
@@ -78,7 +78,7 @@ expected<actor> node_command::spawn_node(scoped_actor& self,
     spawn_component("importer")
   );
   if (err) {
-    VAST_ERROR(self->system().render(err));
+    VAST_ERROR(&self, self->system().render(err));
     cleanup(node);
     return err;
   }
@@ -99,7 +99,7 @@ node_command::connect_to_node(scoped_actor& self,
     err += endpoint_str;
     return make_error(sec::invalid_argument, std::move(err));
   }
-  VAST_INFO("connect to remote node:", id);
+  VAST_INFO(&self, "connect to remote node:", id);
   auto& sys_cfg = self->system().config();
   auto use_encryption = !sys_cfg.openssl_certificate.empty()
                         || !sys_cfg.openssl_key.empty()
@@ -109,7 +109,7 @@ node_command::connect_to_node(scoped_actor& self,
   auto host = node_endpoint.host;
   if (node_endpoint.host.empty())
     node_endpoint.host = "127.0.0.1";
-  VAST_INFO("connecting to", node_endpoint.host << ':' << node_endpoint.port);
+  VAST_INFO(&self, "connecting to", node_endpoint.host << ':' << node_endpoint.port);
   if (use_encryption) {
 #ifdef VAST_USE_OPENSSL
     return openssl::remote_actor(self->system(), node_endpoint.host,

--- a/libvast/src/system/node_command.cpp
+++ b/libvast/src/system/node_command.cpp
@@ -56,7 +56,7 @@ expected<actor> node_command::spawn_node(scoped_actor& self,
   auto id = get_or(opts, "id", defaults::command::node_id);
   auto dir = get_or(opts, "dir", defaults::command::directory);
   auto abs_dir = path{dir}.complete();
-  VAST_INFO(this, "spawning local node:", id);
+  VAST_DEBUG(this, "spawns local node:", id);
   // Pointer to the root command to system::node.
   auto node = self->spawn(system::node, id, abs_dir);
   node_spawned_ = true;
@@ -99,7 +99,7 @@ node_command::connect_to_node(scoped_actor& self,
     err += endpoint_str;
     return make_error(sec::invalid_argument, std::move(err));
   }
-  VAST_INFO(&self, "connect to remote node:", id);
+  VAST_DEBUG(&self, "connect to remote node:", id);
   auto& sys_cfg = self->system().config();
   auto use_encryption = !sys_cfg.openssl_certificate.empty()
                         || !sys_cfg.openssl_key.empty()

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -46,7 +46,7 @@ partition::partition(caf::actor_system& sys, const path& base_dir, uuid id,
   // are pre-loading all INDEXER types we are aware of.
   if (exists(dir_)) {
     if (auto err = load(sys_, meta_file(), meta_data_)) {
-      VAST_ERROR("unable to read partition meta data:", sys_.render(err));
+      VAST_ERROR(this, "unable to read meta data:", sys_.render(err));
     } else {
       for (auto& kvp : meta_data_.types) {
         // We spawn all INDEXER actors immediately. However, the factory spawns

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -46,7 +46,7 @@ partition::partition(caf::actor_system& sys, const path& base_dir, uuid id,
   // are pre-loading all INDEXER types we are aware of.
   if (exists(dir_)) {
     if (auto err = load(sys_, meta_file(), meta_data_)) {
-      VAST_ERROR(this, "unable to read meta data:", sys_.render(err));
+      VAST_ERROR(this, "failed to read meta data:", sys_.render(err));
     } else {
       for (auto& kvp : meta_data_.types) {
         // We spawn all INDEXER actors immediately. However, the factory spawns

--- a/libvast/src/system/pcap_reader_command.cpp
+++ b/libvast/src/system/pcap_reader_command.cpp
@@ -45,7 +45,7 @@ pcap_reader_command::make_source(caf::scoped_actor& self,
                                  argument_iterator end) {
   VAST_UNUSED(begin, end);
   VAST_TRACE(VAST_ARG("args", begin, end));
-  VAST_DEBUG(VAST_ARG(options));
+  VAST_DEBUG(this, "::make_source called with options:", VAST_ARG(options));
   auto input = get_or(options, "read", defaults::command::read_path);
   auto cutoff = get_or(options, "cutoff", defaults::command::cutoff);
   auto flow_max = get_or(options, "flow-max", defaults::command::max_flows);

--- a/libvast/src/system/reader_command_base.cpp
+++ b/libvast/src/system/reader_command_base.cpp
@@ -53,7 +53,7 @@ int reader_command_base::run_impl(caf::actor_system& sys,
   if (!node_opt)
     return EXIT_FAILURE;
   auto node = std::move(*node_opt);
-  VAST_INFO("got node");
+  VAST_INFO(this, "got node");
   /// Spawn an actor that takes care of CTRL+C and friends.
   auto sig_mon = self->spawn<detached>(system::signal_monitor, 750ms,
                                        actor{self});
@@ -69,20 +69,20 @@ int reader_command_base::run_impl(caf::actor_system& sys,
     [&](const std::string& id, system::registry& reg) {
       auto er = reg.components[id].equal_range("importer");
       if (er.first == er.second) {
-        VAST_ERROR("no importers available at node", id);
+        VAST_ERROR(this, "did not receive any importers from node", id);
         stop = true;
       } else if (reg.components[id].count("importer") > 1) {
-        VAST_ERROR("multiple IMPOTER actors are not yet supported");
+        VAST_ERROR(this, "does not support multiple IMPORTER actors yet");
         stop = true;
       } else {
-        VAST_DEBUG("connecting source to importer");
+        VAST_DEBUG(this, "connecting to importer");
         importer = er.first->second.actor;
         self->send(src, system::sink_atom::value, importer);
       }
     },
     [&](const error& e) {
       VAST_IGNORE_UNUSED(e);
-      VAST_ERROR(self->system().render(e));
+      VAST_ERROR(this, self->system().render(e));
       stop = true;
     }
   );
@@ -97,12 +97,12 @@ int reader_command_base::run_impl(caf::actor_system& sys,
   self->do_receive(
     [&](const down_msg& msg) {
       if (msg.source == node)  {
-        VAST_DEBUG("received DOWN from node");
+        VAST_DEBUG(this, "received DOWN from node");
         self->send_exit(src, exit_reason::user_shutdown);
         rc = EXIT_FAILURE;
         stop = true;
       } else if (msg.source == src) {
-        VAST_DEBUG("received DOWN from source");
+        VAST_DEBUG(this, "received DOWN from source");
         if (caf::get_or(options, "blocking", false))
           self->send(importer, subscribe_atom::value, flush_atom::value, self);
         else
@@ -110,11 +110,11 @@ int reader_command_base::run_impl(caf::actor_system& sys,
       }
     },
     [&](flush_atom) {
-      VAST_DEBUG("received flush from IMPORTER");
+      VAST_DEBUG(this, "received flush from IMPORTER");
       stop = true;
     },
     [&](system::signal_atom, int signal) {
-      VAST_DEBUG("got " << ::strsignal(signal));
+      VAST_DEBUG(this, "got " << ::strsignal(signal));
       if (signal == SIGINT || signal == SIGTERM)
         self->send_exit(src, exit_reason::user_shutdown);
     }

--- a/libvast/src/system/reader_command_base.cpp
+++ b/libvast/src/system/reader_command_base.cpp
@@ -53,7 +53,7 @@ int reader_command_base::run_impl(caf::actor_system& sys,
   if (!node_opt)
     return EXIT_FAILURE;
   auto node = std::move(*node_opt);
-  VAST_INFO(this, "got node");
+  VAST_DEBUG(this, "got node");
   /// Spawn an actor that takes care of CTRL+C and friends.
   auto sig_mon = self->spawn<detached>(system::signal_monitor, 750ms,
                                        actor{self});

--- a/libvast/src/system/reader_command_base.cpp
+++ b/libvast/src/system/reader_command_base.cpp
@@ -75,7 +75,7 @@ int reader_command_base::run_impl(caf::actor_system& sys,
         VAST_ERROR(this, "does not support multiple IMPORTER actors yet");
         stop = true;
       } else {
-        VAST_DEBUG(this, "connecting to importer");
+        VAST_DEBUG(this, "connects to importer");
         importer = er.first->second.actor;
         self->send(src, system::sink_atom::value, importer);
       }

--- a/libvast/src/system/remote_command.cpp
+++ b/libvast/src/system/remote_command.cpp
@@ -70,7 +70,7 @@ int remote_command::run_impl(actor_system& sys,
     },
     [&](const error& e) {
       VAST_IGNORE_UNUSED(e);
-      VAST_ERROR(self->system().render(e));
+      VAST_ERROR(this, self->system().render(e));
       std::cerr << self->system().render(e) << std::endl;
       result = false;
     });

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -84,7 +84,7 @@ int start_command::run_impl(actor_system& sys,
     self->send_exit(node, exit_reason::user_shutdown);
     return EXIT_FAILURE;
   }
-  VAST_INFO_("... listening on", (host ? host : "") << ':' << *bound_port);
+  VAST_INFO_("VAST node is listening on", (host ? host : "") << ':' << *bound_port);
   // Spawn signal handler.
   auto sig_mon = self->spawn<detached>(system::signal_monitor, 750ms, self);
   auto guard = caf::detail::make_scope_guard([&] {

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -53,7 +53,7 @@ int start_command::run_impl(actor_system& sys,
   auto endpoint_str = get_or(options, "endpoint", defaults::command::endpoint);
   endpoint node_endpoint;
   if (!parsers::endpoint(endpoint_str, node_endpoint)) {
-    VAST_ERROR_("invalid endpoint:", endpoint_str);
+    VAST_ERROR_ANON("invalid endpoint:", endpoint_str);
     return EXIT_FAILURE;
   }
   // Get a convenient and blocking way to interact with actors.
@@ -80,11 +80,11 @@ int start_command::run_impl(actor_system& sys,
   };
   auto bound_port = publish();
   if (!bound_port) {
-    VAST_ERROR_(self->system().render(bound_port.error()));
+    VAST_ERROR_ANON(self->system().render(bound_port.error()));
     self->send_exit(node, exit_reason::user_shutdown);
     return EXIT_FAILURE;
   }
-  VAST_INFO_("VAST node is listening on", (host ? host : "") << ':' << *bound_port);
+  VAST_INFO_ANON("VAST node is listening on", (host ? host : "") << ':' << *bound_port);
   // Spawn signal handler.
   auto sig_mon = self->spawn<detached>(system::signal_monitor, 750ms, self);
   auto guard = caf::detail::make_scope_guard([&] {
@@ -97,13 +97,13 @@ int start_command::run_impl(actor_system& sys,
   self->do_receive(
     [&](const down_msg& msg) {
       VAST_ASSERT(msg.source == node);
-      VAST_DEBUG_("... received DOWN from node");
+      VAST_DEBUG_ANON("... received DOWN from node");
       stop = true;
       if (msg.reason != exit_reason::user_shutdown)
         rc = 1;
     },
     [&](system::signal_atom, int signal) {
-      VAST_DEBUG_("... got " << ::strsignal(signal));
+      VAST_DEBUG_ANON("... got " << ::strsignal(signal));
       if (signal == SIGINT || signal == SIGTERM)
         self->send_exit(node, exit_reason::user_shutdown);
       else

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -53,7 +53,7 @@ int start_command::run_impl(actor_system& sys,
   auto endpoint_str = get_or(options, "endpoint", defaults::command::endpoint);
   endpoint node_endpoint;
   if (!parsers::endpoint(endpoint_str, node_endpoint)) {
-    VAST_ERROR("invalid endpoint:", endpoint_str);
+    VAST_ERROR_("invalid endpoint:", endpoint_str);
     return EXIT_FAILURE;
   }
   // Get a convenient and blocking way to interact with actors.
@@ -80,11 +80,11 @@ int start_command::run_impl(actor_system& sys,
   };
   auto bound_port = publish();
   if (!bound_port) {
-    VAST_ERROR(self->system().render(bound_port.error()));
+    VAST_ERROR_(self->system().render(bound_port.error()));
     self->send_exit(node, exit_reason::user_shutdown);
     return EXIT_FAILURE;
   }
-  VAST_INFO("listening on", (host ? host : "") << ':' << *bound_port);
+  VAST_INFO_("... listening on", (host ? host : "") << ':' << *bound_port);
   // Spawn signal handler.
   auto sig_mon = self->spawn<detached>(system::signal_monitor, 750ms, self);
   auto guard = caf::detail::make_scope_guard([&] {
@@ -97,13 +97,13 @@ int start_command::run_impl(actor_system& sys,
   self->do_receive(
     [&](const down_msg& msg) {
       VAST_ASSERT(msg.source == node);
-      VAST_DEBUG("received DOWN from node");
+      VAST_DEBUG_("... received DOWN from node");
       stop = true;
       if (msg.reason != exit_reason::user_shutdown)
         rc = 1;
     },
     [&](system::signal_atom, int signal) {
-      VAST_DEBUG("got " << ::strsignal(signal));
+      VAST_DEBUG_("... got " << ::strsignal(signal));
       if (signal == SIGINT || signal == SIGTERM)
         self->send_exit(node, exit_reason::user_shutdown);
       else

--- a/libvast/src/system/writer_command_base.cpp
+++ b/libvast/src/system/writer_command_base.cpp
@@ -47,7 +47,7 @@ int writer_command_base::run_impl(caf::actor_system& sys,
     self->send_exit(sig_mon, exit_reason::user_shutdown);
   });
   // Spawn a sink.
-  VAST_DEBUG(this, "spawning sink with parameters:", deep_to_string(options));
+  VAST_DEBUG(this, "spawns sink with parameters:", deep_to_string(options));
   auto snk_opt = make_sink(self, options, begin, end);
   if (!snk_opt) {
     std::cerr << "unable to spawn sink: " << sys.render(snk_opt.error())
@@ -70,7 +70,7 @@ int writer_command_base::run_impl(caf::actor_system& sys,
     args += make_message("--unified");
   auto max_events = get_or<uint64_t>(options, "events", 0u);
   args += make_message("-e", std::to_string(max_events));
-  VAST_DEBUG(this, "spawning exporter with parameters:", to_string(args));
+  VAST_DEBUG(this, "spawns exporter with parameters:", to_string(args));
   self->request(node, infinite, "spawn", args).receive(
     [&](const actor& a) {
       exp = a;

--- a/libvast/src/table_index.cpp
+++ b/libvast/src/table_index.cpp
@@ -118,7 +118,7 @@ caf::error table_index::add(const const_table_slice_handle& x) {
         auto& value_type = f.trace.back()->type;
         if (!has_skip_attribute(layout())) {
           auto fac = [&] {
-            VAST_DEBUG(this, "making field indexer at offset", f.offset,
+            VAST_DEBUG(this, "makes field indexer at offset", f.offset,
                        "with type", value_type);
             auto dir = key_to_dir(f.key(), data_dir());
             return make_column_index(sys_, dir, value_type, i);

--- a/libvast/src/table_index.cpp
+++ b/libvast/src/table_index.cpp
@@ -118,8 +118,8 @@ caf::error table_index::add(const const_table_slice_handle& x) {
         auto& value_type = f.trace.back()->type;
         if (!has_skip_attribute(layout())) {
           auto fac = [&] {
-            VAST_DEBUG("make field indexer at offset", f.offset, "with type",
-                       value_type);
+            VAST_DEBUG(this, "making field indexer at offset", f.offset,
+                       "with type", value_type);
             auto dir = key_to_dir(f.key(), data_dir());
             return make_column_index(sys_, dir, value_type, i);
           };
@@ -261,7 +261,7 @@ caf::expected<bitmap> table_index::lookup_impl(const predicate& pred,
     // Redirect to ordinary data lookup on column 0.
     return lookup_impl(pred, dx, x);
   }
-  VAST_WARNING("unsupported attribute:", ex.attr);
+  VAST_WARNING(this, "unsupported attribute:", ex.attr);
   return ec::invalid_query;
 }
 
@@ -280,7 +280,7 @@ caf::expected<bitmap> table_index::lookup_impl(const predicate& pred,
   VAST_ASSERT(t);
   auto index = r.flat_index_at(dx.offset);
   if (!index) {
-    VAST_DEBUG("invalid offset for record type", dx.type);
+    VAST_DEBUG(this, "invalid offset for record type", dx.type);
     return bitmap{};
   }
   auto fac = [&] {

--- a/libvast/src/table_index.cpp
+++ b/libvast/src/table_index.cpp
@@ -261,7 +261,7 @@ caf::expected<bitmap> table_index::lookup_impl(const predicate& pred,
     // Redirect to ordinary data lookup on column 0.
     return lookup_impl(pred, dx, x);
   }
-  VAST_WARNING(this, "unsupported attribute:", ex.attr);
+  VAST_WARNING(this, "got unsupported attribute:", ex.attr);
   return ec::invalid_query;
 }
 
@@ -280,7 +280,7 @@ caf::expected<bitmap> table_index::lookup_impl(const predicate& pred,
   VAST_ASSERT(t);
   auto index = r.flat_index_at(dx.offset);
   if (!index) {
-    VAST_DEBUG(this, "invalid offset for record type", dx.type);
+    VAST_DEBUG(this, "got invalid offset for record type", dx.type);
     return bitmap{};
   }
   auto fac = [&] {

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -76,7 +76,8 @@ table_slice_ptr table_slice::make_ptr(record_type layout,
   using factory_fun = table_slice_ptr (*)(record_type);
   auto val = sys.runtime_settings().get(impl);
   if (!caf::holds_alternative<generic_fun>(val)) {
-    VAST_ERROR("no factory function stored for implementation key", impl);
+    VAST_ERROR_("table_slice",
+                  "has no factory function for implementation key", impl);
     return nullptr;
   }
   auto fun = reinterpret_cast<factory_fun>(caf::get<generic_fun>(val));

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -76,8 +76,8 @@ table_slice_ptr table_slice::make_ptr(record_type layout,
   using factory_fun = table_slice_ptr (*)(record_type);
   auto val = sys.runtime_settings().get(impl);
   if (!caf::holds_alternative<generic_fun>(val)) {
-    VAST_ERROR_("table_slice",
-                  "has no factory function for implementation key", impl);
+    VAST_ERROR_ANON("table_slice", "has no factory function for implementation key",
+                impl);
     return nullptr;
   }
   auto fun = reinterpret_cast<factory_fun>(caf::get<generic_fun>(val));

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -63,7 +63,7 @@ extern size_t max_flow_age;
 extern size_t max_flows;
 
 /// The unique ID of this node.
-extern std::string node_id;
+extern const char* node_id;
 
 } // namespace command
 

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -203,4 +203,38 @@ using detected_or = detector<Default, void, Op, Args...>;
 template <class Default, template<class...> class Op, class... Args>
 using detected_or_t = typename detected_or<Default, Op, Args...>::type;
 
+// -- operator availability --------------------------------------------------
+
+template <typename T>
+using ostream_operator_t
+  = decltype(std::declval<std::ostream&>() << std::declval<T>());
+
+template <typename T>
+inline constexpr bool has_ostream_operator
+  = is_detected_v<ostream_operator_t, T>;
+
+// -- checks for stringification functions -----------------------------------
+
+template <typename T>
+using to_string_t = decltype(to_string(std::declval<T>()));
+
+template <typename T>
+inline constexpr bool has_to_string = is_detected_v<to_string_t, T>;
+
+template <typename T>
+using name_getter_t =
+  typename std::is_convertible<decltype(std::declval<T>().name()),
+                               std::string_view>::type;
+
+template <typename T>
+inline constexpr bool has_name_getter = is_detected_v<name_getter_t, T>;
+
+template <typename T>
+using name_member_t =
+  typename std::is_convertible<decltype(std::declval<T>().name),
+                               std::string_view>::type;
+
+template <typename T>
+inline constexpr bool has_name_member = is_detected_v<name_member_t, T>;
+
 } // namespace vast::detail

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -15,6 +15,7 @@
 
 #include <caf/logger.hpp>
 
+#include "vast/config.hpp"
 #include "vast/detail/pp.hpp"
 #include "vast/detail/type_traits.hpp"
 

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -58,13 +58,22 @@ auto id_or_name(T&& x) {
     "const char* is not allowed for the first argument in a logging statement"
     "supply a component or use `VAST_[ERROR|WARNING|INFO|DEBUG]_ANON` instead");
 
-  using Type = std::remove_pointer_t<T>;
-  if constexpr (has_ostream_operator<Type>)
-    return x;
-  else if constexpr (has_to_string<Type>)
-    return to_string(*x);
-  else
-    return caf::detail::pretty_type_name(typeid(Type));
+  if constexpr (std::is_pointer_v<T>) {
+    using value_type = std::remove_pointer_t<T>;
+    if constexpr (has_ostream_operator<value_type>)
+      return *x;
+    else if constexpr (has_to_string<value_type>)
+      return to_string(*x);
+    else
+      return caf::detail::pretty_type_name(typeid(value_type));
+  } else {
+    if constexpr (has_ostream_operator<T>)
+      return x;
+    else if constexpr (has_to_string<T>)
+      return to_string(x);
+    else
+      return caf::detail::pretty_type_name(typeid(T));
+  }
 }
 } // namespace vast::detail
 #define VAST_LOG_COMPONENT(lvl, m, ...)                                        \
@@ -85,35 +94,35 @@ auto id_or_name(T&& x) {
 
 #if VAST_LOG_LEVEL >= 0
 #define VAST_ERROR(...) VAST_LOG_COMPONENT(CAF_LOG_LEVEL_ERROR, __VA_ARGS__)
-#define VAST_ERROR_(...) VAST_LOG(CAF_LOG_LEVEL_ERROR, __VA_ARGS__)
+#define VAST_ERROR_ANON(...) VAST_LOG(CAF_LOG_LEVEL_ERROR, __VA_ARGS__)
 #else
 #define VAST_ERROR(...) CAF_VOID_STMT
-#define VAST_ERROR_(...) CAF_VOID_STMT
+#define VAST_ERROR_ANON(...) CAF_VOID_STMT
 #endif
 
 
 #if VAST_LOG_LEVEL >= 1
 #define VAST_WARNING(...) VAST_LOG_COMPONENT(CAF_LOG_LEVEL_WARNING, __VA_ARGS__)
-#define VAST_WARNING_(...) VAST_LOG(CAF_LOG_LEVEL_WARNING, __VA_ARGS__)
+#define VAST_WARNING_ANON(...) VAST_LOG(CAF_LOG_LEVEL_WARNING, __VA_ARGS__)
 #else
 #define VAST_WARNING(...) CAF_VOID_STMT
-#define VAST_WARNING_(...) CAF_VOID_STMT
+#define VAST_WARNING_ANON(...) CAF_VOID_STMT
 #endif
 
 #if VAST_LOG_LEVEL >= 2
 #define VAST_INFO(...) VAST_LOG_COMPONENT(CAF_LOG_LEVEL_INFO, __VA_ARGS__)
-#define VAST_INFO_(...) VAST_LOG(CAF_LOG_LEVEL_INFO, __VA_ARGS__)
+#define VAST_INFO_ANON(...) VAST_LOG(CAF_LOG_LEVEL_INFO, __VA_ARGS__)
 #else
 #define VAST_INFO(...) CAF_VOID_STMT
-#define VAST_INFO_(...) CAF_VOID_STMT
+#define VAST_INFO_ANON(...) CAF_VOID_STMT
 #endif
 
 #if VAST_LOG_LEVEL >= 3
 #define VAST_DEBUG(...) VAST_LOG_COMPONENT(CAF_LOG_LEVEL_DEBUG, __VA_ARGS__)
-#define VAST_DEBUG_(...) VAST_LOG(CAF_LOG_LEVEL_DEBUG, __VA_ARGS__)
+#define VAST_DEBUG_ANON(...) VAST_LOG(CAF_LOG_LEVEL_DEBUG, __VA_ARGS__)
 #else
 #define VAST_DEBUG(...) CAF_VOID_STMT
-#define VAST_DEBUG_(...) CAF_VOID_STMT
+#define VAST_DEBUG_ANON(...) CAF_VOID_STMT
 #endif
 
 #else // defined(VAST_LOG_LEVEL)
@@ -125,16 +134,16 @@ auto id_or_name(T&& x) {
 #define VAST_TRACE(...) CAF_VOID_STMT
 
 #define VAST_ERROR(...) CAF_VOID_STMT
-#define VAST_ERROR_(...) CAF_VOID_STMT
+#define VAST_ERROR_ANON(...) CAF_VOID_STMT
 
 #define VAST_WARNING(...) CAF_VOID_STMT
-#define VAST_WARNING_(...) CAF_VOID_STMT
+#define VAST_WARNING_ANON(...) CAF_VOID_STMT
 
 #define VAST_INFO(...) CAF_VOID_STMT
-#define VAST_INFO_(...) CAF_VOID_STMT
+#define VAST_INFO_ANON(...) CAF_VOID_STMT
 
 #define VAST_DEBUG(...) CAF_VOID_STMT
-#define VAST_DEBUG_(...) CAF_VOID_STMT
+#define VAST_DEBUG_ANON(...) CAF_VOID_STMT
 
 #endif // defined(VAST_LOG_LEVEL)
 

--- a/libvast/vast/save.hpp
+++ b/libvast/vast/save.hpp
@@ -57,9 +57,9 @@ caf::error save(caf::actor_system& sys, Sink&& out, const Ts&... xs) {
     return save<Method>(sys, sink, xs...);
   } else if constexpr (std::is_same_v<sink_type, path>) {
     if (auto dir = out.parent(); !exists(dir)) {
-      VAST_DEBUG_(__func__, "creating directory", dir);
+      VAST_DEBUG_ANON(__func__, "creating directory", dir);
       if (auto res = mkdir(dir); !res) {
-        VAST_DEBUG_(__func__, "failed to create directory", dir);
+        VAST_DEBUG_ANON(__func__, "failed to create directory", dir);
         return res.error();
       }
     }
@@ -74,4 +74,3 @@ caf::error save(caf::actor_system& sys, Sink&& out, const Ts&... xs) {
 }
 
 } // namespace vast
-

--- a/libvast/vast/save.hpp
+++ b/libvast/vast/save.hpp
@@ -57,9 +57,9 @@ caf::error save(caf::actor_system& sys, Sink&& out, const Ts&... xs) {
     return save<Method>(sys, sink, xs...);
   } else if constexpr (std::is_same_v<sink_type, path>) {
     if (auto dir = out.parent(); !exists(dir)) {
-      VAST_DEBUG("creating directory", dir);
+      VAST_DEBUG_(__func__, "creating directory", dir);
       if (auto res = mkdir(dir); !res) {
-        VAST_DEBUG("failed to create directory", dir);
+        VAST_DEBUG_(__func__, "failed to create directory", dir);
         return res.error();
       }
     }

--- a/libvast/vast/system/indexer_manager.hpp
+++ b/libvast/vast/system/indexer_manager.hpp
@@ -44,7 +44,7 @@ public:
       VAST_ASSERT(a != nullptr);
       auto resolved = caf::visit(type_resolver{t}, expr);
       if (resolved && caf::visit(matcher{t}, *resolved)) {
-        VAST_DEBUG("found matching type for expression:", t);
+        VAST_DEBUG(this, "found matching type for expression:", t);
         f(a);
         ++num;
       }

--- a/libvast/vast/system/sink.hpp
+++ b/libvast/vast/system/sink.hpp
@@ -71,7 +71,7 @@ caf::behavior sink(caf::stateful_actor<sink_state<Writer>>* self,
       for (auto& x : xs) {
         auto r = self->state.writer.write(x);
         if (!r) {
-          VAST_ERROR(self->system().render(r.error()));
+          VAST_ERROR(self, self->system().render(r.error()));
           self->quit(r.error());
           return;
         }

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -188,14 +188,14 @@ struct source_state {
         // Skip bogus input that failed to parse.
         auto& err = maybe_e.error();
         if (err == ec::parse_error) {
-          VAST_WARNING(self->system().render(err));
+          VAST_WARNING(self, self->system().render(err));
           continue;
         }
         // Log unexpected errors and when reaching the end of input.
         if (err == ec::end_of_input) {
-          VAST_INFO(self->system().render(err));
+          VAST_INFO(self, self->system().render(err));
         } else {
-          VAST_ERROR(self->system().render(err));
+          VAST_ERROR(self, self->system().render(err));
         }
         /// Produce one final slices if possible.
         for (auto& kvp : builders) {

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -193,7 +193,7 @@ struct source_state {
         }
         // Log unexpected errors and when reaching the end of input.
         if (err == ec::end_of_input) {
-          VAST_INFO(self, self->system().render(err));
+          VAST_DEBUG(self, self->system().render(err));
         } else {
           VAST_ERROR(self, self->system().render(err));
         }
@@ -223,10 +223,10 @@ struct source_state {
       }
       /// Add meta column(s).
       if (auto ts = e.timestamp(); !bptr->add(ts))
-        VAST_INFO(self, "failed to add timestamp", ts);
+        VAST_WARNING(self, "failed to add timestamp", ts);
       /// Add data column(s).
       if (auto data = e.data(); !bptr->recursive_add(data, e.type()))
-        VAST_INFO(self, "failed to add data", data);
+        VAST_WARNING(self, "failed to add data", data);
       ++produced;
       if (bptr->rows() == table_slice_size)
         finish_slice(bptr);


### PR DESCRIPTION
This PR attempts to make the VASTs log more consistent.

Tasks:
- [x] Let `VAST_{ERROR,WARNING,INFO,DEBUG}` reject `const char*` as its first parameter
- [x] Add `VAST_{ERROR,WARNING,INFO,DEBUG}_` to bypass this check.
- [x] Convert messages to *subject verb object* style
- [x] Reserve `VAST_INFO` to the main system actors (SINK, SOURCE, IMPORTER, ARCHIVE, INDEX, EXPORTER)
- [x] Add logging guidelines to`CONTRIBUTING.md`