### PR TITLE
Detect build_config.hpp in build directories

### DIFF
--- a/cmake/FindCAF.cmake
+++ b/cmake/FindCAF.cmake
@@ -22,18 +22,6 @@ if(CAF_FIND_COMPONENTS STREQUAL "")
   message(FATAL_ERROR "FindCAF requires at least one COMPONENT.")
 endif()
 
-macro(add_include_dir new_dir)
-  set(duplicate false)
-  foreach (p ${CAF_INCLUDE_DIRS})
-    if (${p} STREQUAL ${new_dir})
-      set(duplicate true)
-    endif ()
-  endforeach ()
-  if (NOT duplicate)
-    set(CAF_INCLUDE_DIRS ${CAF_INCLUDE_DIRS} ${new_dir})
-  endif()
-endmacro()
-
 # iterate over user-defined components
 foreach (comp ${CAF_FIND_COMPONENTS})
   # we use uppercase letters only for variable names
@@ -83,10 +71,10 @@ foreach (comp ${CAF_FIND_COMPONENTS})
         message(WARNING "Found all.hpp for CAF core, but not build_config.hpp")
         set(CAF_${comp}_FOUND false)
       else()
-        add_include_dir("${caf_build_header_path}")
+        list(APPEND CAF_INCLUDE_DIRS "${caf_build_header_path}")
       endif()
     endif()
-    add_include_dir("${CAF_INCLUDE_DIR_${UPPERCOMP}}")
+    list(APPEND CAF_INCLUDE_DIRS "${CAF_INCLUDE_DIR_${UPPERCOMP}}")
     # look for (.dll|.so|.dylib) file, again giving hints for non-installed CAFs
     # skip probe_event as it is header only
     if (NOT ${comp} STREQUAL "probe_event" AND NOT ${comp} STREQUAL "test")
@@ -113,6 +101,8 @@ foreach (comp ${CAF_FIND_COMPONENTS})
     endif ()
   endif ()
 endforeach ()
+
+list(REMOVE_DUPLICATES CAF_INCLUDE_DIRS)
 
 # let CMake check whether all requested components have been found
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindCAF.cmake
+++ b/cmake/FindCAF.cmake
@@ -1,8 +1,8 @@
-# Try to find CAF headers and library.
+# Try to find CAF headers and libraries.
 #
 # Use this module as follows:
 #
-#     find_package(CAF)
+#     find_package(CAF [COMPONENTS <core|io|opencl|...>*] [REQUIRED])
 #
 # Variables used by this module (they can change the default behaviour and need
 # to be set before calling find_package):
@@ -18,6 +18,22 @@
 #  CAF_LIBRARY_$C         Library file for component $C
 #  CAF_INCLUDE_DIR_$C     Include path for component $C
 
+if(CAF_FIND_COMPONENTS STREQUAL "")
+  message(FATAL_ERROR "FindCAF requires at least one COMPONENT.")
+endif()
+
+macro(add_include_dir new_dir)
+  set(duplicate false)
+  foreach (p ${CAF_INCLUDE_DIRS})
+    if (${p} STREQUAL ${new_dir})
+      set(duplicate true)
+    endif ()
+  endforeach ()
+  if (NOT duplicate)
+    set(CAF_INCLUDE_DIRS ${CAF_INCLUDE_DIRS} ${new_dir})
+  endif()
+endmacro()
+
 # iterate over user-defined components
 foreach (comp ${CAF_FIND_COMPONENTS})
   # we use uppercase letters only for variable names
@@ -32,7 +48,9 @@ foreach (comp ${CAF_FIND_COMPONENTS})
   if (CAF_ROOT_DIR)
     set(header_hints
         "${CAF_ROOT_DIR}/include"
-        "${CAF_ROOT_DIR}/../libcaf_${comp}")
+        "${CAF_ROOT_DIR}/libcaf_${comp}"
+        "${CAF_ROOT_DIR}/../libcaf_${comp}"
+        "${CAF_ROOT_DIR}/../../libcaf_${comp}")
   endif ()
   find_path(CAF_INCLUDE_DIR_${UPPERCOMP}
             NAMES
@@ -47,18 +65,28 @@ foreach (comp ${CAF_FIND_COMPONENTS})
   mark_as_advanced(CAF_INCLUDE_DIR_${UPPERCOMP})
   if (NOT "${CAF_INCLUDE_DIR_${UPPERCOMP}}"
       STREQUAL "CAF_INCLUDE_DIR_${UPPERCOMP}-NOTFOUND")
-    # mark as found (set back to false in case library cannot be found)
+    # mark as found (set back to false when missing library or build header)
     set(CAF_${comp}_FOUND true)
-    # add to CAF_INCLUDE_DIRS only if path isn't already set
-    set(duplicate false)
-    foreach (p ${CAF_INCLUDE_DIRS})
-      if (${p} STREQUAL ${CAF_INCLUDE_DIR_${UPPERCOMP}})
-        set(duplicate true)
-      endif ()
-    endforeach ()
-    if (NOT duplicate)
-      set(CAF_INCLUDE_DIRS ${CAF_INCLUDE_DIRS} ${CAF_INCLUDE_DIR_${UPPERCOMP}})
+    # check for CMake-generated build header for the core component
+    if ("${comp}" STREQUAL "core")
+      find_path(caf_build_header_path
+                NAMES
+                  caf/detail/build_config.hpp
+                HINTS
+                  ${header_hints}
+                  /usr/include
+                  /usr/local/include
+                  /opt/local/include
+                  /sw/include
+                  ${CMAKE_INSTALL_PREFIX}/include)
+      if ("${caf_build_header_path}" STREQUAL "caf_build_header_path-NOTFOUND")
+        message(WARNING "Found all.hpp for CAF core, but not build_config.hpp")
+        set(CAF_${comp}_FOUND false)
+      else()
+        add_include_dir("${caf_build_header_path}")
+      endif()
     endif()
+    add_include_dir("${CAF_INCLUDE_DIR_${UPPERCOMP}}")
     # look for (.dll|.so|.dylib) file, again giving hints for non-installed CAFs
     # skip probe_event as it is header only
     if (NOT ${comp} STREQUAL "probe_event" AND NOT ${comp} STREQUAL "test")


### PR DESCRIPTION
Fix `FindCAF.cmake` to work with CAF build directories again.