### PR TITLE
Add configure option for no-omit-frame-pointer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ set(LDFLAGS "$ENV{LDFLAGS}")
 
 # Ninja doesn't colorize compiler diagnostics by default.
 if (CMAKE_GENERATOR STREQUAL "Ninja")
-  set(EXTRA_FLAGS "-fdiagnostics-color")
+  set(EXTRA_FLAGS "${EXTRA_FLAGS} -fdiagnostics-color")
 endif ()
 
 # To give the user full control, we don't mess with with CXX_FLAGS if provided.

--- a/configure
+++ b/configure
@@ -30,6 +30,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --show-time-report      show where the compiler spends its time
     --no-auto-libc++        do not automatically use libc++ with Clang
     --more-warnings         enables most warnings on GCC and Clang
+    --no-omit-frame-pointer forces -fno-omit-frame-pointer for all builds
 
   Debugging:
     --log-level=LEVEL       maximum compile-time log level [debug]
@@ -146,8 +147,11 @@ while [ $# -ne 0 ]; do
       append_cache_entry NO_AUTO_LIBCPP BOOL yes
       ;;
     --more-warnings)
-        append_cache_entry MORE_WARNINGS BOOL yes
-        ;;
+      append_cache_entry MORE_WARNINGS BOOL yes
+      ;;
+    --no-omit-frame-pointer)
+      append_cache_entry EXTRA_FLAGS STRING "-fno-omit-frame-pointer"
+      ;;
     --log-level=*)
       append_cache_entry VAST_LOG_LEVEL INTEGER $(levelize $optarg)
       ;;


### PR DESCRIPTION
Generating flame graphs for release builds requires setting this flag.
However, setting the flag via `CXX_FLAGS` is cumbersome. Mainly, because
VAST has the bad habit to completely bypass any setup when passing any
flags instead of extending the flags.