### PR TITLE
Fix parsing of CAF options

### DIFF
--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -67,6 +67,9 @@ configuration& configuration::parse(int argc, char** argv) {
   std::vector<std::string> caf_args;
   std::move(caf_opt, command_line.end(), std::back_inserter(caf_args));
   command_line.erase(caf_opt, command_line.end());
+  // Remove caf# suffix for CAF parser.
+  for (auto& arg : caf_args)
+    arg.erase(2, 4);
   actor_system_config::parse(std::move(caf_args));
   return *this;
 }


### PR DESCRIPTION
CAF no longer accepts the old `caf#` prefix. However, it's still useful to continue using it for disambiguation with command options. This patch simply removes the `caf#` prefix before passing the options to CAF's parser.