### PR TITLE
Flatten namespace vast::{system:: => }detail

### DIFF
--- a/libvast/src/system/task.cpp
+++ b/libvast/src/system/task.cpp
@@ -21,8 +21,8 @@
 
 using namespace caf;
 
-namespace vast {
-namespace system {
+namespace vast::system {
+
 namespace {
 
 template <class Actor>
@@ -52,9 +52,7 @@ void complete(Actor self, const actor_addr& a) {
 
 } // namespace <anonymous>
 
-namespace detail {
-
-behavior task(stateful_actor<task_state>* self, message done_msg) {
+behavior task_impl(stateful_actor<task_state>* self, message done_msg) {
   self->state.done_msg = std::move(done_msg);
   self->set_exit_handler(
     [=](const exit_msg& msg) {
@@ -105,7 +103,4 @@ behavior task(stateful_actor<task_state>* self, message done_msg) {
   };
 }
 
-} // namespace detail
-
-} // namespace system
-} // namespace vast
+} // namespace vast::system

--- a/libvast/vast/system/replicated_store.hpp
+++ b/libvast/vast/system/replicated_store.hpp
@@ -97,10 +97,13 @@ private:
   caf::actor_id id_;
 };
 
-namespace detail {
+} // namespace vast::system
+
+namespace vast::detail {
 
 template <class Actor>
 auto apply(Actor* self, caf::message& operation) {
+  using namespace vast::system;
   using key_type = typename decltype(self->state.store)::key_type;
   using value_type = typename decltype(self->state.store)::mapped_type;
   return *operation.apply({
@@ -126,6 +129,7 @@ auto apply(Actor* self, caf::message& operation) {
 // Applies a mutable operation coming from the consensus module.
 template <class Actor>
 void update(Actor* self, caf::message& command) {
+  using namespace vast::system;
   command.apply({
     [=](const actor_identity& identity, uint64_t id, caf::message operation) {
       if (identity != self->address()) {
@@ -156,6 +160,7 @@ void update(Actor* self, caf::message& command) {
 template <class Actor>
 void replicate(Actor* self, const caf::actor& consensus,
                caf::response_promise rp) {
+  using namespace vast::system;
   auto operation = self->current_mailbox_element()->move_content_to_message();
   auto id = ++self->state.request_id;
   self->state.requests.emplace(id, rp);
@@ -171,7 +176,9 @@ void replicate(Actor* self, const caf::actor& consensus,
   );
 }
 
-} // namespace detail
+} // namespace vast::detail
+
+namespace vast::system {
 
 /// A replicated key-value store that sits on top of a consensus module.
 /// @param self The actor handle.

--- a/libvast/vast/system/task.hpp
+++ b/libvast/vast/system/task.hpp
@@ -33,9 +33,8 @@ struct task_state {
   static inline const char* name = "task";
 };
 
-namespace detail {
-caf::behavior task(caf::stateful_actor<task_state>* self, caf::message done);
-} // namespace detail
+caf::behavior task_impl(caf::stateful_actor<task_state>* self,
+                        caf::message done);
 
 /// An abstraction for work consisting of one or more actor. A work item
 /// completes if the corresponding actor terminates or if one marks the actor
@@ -46,7 +45,7 @@ caf::behavior task(caf::stateful_actor<task_state>* self, caf::message done);
 template <class... Ts>
 caf::behavior task(caf::stateful_actor<task_state>* self, Ts... xs) {
   auto done_msg = caf::make_message(done_atom::value, std::move(xs)...);
-  return detail::task(self, std::move(done_msg));
+  return task_impl(self, std::move(done_msg));
 }
 
 } // namespace vast::system


### PR DESCRIPTION
Including VAST headers in the "wrong" order produces a compiler error for ambiguously defined symbols. Culprit here is the namespace `vast::system::detail`.

Having multiple namespaces with the same name is only asking for trouble. Hence, this PR flattens the namespaces into `vast::detail`.