### PR TITLE
Allow sources to pre-allocate builder rows

### DIFF
--- a/libvast/src/default_table_slice_builder.cpp
+++ b/libvast/src/default_table_slice_builder.cpp
@@ -67,4 +67,13 @@ size_t default_table_slice_builder::rows() const noexcept {
   return slice_ == nullptr ? 0u : slice_->xs_.size();
 }
 
+void default_table_slice_builder::reserve(size_t num_rows) {
+  if (!slice_) {
+    slice_ = caf::make_counted<default_table_slice>(layout_);
+    row_ = vector(layout_.fields.size());
+    col_ = 0;
+  }
+  slice_->xs_.reserve(num_rows);
+}
+
 } // namespace vast

--- a/libvast/src/default_table_slice_builder.cpp
+++ b/libvast/src/default_table_slice_builder.cpp
@@ -27,11 +27,7 @@ default_table_slice_builder::default_table_slice_builder(record_type layout)
 }
 
 bool default_table_slice_builder::append(data x) {
-  if (!slice_) {
-    slice_ = caf::make_counted<default_table_slice>(layout_);
-    row_ = vector(layout_.fields.size());
-    col_ = 0;
-  }
+  lazy_init();
   // TODO: consider an unchecked version for improved performance.
   if (!type_check(layout_.fields[col_].type, x))
     return false;
@@ -68,12 +64,16 @@ size_t default_table_slice_builder::rows() const noexcept {
 }
 
 void default_table_slice_builder::reserve(size_t num_rows) {
-  if (!slice_) {
+  lazy_init();
+  slice_->xs_.reserve(num_rows);
+}
+
+void default_table_slice_builder::lazy_init() {
+  if (slice_ == nullptr) {
     slice_ = caf::make_counted<default_table_slice>(layout_);
     row_ = vector(layout_.fields.size());
     col_ = 0;
   }
-  slice_->xs_.reserve(num_rows);
 }
 
 } // namespace vast

--- a/libvast/src/table_slice_builder.cpp
+++ b/libvast/src/table_slice_builder.cpp
@@ -39,4 +39,8 @@ bool table_slice_builder::recursive_add(const data& x, const type& t) {
                     x, t);
 }
 
+void table_slice_builder::reserve(size_t) {
+  // nop
+}
+
 } // namespace vast

--- a/libvast/vast/default_table_slice_builder.hpp
+++ b/libvast/vast/default_table_slice_builder.hpp
@@ -36,6 +36,8 @@ public:
 
   size_t rows() const noexcept final;
 
+  void reserve(size_t num_rows) final;
+
 private:
   // -- member variables -------------------------------------------------------
 

--- a/libvast/vast/default_table_slice_builder.hpp
+++ b/libvast/vast/default_table_slice_builder.hpp
@@ -39,6 +39,11 @@ public:
   void reserve(size_t num_rows) final;
 
 private:
+  // -- utility functions ------------------------------------------------------
+
+  /// Allocates `slice_` and resets related state if necessary.
+  void lazy_init();
+
   // -- member variables -------------------------------------------------------
 
   record_type layout_;

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -137,7 +137,7 @@ struct source_state {
   }
 
   /// Tries to access the builder for `layout`.
-  table_slice_builder* builder(const type& layout) {
+  table_slice_builder* builder(const type& layout, size_t table_slice_size) {
     auto i = builders.find(layout.name());
     if (i != builders.end())
       return i->second.get();
@@ -151,6 +151,7 @@ struct source_state {
                                  std::move(tstamp_field));
           auto& ref = builders[layout.name()];
           ref = factory(internal);
+          ref->reserve(table_slice_size);
           return ref.get();
         },
         [&](auto&) -> table_slice_builder* {
@@ -206,7 +207,7 @@ struct source_state {
         return {produced, true};
       }
       auto& e = *maybe_e;
-      auto bptr = builder(e.type());
+      auto bptr = builder(e.type(), table_slice_size);
       if (bptr == nullptr)
         continue;
       if (!caf::holds_alternative<caf::none_t>(filter)) {

--- a/libvast/vast/table_slice_builder.hpp
+++ b/libvast/vast/table_slice_builder.hpp
@@ -50,6 +50,10 @@ public:
 
   /// @returns the current number of rows in the table slice.
   virtual size_t rows() const noexcept = 0;
+
+  /// Allows the table slice builder to allocate sufficient storage for up to
+  /// `num_rows` rows.
+  virtual void reserve(size_t num_rows);
 };
 
 /// @relates table_slice_builder


### PR DESCRIPTION
The table slice builder usually knows beforehand how many rows we're about to add. Giving it a parameter for calling `reserve` on the internal vector avoids unnecessary allocations.