### PR TITLE
Quit exporter in case of error

### DIFF
--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -295,9 +295,6 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
           }
         },
         [=](const error& e) {
-          VAST_IGNORE_UNUSED(e);
-          VAST_DEBUG(self, "failed to lookup query at index:",
-                     self->system().render(e));
           shutdown(self, e);
         }
       );

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -82,14 +82,14 @@ int sink_command::run_impl(caf::actor_system& sys,
   );
   if (!exp) {
     self->send_exit(snk, exit_reason::user_shutdown);
-    return 1;
+    return EXIT_FAILURE;
   }
   // Start the exporter.
   self->send(exp, system::sink_atom::value, snk);
   self->send(exp, system::run_atom::value);
   self->monitor(snk);
   self->monitor(exp);
-  auto rc = 0;
+  auto rc = EXIT_SUCCESS;
   auto stop = false;
   self->do_receive(
     [&](const down_msg& msg) {
@@ -97,14 +97,14 @@ int sink_command::run_impl(caf::actor_system& sys,
         VAST_DEBUG(this, "received DOWN from node");
         self->send_exit(snk, exit_reason::user_shutdown);
         self->send_exit(exp, exit_reason::user_shutdown);
-        rc = 1;
+        rc = EXIT_FAILURE;
       } else if (msg.source == exp) {
         VAST_DEBUG(this, "received DOWN from exporter");
         self->send_exit(snk, exit_reason::user_shutdown);
       } else if (msg.source == snk) {
         VAST_DEBUG(this, "received DOWN from sink");
         self->send_exit(exp, exit_reason::user_shutdown);
-        rc = 1;
+        rc = EXIT_FAILURE;
       } else {
         VAST_ASSERT(!"received DOWN from inexplicable actor");
       }

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -108,6 +108,11 @@ int sink_command::run_impl(caf::actor_system& sys,
       } else {
         VAST_ASSERT(!"received DOWN from inexplicable actor");
       }
+      if (msg.reason) {
+        VAST_WARNING(
+          this, "received error message:", self->system().render(msg.reason));
+        rc = EXIT_FAILURE;
+      }
       stop = true;
     },
     [&](system::signal_atom, int signal) {


### PR DESCRIPTION
Before this change the exporter would not terminate itself when it received an error from the index. This is the fix.