### PR TITLE
Remove distinction between meta and data columns

### DIFF
--- a/libvast/src/column_index.cpp
+++ b/libvast/src/column_index.cpp
@@ -36,27 +36,6 @@ caf::expected<column_index_ptr> init_res(column_index_ptr res) {
 
 } // namespace <anonymous>
 
-caf::expected<column_index_ptr> make_type_column_index(caf::actor_system& sys,
-                                                       path filename) {
-  struct impl : column_index {
-    impl(caf::actor_system& sys, path&& fname)
-      : column_index(sys, string_type{}, std::move(fname)) {
-      // nop
-    }
-
-    void add(const table_slice_ptr& x) override {
-      VAST_TRACE(VAST_ARG(x));
-      if (has_skip_attribute_)
-        return;
-      auto tn = x->layout().name();
-      auto offset = x->offset();
-      for (table_slice::size_type row = 0; row < x->rows(); ++row)
-        idx_->append(make_data_view(tn), offset + row);
-    }
-  };
-  return init_res(std::make_unique<impl>(sys, std::move(filename)));
-}
-
 caf::expected<column_index_ptr> make_column_index(caf::actor_system& sys,
                                                   path filename,
                                                   type column_type,

--- a/libvast/src/table_index.cpp
+++ b/libvast/src/table_index.cpp
@@ -108,15 +108,9 @@ caf::error table_index::add(const table_slice_ptr& x) {
   auto first = x->offset();
   auto last = x->offset() + x->rows();
   VAST_ASSERT(first < last);
-  if (first >= row_ids_.size()) {
-    row_ids_.append_bits(false, first - row_ids_.size());
-    row_ids_.append_bits(true, last - first);
-  } else {
-    ids tmp;
-    tmp.append_bits(false, first);
-    tmp.append_bits(true, last - first);
-    row_ids_ |= tmp;
-  }
+  VAST_ASSERT(first >= row_ids_.size());
+  row_ids_.append_bits(false, first - row_ids_.size());
+  row_ids_.append_bits(true, last - first);
   // Iterate columns directly if all columns are present in memory.
   if (dirty_) {
     for (auto& col : columns_) {

--- a/libvast/src/table_index.cpp
+++ b/libvast/src/table_index.cpp
@@ -35,10 +35,13 @@ auto key_to_dir(std::string key, const path& prefix) {
 
 caf::expected<table_index> make_table_index(caf::actor_system& sys,
                                             path base_dir, record_type layout) {
+  // Layouts need to be flat.
+  VAST_ASSERT(layout.fields.size() == flat_size(layout));
+  VAST_TRACE(VAST_ARG(base_dir), VAST_ARG(layout));
   caf::error err;
   table_index result{sys, std::move(layout), base_dir};
-  result.columns_.resize(table_index::meta_column_count
-                         + flat_size(result.layout()));
+  if (auto err = result.init())
+    return err;
   return result;
 }
 
@@ -55,14 +58,25 @@ table_index::~table_index() noexcept {
 
 // -- persistence --------------------------------------------------------------
 
+caf::error table_index::init() {
+  VAST_TRACE("");
+  columns_.resize(layout().fields.size());
+  auto filename = base_dir_ / "row_ids";
+  if (exists(filename))
+    return load(sys_, filename, row_ids_);
+  return caf::none;
+}
+
 caf::error table_index::flush_to_disk() {
   // Unless `add` was called at least once there's nothing to flush.
+  VAST_TRACE("");
   if (!dirty_)
     return caf::none;
+  if (auto err = save(sys_, base_dir_ / "row_ids", row_ids_))
+    return err;
   for (auto& col : columns_) {
     VAST_ASSERT(col != nullptr);
-    auto err = col->flush_to_disk();
-    if (err)
+    if (auto err = col->flush_to_disk())
       return err;
   }
   dirty_ = false;
@@ -90,6 +104,20 @@ caf::error table_index::add(const table_slice_ptr& x) {
   VAST_ASSERT(x != nullptr);
   VAST_ASSERT(x->layout() == layout());
   VAST_TRACE(VAST_ARG(x));
+  // Store IDs of the new rows.
+  auto first = x->offset();
+  auto last = x->offset() + x->rows();
+  VAST_ASSERT(first < last);
+  if (first >= row_ids_.size()) {
+    row_ids_.append_bits(false, first - row_ids_.size());
+    row_ids_.append_bits(true, last - first);
+  } else {
+    ids tmp;
+    tmp.append_bits(false, first);
+    tmp.append_bits(true, last - first);
+    row_ids_ |= tmp;
+  }
+  // Iterate columns directly if all columns are present in memory.
   if (dirty_) {
     for (auto& col : columns_) {
       VAST_ASSERT(col != nullptr);
@@ -97,20 +125,13 @@ caf::error table_index::add(const table_slice_ptr& x) {
     }
     return caf::none;
   }
+  // Create columns on-the-fly.
   auto fun = [&](column_index& col) -> caf::error {
     col.add(x);
     return caf::none;
   };
-  auto mk_type = [&] {
-    return make_type_column_index(sys_, meta_dir() / "type");
-  };
   return caf::error::eval(
-    [&] {
-      // Column 0 is our meta index for the event type.
-      return with_meta_column(0, mk_type, fun);
-    },
     [&]() -> caf::error {
-      // Coluns 1-N are our data fields.
       // Iterate all types of the record.
       size_t i = 0;
       for (auto&& f : record_type::each{layout()}) {
@@ -122,8 +143,7 @@ caf::error table_index::add(const table_slice_ptr& x) {
             auto dir = key_to_dir(f.key(), data_dir());
             return make_column_index(sys_, dir, value_type, i);
           };
-          auto err = with_data_column(i, fac, fun);
-          if (err)
+          if (auto err = with_column(i, fac, fun))
             return err;
           ++i;
         }
@@ -235,22 +255,15 @@ caf::expected<bitmap> table_index::lookup_impl(const predicate& pred,
                                                const attribute_extractor& ex,
                                                const data& x) {
   VAST_TRACE(VAST_ARG(pred), VAST_ARG(ex), VAST_ARG(x));
-  VAST_IGNORE_UNUSED(x);
-  // We know that the columns vector contains two meta fields: time at index
-  // 0 and type at index 1.
-  static_assert(table_index::meta_column_count == 1);
-  VAST_ASSERT(columns_.size() >= table_index::meta_column_count);
   if (ex.attr == "type") {
     VAST_ASSERT(caf::holds_alternative<std::string>(x));
-    auto fac = [&] {
-      return make_type_column_index(sys_, meta_dir() / "type");
-    };
-    return with_meta_column(0, fac, [&](column_index& col) {
-      return col.lookup(pred);
-    });
+    // No hits if the queries name doesn't match our type.
+    if (layout().name() != caf::get<std::string>(x))
+      return ids{};
+    // Otherwise all rows match.
+    return row_ids_;
   } else if (ex.attr == "time") {
     // TODO: reconsider whether we still want to support "&time ..." queries.
-    /// We assume column 0 to hold the timestamp.
     VAST_ASSERT(caf::holds_alternative<timestamp>(x));
     if (layout().fields.empty() || layout().fields[0].type != timestamp_type{})
       return ec::invalid_query;
@@ -286,7 +299,7 @@ caf::expected<bitmap> table_index::lookup_impl(const predicate& pred,
     auto dir = key_to_dir(*k, data_dir());
     return make_column_index(sys_, dir, *t, *index);
   };
-  return with_data_column(*index, fac, [&](column_index& col) {
+  return with_column(*index, fac, [&](column_index& col) {
     return col.lookup(pred);
   });
   return bitmap{};

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -272,16 +272,10 @@ TEST(multiple partitions bro conn log lookup no messaging) {
         CHECK(path_set.emplace(col->filename()).second);
         auto idx_offset = std::min((i + 1) * slice_size, bro_conn_log.size());
         CHECK_EQUAL(col->idx().offset(), idx_offset);
-        if (col_id == 0) {
-          // First (and only) meta field is the type.
-          CHECK_EQUAL(col->index_type(), string_type{});
-        } else {
-          // Data field.
-          offset off{col_id - 1};
-          auto type_at_offset = layout.at(off);
-          REQUIRE_NOT_EQUAL(type_at_offset, nullptr);
-          CHECK_EQUAL(col->index_type(), *type_at_offset);
-        }
+        offset off{col_id};
+        auto type_at_offset = layout.at(off);
+        REQUIRE_NOT_EQUAL(type_at_offset, nullptr);
+        CHECK_EQUAL(col->index_type(), *type_at_offset);
         ++col_id;
       });
     });

--- a/libvast/vast/column_index.hpp
+++ b/libvast/vast/column_index.hpp
@@ -29,11 +29,6 @@ namespace vast {
 
 // -- free functions -----------------------------------------------------------
 
-/// Creates a single column for the type name.
-/// @relates column_index
-caf::expected<column_index_ptr> make_type_column_index(caf::actor_system& sys,
-                                                       path filename);
-
 /// Creates a single colum for a value at column `col`.
 /// @relates column_index
 caf::expected<column_index_ptr> make_column_index(caf::actor_system& sys,

--- a/libvast/vast/table_index.hpp
+++ b/libvast/vast/table_index.hpp
@@ -21,8 +21,9 @@
 #include <caf/expected.hpp>
 #include <caf/fwd.hpp>
 
-#include "vast/filesystem.hpp"
 #include "vast/column_index.hpp"
+#include "vast/filesystem.hpp"
+#include "vast/ids.hpp"
 #include "vast/type.hpp"
 
 #include "vast/detail/range.hpp"
@@ -54,12 +55,6 @@ public:
   /// Identifies a subset of columns.
   using columns_range = detail::iterator_range<columns_vector::iterator>;
 
-  // -- constants --------------------------------------------------------------
-
-  /// Number of columns holding meta information. Currently, we only store type
-  /// names as meta data.
-  static constexpr std::ptrdiff_t meta_column_count = 1;
-
   // -- constructors, destructors, and assignment operators --------------------
 
   table_index(caf::actor_system& sys);
@@ -70,35 +65,17 @@ public:
 
   // -- persistence ------------------------------------------------------------
 
+  /// Load state from disk.
+  caf::error init();
+
   /// Persists all indexes to disk.
   caf::error flush_to_disk();
 
   /// -- properties ------------------------------------------------------------
 
-  /// @returns the colums for storing meta information.
-  columns_range meta_columns() {
-    auto first = columns_.begin();
-    return {first, first + meta_column_count};
-  }
-
-  /// @returns the columns for storing data.
-  columns_range data_columns() {
-    return {columns_.begin() + meta_column_count, columns_.end()};
-  }
-
   /// @returns the number of columns.
   size_t num_columns() const {
     return columns_.size();
-  }
-
-  /// @returns the number of columns for storing meta information.
-  size_t num_meta_columns() const {
-    return static_cast<size_t>(meta_column_count);
-  }
-
-  /// @returns the number of columns for storing data.
-  size_t num_data_columns() const {
-    return num_columns() - num_meta_columns();
   }
 
   /// @returns the column at given index.
@@ -109,7 +86,7 @@ public:
   ///          in case it doesn't yet exist.
   /// @pre `column_size < num_columns()`
   template <class Factory, class Continuation>
-  auto with_column(size_t column_index, Factory& factory, Continuation& f) {
+  auto with_column(size_t column_index, Factory& factory, Continuation f) {
     VAST_ASSERT(column_index < columns_.size());
     auto& col = columns_[column_index];
     using result_type = decltype(f(*col));
@@ -120,24 +97,6 @@ public:
       col = std::move(*fac_res);
     }
     return f(*col);
-  }
-
-  /// @returns the column for meta information at given index and creates it
-  ///          lazily from the factory in case it doesn't yet exist.
-  /// @pre `column_size < num_columns()`
-  template <class Factory, class Continuation>
-  auto with_meta_column(size_t column_index, Factory factory, Continuation f) {
-    VAST_ASSERT(column_index < meta_column_count);
-    return with_column(column_index, factory, f);
-  }
-
-  /// @returns the column for data at given index and creates it lazily from the
-  ///          factory in case it doesn't yet exist.
-  /// @pre `column_size < num_columns()`
-  template <class Factory, class Continuation>
-  auto with_data_column(size_t column_index, Factory factory, Continuation f) {
-    VAST_ASSERT(column_index < num_data_columns());
-    return with_column(column_index + num_meta_columns(), factory, f);
   }
 
   /// Applies `f` to each column pointer.
@@ -219,6 +178,9 @@ private:
 
   /// Allows a shortcut in `add` if all columns are initialized.
   bool dirty_;
+
+  /// Stores what IDs are present in this table.
+  ids row_ids_;
 
   /// Hosting actor system.
   caf::actor_system& sys_;


### PR DESCRIPTION
We no longer need to distinguish meta from actual data, since the only remaining meta column represents a type name. With (homogeneous) table slices, we don't need an index anymore and can process `&type` extractors more efficiently.