### PR TITLE
Harmonize serialization of meta index and synopsis 

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -104,6 +104,7 @@ set(libvast_sources
   src/table_slice.cpp
   src/table_slice_builder.cpp
   src/time.cpp
+  src/timestamp_synopsis.cpp
   src/to_events.cpp
   src/type.cpp
   src/uuid.cpp

--- a/libvast/src/default_table_slice.cpp
+++ b/libvast/src/default_table_slice.cpp
@@ -66,7 +66,7 @@ table_slice_ptr default_table_slice::make(record_type layout,
 }
 
 caf::atom_value default_table_slice::implementation_id() const noexcept {
-  return caf::atom("DEFAULT");
+  return caf::atom("TS_Default");
 }
 
 } // namespace vast

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -163,44 +163,23 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
   ), expr);
 }
 
-void meta_index::factory(synopsis_factory f) {
+void meta_index::factory(caf::atom_value implementation_id,
+                         synopsis_factory f) {
+  synopsis_type_ = implementation_id;
   make_synopsis_ = f;
   blacklisted_layouts_.clear();
 }
 
 caf::error inspect(caf::serializer& sink, const meta_index& x) {
-  caf::atom_value tag;
-  if (sink.context() != nullptr)
-    tag = get_synopsis_factory_tag(sink.context()->system());
-  else if (x.make_synopsis_ != make_synopsis)
-    return make_error(ec::unspecified, "no actor system for custom factory");
-  else
-    tag = caf::atom("DEFAULT");
-  return sink(tag, x.partition_synopses_);
+  return sink(x.synopsis_type_, x.partition_synopses_);
 }
 
 caf::error inspect(caf::deserializer& source, meta_index& x) {
-  caf::atom_value tag;
-  auto err = source(tag);
-  if (err)
-    return err;
-  if (tag != caf::atom("DEFAULT")) {
-    if (source.context() == nullptr)
-      return make_error(ec::unspecified, "no actor system for custom factory");
-    if (tag != get_synopsis_factory_tag(source.context()->system()))
-      return make_error(ec::unspecified, "synopsis factory mismatch");
-    auto f = get_synopsis_factory_fun(source.context()->system());
-    x.factory(f);
-  }
+  if (auto ex = deserialize_synopsis_factory(source))
+    x.factory(ex->first, ex->second);
+  else
+    return std::move(ex.error());
   return source(x.partition_synopses_);
-}
-
-bool set_synopsis_factory(caf::actor_system& sys, meta_index& x) {
-  if (auto f = get_synopsis_factory_fun(sys)) {
-    x.factory(f);
-    return true;
-  }
-  return false;
 }
 
 } // namespace vast

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -163,15 +163,15 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
   ), expr);
 }
 
-void meta_index::factory(caf::atom_value implementation_id,
+void meta_index::factory(caf::atom_value factory_id,
                          synopsis_factory f) {
-  synopsis_type_ = implementation_id;
+  factory_id_ = factory_id;
   make_synopsis_ = f;
   blacklisted_layouts_.clear();
 }
 
 caf::error inspect(caf::serializer& sink, const meta_index& x) {
-  return sink(x.synopsis_type_, x.partition_synopses_);
+  return sink(x.factory_id_, x.partition_synopses_);
 }
 
 caf::error inspect(caf::deserializer& source, meta_index& x) {

--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -85,6 +85,13 @@ public:
                                   timestamp::min()} {
     // nop
   }
+
+  bool equals(const synopsis& other) const noexcept override {
+    if (typeid(other) != typeid(timestamp_synopsis))
+      return false;
+    auto& dref = static_cast<const timestamp_synopsis&>(other);
+    return type() == dref.type() && min() == dref.min() && max() == dref.max();
+  }
 };
 
 } // namespace <anonymous>

--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -17,6 +17,7 @@
 #include <caf/runtime_settings_map.hpp>
 
 #include "vast/error.hpp"
+#include "vast/logger.hpp"
 #include "vast/min_max_synopsis.hpp"
 
 #include "vast/detail/overload.hpp"
@@ -35,47 +36,56 @@ const vast::type& synopsis::type() const {
   return type_;
 }
 
+caf::atom_value synopsis::implementation_id() const noexcept {
+  return caf::atom("Sy_Default");
+}
+
 caf::error inspect(caf::serializer& sink, synopsis_ptr& ptr) {
   if (!ptr) {
     type dummy;
     return sink(dummy);
   }
-  return caf::error::eval([&] { return sink(ptr->type()); },
-                          [&] { return ptr->serialize(sink); });
+  return caf::error::eval(
+    [&] { return sink(ptr->type(), ptr->implementation_id()); },
+    [&] { return ptr->serialize(sink); });
 }
 
 caf::error inspect(caf::deserializer& source, synopsis_ptr& ptr) {
+  // Read synopsis type.
   type t;
-  auto err = source(t);
-  if (err)
+  if (auto err = source(t))
     return err;
   // Only default-constructed synopses have an empty type.
   if (!t) {
     ptr.reset();
     return caf::none;
   }
-  if (source.context() != nullptr) {
-    auto factory = get_synopsis_factory_fun(source.context()->system());
-    ptr = factory ? factory(std::move(t)) : make_synopsis(std::move(t));
-  } else {
-    ptr = make_synopsis(std::move(t));
-  }
-  return ptr->deserialize(source);
+  // Select factory based on the implementation ID.
+  synopsis_factory f;
+  if (auto ex = deserialize_synopsis_factory(source))
+    f = ex->second;
+  else
+    return std::move(ex.error());
+  // Deserialize into a new instance.
+  auto new_ptr = f(std::move(t));
+  if (auto err = new_ptr->deserialize(source))
+    return err;
+  // Change `ptr` only after successfully deserializing.
+  using std::swap;
+  swap(ptr, new_ptr);
+  return caf::none;
 }
 
 namespace {
 
-class timestamp_synopsis : public min_max_synopsis<timestamp> {
+class timestamp_synopsis final : public min_max_synopsis<timestamp> {
 public:
-  timestamp_synopsis(vast::type x) 
+  timestamp_synopsis(vast::type x)
     : min_max_synopsis<timestamp>{std::move(x), timestamp::max(),
                                   timestamp::min()} {
     // nop
   }
 };
-
-constexpr auto synopis_factory_fun_atom = caf::atom("SYNOPSIS_F");
-constexpr auto synopis_factory_tag_atom = caf::atom("SYNOPSIS_T");
 
 } // namespace <anonymous>
 
@@ -89,31 +99,30 @@ synopsis_ptr make_synopsis(type x) {
     }), x);
 }
 
-// TODO: we should find a way to associate a key-value pair with the
-// runtime-settings map, with key being an atom and value a function pointer.
-// Right now, it's a brittle setup where the user must manage two keys.
-
-synopsis_factory get_synopsis_factory_fun(caf::actor_system& sys) {
-  using generic_fun = caf::runtime_settings_map::generic_function_pointer;
-  auto val = sys.runtime_settings().get(synopis_factory_fun_atom);
-  if (auto fun = caf::get_if<generic_fun>(&val))
-    return reinterpret_cast<synopsis_ptr (*)(type)>(*fun);
-  return {};
-}
-
-caf::atom_value get_synopsis_factory_tag(caf::actor_system& sys) {
-  auto val = sys.runtime_settings().get(synopis_factory_tag_atom);
-  if (auto x = caf::get_if<caf::atom_value>(&val))
-    return *x;
-  return {};
-}
-
-void set_synopsis_factory(caf::actor_system& sys,
-                          caf::atom_value tag, synopsis_factory factory) {
-  using generic_fun = caf::runtime_settings_map::generic_function_pointer;
-  auto fun = reinterpret_cast<generic_fun>(factory);
-  sys.runtime_settings().set(synopis_factory_tag_atom, tag);
-  sys.runtime_settings().set(synopis_factory_fun_atom, fun);
+expected<std::pair<caf::atom_value, synopsis_factory>>
+deserialize_synopsis_factory(caf::deserializer& source) {
+  // Select factory based on the implementation ID.
+  caf::atom_value impl_id;
+  if (auto err = source(impl_id))
+    return err;
+  synopsis_factory f;
+  if (impl_id == caf::atom("Sy_Default")) {
+    f = make_synopsis;
+  } else {
+    if (source.context() != nullptr)
+      return caf::sec::no_context;
+    using generic_fun = caf::runtime_settings_map::generic_function_pointer;
+    auto& sys = source.context()->system();
+    auto val = sys.runtime_settings().get(impl_id);
+    if (!caf::holds_alternative<generic_fun>(val)) {
+      VAST_ERROR_ANON("synopsis",
+                      "has no factory function for implementation key",
+                      impl_id);
+      return ec::invalid_synopsis_type;
+    }
+    f = reinterpret_cast<synopsis_factory>(caf::get<generic_fun>(val));
+  }
+  return std::make_pair(impl_id, f);
 }
 
 } // namespace vast

--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -36,7 +36,7 @@ const vast::type& synopsis::type() const {
   return type_;
 }
 
-caf::atom_value synopsis::implementation_id() const noexcept {
+caf::atom_value synopsis::factory_id() const noexcept {
   return caf::atom("Sy_Default");
 }
 
@@ -46,7 +46,7 @@ caf::error inspect(caf::serializer& sink, synopsis_ptr& ptr) {
     return sink(dummy);
   }
   return caf::error::eval(
-    [&] { return sink(ptr->type(), ptr->implementation_id()); },
+    [&] { return sink(ptr->type(), ptr->factory_id()); },
     [&] { return ptr->serialize(sink); });
 }
 

--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -18,7 +18,7 @@
 
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
-#include "vast/min_max_synopsis.hpp"
+#include "vast/timestamp_synopsis.hpp"
 
 #include "vast/detail/overload.hpp"
 
@@ -75,26 +75,6 @@ caf::error inspect(caf::deserializer& source, synopsis_ptr& ptr) {
   swap(ptr, new_ptr);
   return caf::none;
 }
-
-namespace {
-
-class timestamp_synopsis final : public min_max_synopsis<timestamp> {
-public:
-  timestamp_synopsis(vast::type x)
-    : min_max_synopsis<timestamp>{std::move(x), timestamp::max(),
-                                  timestamp::min()} {
-    // nop
-  }
-
-  bool equals(const synopsis& other) const noexcept override {
-    if (typeid(other) != typeid(timestamp_synopsis))
-      return false;
-    auto& dref = static_cast<const timestamp_synopsis&>(other);
-    return type() == dref.type() && min() == dref.min() && max() == dref.max();
-  }
-};
-
-} // namespace <anonymous>
 
 synopsis_ptr make_synopsis(type x) {
   return caf::visit(detail::overload(

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -99,7 +99,7 @@ caf::error table_slice::deserialize_ptr(caf::deserializer& source,
 
 table_slice_ptr make_table_slice(record_type layout, caf::actor_system& sys,
                                  caf::atom_value impl) {
-  if (impl == caf::atom("DEFAULT")) {
+  if (impl == caf::atom("TS_Default")) {
     return caf::make_copy_on_write<default_table_slice>(std::move(layout));
   }
   using generic_fun = caf::runtime_settings_map::generic_function_pointer;

--- a/libvast/src/timestamp_synopsis.cpp
+++ b/libvast/src/timestamp_synopsis.cpp
@@ -1,0 +1,31 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/timestamp_synopsis.hpp"
+
+namespace vast {
+
+timestamp_synopsis::timestamp_synopsis(vast::type x)
+  : min_max_synopsis<timestamp>{std::move(x), timestamp::max(),
+                                timestamp::min()} {
+  // nop
+}
+
+bool timestamp_synopsis::equals(const synopsis& other) const noexcept {
+  if (typeid(other) != typeid(timestamp_synopsis))
+    return false;
+  auto& dref = static_cast<const timestamp_synopsis&>(other);
+  return type() == dref.type() && min() == dref.min() && max() == dref.max();
+}
+
+} // namespace vast

--- a/libvast/test/default_table_slice.cpp
+++ b/libvast/test/default_table_slice.cpp
@@ -206,7 +206,7 @@ TEST(message serialization) {
   CHECK_EQUAL(*slice1.get_as<table_slice_ptr>(0),
               *slice2.get_as<table_slice_ptr>(0));
   CHECK_EQUAL(slice2.get_as<table_slice_ptr>(0)->implementation_id(),
-              caf::atom("DEFAULT"));
+              caf::atom("TS_Default"));
 }
 
 TEST(rebranded message serialization) {

--- a/libvast/test/synopsis.cpp
+++ b/libvast/test/synopsis.cpp
@@ -85,6 +85,7 @@ FIXTURE_SCOPE(synopsis_tests, fixtures::deterministic_actor_system)
 
 TEST(serialization) {
   CHECK_ROUNDTRIP(synopsis_ptr{});
+  CHECK_ROUNDTRIP_DEREF(make_synopsis(timestamp_type{}));
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/synopsis.cpp
+++ b/libvast/test/synopsis.cpp
@@ -13,9 +13,15 @@
 
 #define SUITE synopsis
 
-#include "test.hpp"
+#include "vast/synopsis.hpp"
 
-#include <vast/synopsis.hpp>
+#include "test.hpp"
+#include "fixtures/actor_system.hpp"
+
+#include <vector>
+
+#include <caf/binary_deserializer.hpp>
+#include <caf/binary_serializer.hpp>
 
 using namespace std::chrono_literals;
 using namespace vast;
@@ -74,3 +80,11 @@ TEST(min-max synopsis) {
   CHECK(!x->lookup(greater, nine));
   CHECK(!x->lookup(greater_equal, nine));
 }
+
+FIXTURE_SCOPE(synopsis_tests, fixtures::deterministic_actor_system)
+
+TEST(serialization) {
+  CHECK_ROUNDTRIP(synopsis_ptr{});
+}
+
+FIXTURE_SCOPE_END()

--- a/libvast/test/test.hpp
+++ b/libvast/test/test.hpp
@@ -22,19 +22,22 @@
 
 #include <caf/test/unit_test.hpp>
 
-// Logging
+// -- logging macros -----------------------------------------------------------
+
 #define ERROR CAF_TEST_PRINT_ERROR
 #define INFO CAF_TEST_PRINT_INFO
 #define VERBOSE CAF_TEST_PRINT_VERBOSE
 #define MESSAGE CAF_MESSAGE
 
-// Test setup
+// -- test setup macros --------------------------------------------------------
+
 #define TEST CAF_TEST
 #define TEST_DISABLED CAF_TEST_DISABLED
 #define FIXTURE_SCOPE CAF_TEST_FIXTURE_SCOPE
 #define FIXTURE_SCOPE_END CAF_TEST_FIXTURE_SCOPE_END
 
-// Checking
+// -- macros for checking results ----------------------------------------------
+
 #define REQUIRE CAF_REQUIRE
 #define REQUIRE_EQUAL CAF_REQUIRE_EQUAL
 #define REQUIRE_NOT_EQUAL CAF_REQUIRE_NOT_EQUAL
@@ -51,6 +54,19 @@
 #define CHECK_GREATER_EQUAL CAF_CHECK_GREATER_EQUAL
 #define CHECK_FAIL CAF_CHECK_FAIL
 #define FAIL CAF_FAIL
+
+// -- convenience macros for common check categories ---------------------------
+
+// Checks whether a value initialized from `expr` compares equal to itself
+// after a cycle of serializing and deserializing it. Requires the
+// `deterministic_actor_system` fixture.
+#define CHECK_ROUNDTRIP(expr)                                                  \
+  {                                                                            \
+    auto x = expr;                                                             \
+    CHECK_EQUAL(roundtrip(x), x);                                              \
+  }
+
+// -- global state -------------------------------------------------------------
 
 namespace vast::test {
 

--- a/libvast/test/test.hpp
+++ b/libvast/test/test.hpp
@@ -66,6 +66,17 @@
     CHECK_EQUAL(roundtrip(x), x);                                              \
   }
 
+// Like `CHECK_ROUNDTRIP`, but compares the objects by dereferencing them via
+// `operator*` first.
+#define CHECK_ROUNDTRIP_DEREF(expr)                                            \
+  {                                                                            \
+    auto x = expr;                                                             \
+    auto y = roundtrip(x);                                                     \
+    REQUIRE_NOT_EQUAL(x, nullptr);                                             \
+    REQUIRE_NOT_EQUAL(y, nullptr);                                             \
+    CHECK_EQUAL(*y, *x);                                                       \
+  }
+
 // -- global state -------------------------------------------------------------
 
 namespace vast::test {

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -153,6 +153,43 @@ TEST(type/data compatibility) {
 }
 
 TEST(serialization) {
+  CHECK_ROUNDTRIP(type{});
+  CHECK_ROUNDTRIP(none_type{});
+  CHECK_ROUNDTRIP(boolean_type{});
+  CHECK_ROUNDTRIP(integer_type{});
+  CHECK_ROUNDTRIP(count_type{});
+  CHECK_ROUNDTRIP(real_type{});
+  CHECK_ROUNDTRIP(timespan_type{});
+  CHECK_ROUNDTRIP(timestamp_type{});
+  CHECK_ROUNDTRIP(string_type{});
+  CHECK_ROUNDTRIP(pattern_type{});
+  CHECK_ROUNDTRIP(address_type{});
+  CHECK_ROUNDTRIP(subnet_type{});
+  CHECK_ROUNDTRIP(port_type{});
+  CHECK_ROUNDTRIP(enumeration_type{});
+  CHECK_ROUNDTRIP(vector_type{});
+  CHECK_ROUNDTRIP(set_type{});
+  CHECK_ROUNDTRIP(map_type{});
+  CHECK_ROUNDTRIP(record_type{});
+  CHECK_ROUNDTRIP(alias_type{});
+  CHECK_ROUNDTRIP(type{none_type{}});
+  CHECK_ROUNDTRIP(type{boolean_type{}});
+  CHECK_ROUNDTRIP(type{integer_type{}});
+  CHECK_ROUNDTRIP(type{count_type{}});
+  CHECK_ROUNDTRIP(type{real_type{}});
+  CHECK_ROUNDTRIP(type{timespan_type{}});
+  CHECK_ROUNDTRIP(type{timestamp_type{}});
+  CHECK_ROUNDTRIP(type{string_type{}});
+  CHECK_ROUNDTRIP(type{pattern_type{}});
+  CHECK_ROUNDTRIP(type{address_type{}});
+  CHECK_ROUNDTRIP(type{subnet_type{}});
+  CHECK_ROUNDTRIP(type{port_type{}});
+  CHECK_ROUNDTRIP(type{enumeration_type{}});
+  CHECK_ROUNDTRIP(type{vector_type{}});
+  CHECK_ROUNDTRIP(type{set_type{}});
+  CHECK_ROUNDTRIP(type{map_type{}});
+  CHECK_ROUNDTRIP(type{record_type{}});
+  CHECK_ROUNDTRIP(type{alias_type{}});
   auto r = record_type{
     {"x", integer_type{}},
     {"y", address_type{}},
@@ -164,13 +201,8 @@ TEST(serialization) {
     {"b", vector_type{boolean_type{}}.name("foo")},
     {"c", r}
   };
-  r = r.name("foo");
-  std::vector<char> buf;
-  auto t0 = type{r};
-  CHECK_EQUAL(save(sys, buf, t0), caf::none);
-  type t1;
-  CHECK_EQUAL(load(sys, buf, t1), caf::none);
-  CHECK_EQUAL(t0, t1);
+  r.name("foo");
+  CHECK_ROUNDTRIP(r);
 }
 
 TEST(record range) {
@@ -586,7 +618,7 @@ TEST(parseable) {
 
 TEST(hashable) {
   auto hash = [&](auto&& x) { return uhash<xxhash64>{}(x); };
-  CHECK_EQUAL(hash(type{}), 10680828680203489530ul);
+  CHECK_EQUAL(hash(type{}), 10764519495013463364ul);
   CHECK_EQUAL(hash(boolean_type{}), 12612883901365648434ul);
   CHECK_EQUAL(hash(type{boolean_type{}}), 13047344884484907481ul);
   CHECK_NOT_EQUAL(hash(type{boolean_type{}}), hash(boolean_type{}));

--- a/libvast/vast/error.hpp
+++ b/libvast/vast/error.hpp
@@ -48,6 +48,8 @@ enum class ec : uint8_t {
   syntax_error,
   /// Deserialization failed because an unknown implementation type was found.
   invalid_table_slice_type,
+  /// Deserialization failed because an unknown implementation type was found.
+  invalid_synopsis_type,
 };
 
 /// @relates ec

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -18,7 +18,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include <caf/atom.hpp>
 #include <caf/fwd.hpp>
+#include <caf/meta/load_callback.hpp>
 
 #include "vast/fwd.hpp"
 #include "vast/synopsis.hpp"
@@ -49,14 +51,18 @@ public:
   /// @returns A vector of UUIDs representing candidate partitions.
   std::vector<uuid> lookup(const expression& expr) const;
 
-  /// Replaces the synopsis factory.
-  /// @param f The factory to use.
-  void factory(synopsis_factory f);
+  /// Tries to replace the synopsis factory.
+  /// @param implementation_id The synopsis type to use.
+  /// @param f The synopsis factory to use.
+  /// @pre `f` is registered in the runtime settings unter the key
+  ///      `implementation_id`
+  void factory(caf::atom_value implementation_id, synopsis_factory f);
 
   // -- concepts ---------------------------------------------------------------
 
-  friend caf::error inspect(caf::serializer& sink, const meta_index& x);
-  friend caf::error inspect(caf::deserializer& source, meta_index& x);
+  friend caf::error inspect(caf::serializer&, const meta_index&);
+
+  friend caf::error inspect(caf::deserializer&, meta_index&);
 
 private:
   // Synopsis structures for a givn layout.
@@ -73,13 +79,10 @@ private:
 
   /// The factory function to construct a synopsis structure for a type.
   synopsis_factory make_synopsis_;
+
+  /// The implementation ID for objects created by `make_synopsis_`.
+  caf::atom_value synopsis_type_;
 };
 
-/// Tries to set a new synopsis factory from an actor system.
-/// @param sys The actor system.
-/// @param x The meta index instance.
-/// @returns `true` iff *sys* contains a synopsis factory.
-/// @relates meta_index
-bool set_synopsis_factory(caf::actor_system& sys, meta_index& x);
 
 } // namespace vast

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -20,7 +20,6 @@
 
 #include <caf/atom.hpp>
 #include <caf/fwd.hpp>
-#include <caf/meta/load_callback.hpp>
 
 #include "vast/fwd.hpp"
 #include "vast/synopsis.hpp"
@@ -51,7 +50,7 @@ public:
   /// @returns A vector of UUIDs representing candidate partitions.
   std::vector<uuid> lookup(const expression& expr) const;
 
-  /// Tries to replace the synopsis factory.
+  /// Replaces the synopsis factory.
   /// @param factory_id The system-wide ID for `f`.
   /// @param f The synopsis factory to use.
   /// @pre `f` is registered in the runtime settings unter the key

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -52,11 +52,11 @@ public:
   std::vector<uuid> lookup(const expression& expr) const;
 
   /// Tries to replace the synopsis factory.
-  /// @param implementation_id The synopsis type to use.
+  /// @param factory_id The system-wide ID for `f`.
   /// @param f The synopsis factory to use.
   /// @pre `f` is registered in the runtime settings unter the key
-  ///      `implementation_id`
-  void factory(caf::atom_value implementation_id, synopsis_factory f);
+  ///      `factory_id`
+  void factory(caf::atom_value factory_id, synopsis_factory f);
 
   // -- concepts ---------------------------------------------------------------
 
@@ -81,7 +81,7 @@ private:
   synopsis_factory make_synopsis_;
 
   /// The implementation ID for objects created by `make_synopsis_`.
-  caf::atom_value synopsis_type_;
+  caf::atom_value factory_id_;
 };
 
 

--- a/libvast/vast/min_max_synopsis.hpp
+++ b/libvast/vast/min_max_synopsis.hpp
@@ -90,6 +90,14 @@ public:
     return source(min_, max_);
   }
 
+  T min() const noexcept {
+    return min_;
+  }
+
+  T max() const noexcept {
+    return max_;
+  }
+
 private:
   T min_;
   T max_;

--- a/libvast/vast/synopsis.hpp
+++ b/libvast/vast/synopsis.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include <caf/intrusive_ptr.hpp>
 #include <caf/ref_counted.hpp>
 
@@ -56,7 +58,7 @@ public:
   // -- serialization ----------------------------------------------------------
 
   /// @returns a unique identifier for the implementing class.
-  //virtual caf::atom_value implementation_id() const noexcept = 0;
+  virtual caf::atom_value implementation_id() const noexcept;
 
   /// Saves the contents (excluding the layout!) of this slice to `sink`.
   virtual caf::error serialize(caf::serializer& sink) const = 0;
@@ -85,21 +87,8 @@ synopsis_ptr make_synopsis(type x);
 /// @relates synopsis get_synopsis_factory_fun set_synopsis_factory
 using synopsis_factory = synopsis_ptr (*)(type);
 
-/// Looks for a synopsis factory in an actor system.
-/// @param sys The actor system to search for a synopsis factory function.
 /// @relates synopsis synopsis_factory
-synopsis_factory get_synopsis_factory_fun(caf::actor_system& sys);
-
-/// Looks for a synopsis factory in an actor system.
-/// @param sys The actor system to search for a synopsis factory tag.
-/// @relates synopsis get_synopsis_factory_fun set_synopsis_factory
-caf::atom_value get_synopsis_factory_tag(caf::actor_system& sys);
-
-/// Sets a factory in an actor system.
-/// @param tag The atom key under which the factory is retrievable.
-/// @param factory A pointer to a factory function.
-/// @relates synopsis get_synopsis_factory_fun get_synopsis_factory_tag
-void set_synopsis_factory(caf::actor_system& sys,
-                          caf::atom_value tag, synopsis_factory factory);
+expected<std::pair<caf::atom_value, synopsis_factory>>
+deserialize_synopsis_factory(caf::deserializer& source);
 
 } // namespace vast

--- a/libvast/vast/synopsis.hpp
+++ b/libvast/vast/synopsis.hpp
@@ -52,6 +52,9 @@ public:
   /// @returns The evaluation result of `*this op rhs`.
   virtual bool lookup(relational_operator op, data_view rhs) const = 0;
 
+  /// Tests whether two objects are equal.
+  virtual bool equals(const synopsis& other) const noexcept = 0;
+
   /// @returns the type this synopsis operates for.
   const vast::type& type() const;
 
@@ -69,6 +72,16 @@ public:
 private:
   vast::type type_;
 };
+
+/// @relates synopsis
+inline bool operator==(const synopsis& x, const synopsis& y) {
+  return x.equals(y);
+}
+
+/// @relates synopsis
+inline bool operator!=(const synopsis& x, const synopsis& y) {
+  return !(x == y);
+}
 
 /// @relates synopsis
 caf::error inspect(caf::serializer& sink, synopsis_ptr& ptr);

--- a/libvast/vast/synopsis.hpp
+++ b/libvast/vast/synopsis.hpp
@@ -60,8 +60,9 @@ public:
 
   // -- serialization ----------------------------------------------------------
 
-  /// @returns a unique identifier for the implementing class.
-  virtual caf::atom_value implementation_id() const noexcept;
+  /// @returns a unique identifier for the factory required to make instances
+  ///          of this synopsis.
+  virtual caf::atom_value factory_id() const noexcept;
 
   /// Saves the contents (excluding the layout!) of this slice to `sink`.
   virtual caf::error serialize(caf::serializer& sink) const = 0;

--- a/libvast/vast/timestamp_synopsis.hpp
+++ b/libvast/vast/timestamp_synopsis.hpp
@@ -1,0 +1,28 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/min_max_synopsis.hpp"
+#include "vast/synopsis.hpp"
+
+namespace vast {
+
+class timestamp_synopsis final : public min_max_synopsis<timestamp> {
+public:
+  timestamp_synopsis(vast::type x);
+
+  bool equals(const synopsis& other) const noexcept override;
+};
+
+} // namespace vast

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -869,6 +869,10 @@ struct sum_type_access<vast::type> {
 
 namespace vast {
 
+/// Identifies default-constructed `type` objects.
+static constexpr uint8_t invalid_type_tag = 255;
+
+/// @private
 template <class Inspector, class T>
 auto make_inspect_fun() {
   using fun = typename Inspector::result_type (*)(Inspector&, type&);
@@ -881,19 +885,25 @@ auto make_inspect_fun() {
   return static_cast<fun>(lambda);
 }
 
+/// @private
 template <class Inspector, class... Ts>
 auto make_inspect(caf::detail::type_list<Ts...>) {
-  return [](Inspector& f, type::inspect_helper& x) {
+  return [](Inspector& f, type::inspect_helper& x) -> caf::error {
     using result_type = typename Inspector::result_type;
     if constexpr (Inspector::reads_state) {
-      return caf::visit(f, x.x);
+      if (x.type_tag != invalid_type_tag)
+        caf::visit(f, x.x);
+      return caf::none;
     } else {
       using reference = type&;
       using fun = result_type (*)(Inspector&, reference);
       static fun tbl[] = {
         make_inspect_fun<Inspector, Ts>()...
       };
-      return tbl[x.type_tag](f, x.x);
+      if (x.type_tag != invalid_type_tag)
+        return tbl[x.type_tag](f, x.x);
+      x.x = type{};
+      return caf::none;
     }
   };
 }
@@ -909,7 +919,7 @@ auto inspect(Inspector& f, type::inspect_helper& x) {
 template <class Inspector>
 auto inspect(Inspector& f, type& x) {
   // We use a single byte for the type index on the wire.
-  auto type_tag = static_cast<uint8_t>(x->index());
+  auto type_tag = x ? static_cast<uint8_t>(x->index()) : invalid_type_tag;
   type::inspect_helper helper{type_tag, x};
   return f(caf::meta::omittable(), type_tag, helper);
 }
@@ -920,12 +930,12 @@ auto inspect(Inspector& f, type& x) {
 
 namespace std {
 
-#define VAST_DEFINE_HASH_SPECIALIZATION(type)             \
-  template <>                                             \
-  struct hash<vast::type> {                               \
-    size_t operator()(const vast::type& x) const {        \
-      return vast::uhash<vast::xxhash64>{}(x);            \
-    }                                                     \
+#define VAST_DEFINE_HASH_SPECIALIZATION(type)                                  \
+  template <>                                                                  \
+  struct hash<vast::type> {                                                    \
+    size_t operator()(const vast::type& x) const {                             \
+      return vast::uhash<vast::xxhash64>{}(x);                                 \
+    }                                                                          \
   }
 
 VAST_DEFINE_HASH_SPECIALIZATION(type);


### PR DESCRIPTION
Synopsis and meta index use complex two-phase mechanisms for registering factories. This uses the same mechanism we already use for table slices. Also fixes a bug with serializing `type` that became apparent when serializing synopsis.