### PR TITLE
Make type implicitly shared

### DIFF
--- a/libvast/src/format/bro.cpp
+++ b/libvast/src/format/bro.cpp
@@ -435,7 +435,7 @@ expected<void> reader::parse_header() {
   // Construct type.
   record_ = std::move(record_fields);
   type_ = unflatten(record_);
-  type_ = type_.name("bro::" + path);
+  type_.name("bro::" + path);
   VAST_DEBUG(this, "parsed bro header:");
   VAST_DEBUG(this, "    #separator", separator_);
   VAST_DEBUG(this, "    #set_separator", set_separator_);

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -57,25 +57,25 @@ bool operator<(const type& x, const type& y) {
 
 type& type::name(const std::string& x) & {
   if (ptr_)
-    ptr_->name_ = x;
+    ptr_.unshared().name_ = x;
   return *this;
 }
 
 type&& type::name(const std::string& x) && {
   if (ptr_)
-    ptr_->name_ = x;
+    ptr_.unshared().name_ = x;
   return std::move(*this);
 }
 
 type& type::attributes(std::vector<attribute> xs) & {
   if (ptr_)
-    ptr_->attributes_ = std::move(xs);
+    ptr_.unshared().attributes_ = std::move(xs);
   return *this;
 }
 
 type&& type::attributes(std::vector<attribute> xs) && {
   if (ptr_)
-    ptr_->attributes_ = std::move(xs);
+    ptr_.unshared().attributes_ = std::move(xs);
   return std::move(*this);
 }
 

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -55,16 +55,28 @@ bool operator<(const type& x, const type& y) {
   return x.ptr_ < y.ptr_;
 }
 
-void type::name(const std::string& x) {
+type& type::name(const std::string& x) & {
   if (ptr_)
-    ptr_->name_ = std::move(x);
+    ptr_->name_ = x;
+  return *this;
 }
 
-type type::attributes(std::vector<attribute> xs) const {
-  type copy{*this};
-  if (copy.ptr_)
-    copy.ptr_->attributes_ = std::move(xs);
-  return copy;
+type&& type::name(const std::string& x) && {
+  if (ptr_)
+    ptr_->name_ = x;
+  return std::move(*this);
+}
+
+type& type::attributes(std::vector<attribute> xs) & {
+  if (ptr_)
+    ptr_->attributes_ = std::move(xs);
+  return *this;
+}
+
+type&& type::attributes(std::vector<attribute> xs) && {
+  if (ptr_)
+    ptr_->attributes_ = std::move(xs);
+  return std::move(*this);
 }
 
 type::operator bool() const {
@@ -73,12 +85,12 @@ type::operator bool() const {
 
 const std::string& type::name() const {
   static const std::string empty_string = "";
-  return ptr_ ? ptr_->name() : empty_string;
+  return ptr_ ? ptr_->name_ : empty_string;
 }
 
 const std::vector<attribute>& type::attributes() const {
   static const std::vector<attribute> no_attributes = {};
-  return ptr_ ? ptr_->attributes() : no_attributes;
+  return ptr_ ? ptr_->attributes_ : no_attributes;
 }
 
 abstract_type_ptr type::ptr() const {
@@ -105,14 +117,6 @@ type::type(abstract_type_ptr x) : ptr_{std::move(x)} {
 
 abstract_type::~abstract_type() {
   // nop
-}
-
-const std::string& abstract_type::name() const {
-  return name_;
-}
-
-const std::vector<attribute>& abstract_type::attributes() const {
-  return attributes_;
 }
 
 bool abstract_type::equals(const abstract_type& other) const {

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -43,15 +43,6 @@ none_type none_type_singleton;
 
 // -- type ---------------------------------------------------------------------
 
-type::type(const type& x) : ptr_{x.ptr_ ? x.ptr_->clone() : nullptr} {
-  // nop
-}
-
-type& type::operator=(const type& x) {
-  ptr_ = x.ptr_ ? x.ptr_->clone() : nullptr;
-  return *this;
-}
-
 bool operator==(const type& x, const type& y) {
   if (x.ptr_ && y.ptr_)
     return *x.ptr_ == *y.ptr_;
@@ -64,11 +55,9 @@ bool operator<(const type& x, const type& y) {
   return x.ptr_ < y.ptr_;
 }
 
-type type::name(std::string x) const {
-  type copy{*this};
-  if (copy.ptr_)
-    copy.ptr_->name_ = std::move(x);
-  return copy;
+void type::name(const std::string& x) {
+  if (ptr_)
+    ptr_->name_ = std::move(x);
 }
 
 type type::attributes(std::vector<attribute> xs) const {

--- a/libvast/test/event.cpp
+++ b/libvast/test/event.cpp
@@ -36,7 +36,7 @@ struct fixture : fixtures::deterministic_actor_system {
       {"x", boolean_type{}},
       {"y", count_type{}},
       {"z", integer_type{}}};
-    t = t.name("foo");
+    t.name("foo");
     // Data
     r.emplace_back(true);
     r.emplace_back(42u);

--- a/libvast/test/fixtures/events.cpp
+++ b/libvast/test/fixtures/events.cpp
@@ -33,7 +33,8 @@ timestamp epoch;
 
 std::vector<event> make_ascending_integers(size_t count) {
   std::vector<event> result;
-  type layout = type{record_type{{"value", integer_type{}}}}.name("test::int");
+  type layout{record_type{{"value", integer_type{}}}};
+  layout.name("test::int");
   for (size_t i = 0; i < count; ++i) {
     result.emplace_back(event::make(vector{static_cast<integer>(i)}, layout));
     result.back().timestamp(epoch + std::chrono::seconds(i));
@@ -43,7 +44,8 @@ std::vector<event> make_ascending_integers(size_t count) {
 
 std::vector<event> make_alternating_integers(size_t count) {
   std::vector<event> result;
-  type layout = type{record_type{{"value", integer_type{}}}}.name("test::int");
+  type layout{record_type{{"value", integer_type{}}}};
+  layout.name("test::int");
   for (size_t i = 0; i < count; ++i) {
     result.emplace_back(event::make(vector{static_cast<integer>(i % 2)},
                                     layout));

--- a/libvast/test/schema.cpp
+++ b/libvast/test/schema.cpp
@@ -66,35 +66,6 @@ TEST(offset finding) {
   CHECK_EQUAL(at(foo_record, 3, 1, 1).name(), real_type{});
 }
 
-TEST(offset finding old) {
-  std::string str = R"__(
-    type a = int
-    type inner = record{ x: int, y: real }
-    type middle = record{ a: int, b: inner }
-    type outer = record{ a: middle, b: record { y: string }, c: int }
-    type foo = record{ a: int, b: real, c: outer, d: middle }
-  )__";
-  auto sch = to<schema>(str);
-  REQUIRE(sch);
-  // Type lookup
-  auto foo = sch->find("foo");
-  REQUIRE(foo);
-  auto r = get_if<record_type>(foo);
-  // Verify type integrity
-  REQUIRE(r);
-  auto t = r->at(offset{0});
-  REQUIRE(t);
-  CHECK(holds_alternative<integer_type>(*t));
-  t = r->at(offset{2, 0, 1, 1});
-  REQUIRE(t);
-  CHECK(holds_alternative<real_type>(*t));
-  t = r->at(offset{2, 0, 1});
-  REQUIRE(t);
-  auto inner = get_if<record_type>(t);
-  REQUIRE(inner);
-  CHECK(inner->name() == "inner");
-}
-
 TEST(merging) {
   std::string str = R"__(
     type a = int

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -74,10 +74,10 @@ TEST(copying) {
 
 TEST(names) {
   type t;
-  t = t.name("foo");
+  t.name("foo");
   CHECK(t.name().empty());
   t = type{string_type{}};
-  t = t.name("foo");
+  t.name("foo");
   CHECK_EQUAL(t.name(), "foo");
 }
 
@@ -99,9 +99,9 @@ TEST(equality comparison) {
   CHECK(type{boolean_type{}} != type{real_type{}});
   auto x = type{string_type{}};
   auto y = type{string_type{}};
-  x = x.name("foo");
+  x.name("foo");
   CHECK(x != y);
-  y = y.name("foo");
+  y.name("foo");
   CHECK(x == y);
   MESSAGE("concrete type comparison");
   CHECK(real_type{} == real_type{});
@@ -509,7 +509,7 @@ TEST(printable) {
   t = map_type{count_type{}, t};
   CHECK_EQUAL(to_string(t), "map<count, set<port> &skip>");
   MESSAGE("signature");
-  t = t.name("jells");
+  t.name("jells");
   std::string sig;
   CHECK(printers::type<policy::signature>(sig, t));
   CHECK_EQUAL(sig, "jells = map<count, set<port> &skip>");

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -14,6 +14,7 @@
 #define SUITE type
 
 #include "test.hpp"
+#include "type_test.hpp"
 #include "fixtures/actor_system.hpp"
 
 #include "vast/data.hpp"
@@ -84,10 +85,10 @@ TEST(names) {
 TEST(attributes) {
   auto attrs = std::vector<attribute>{{"key", "value"}};
   type t;
-  t = t.attributes(attrs);
+  t.attributes(attrs);
   CHECK(t.attributes().empty());
   t = string_type{};
-  t = t.attributes({{"key", "value"}});
+  t.attributes({{"key", "value"}});
   CHECK_EQUAL(t.attributes(), attrs);
 }
 
@@ -181,19 +182,35 @@ TEST(record range) {
                     {"k", boolean_type{}}
                   }},
             {"m", record_type{
-                    {"y", record_type{{"a", address_type{}}}},
+                    {"y", record_type{
+                            {"a", address_type{}}}},
                     {"f", real_type{}}
                   }},
             {"b", boolean_type{}}
           }},
-    {"y", record_type{{"b", boolean_type{}}}}
+    {"y", record_type{
+            {"b", boolean_type{}}}}
   };
-
+  MESSAGE("check types of record r");
+  auto record_index = r.index();
+  CHECK_EQUAL(at(r, 0)->index(), record_index);
+  CHECK_EQUAL(at(r, 0, 0)->index(), record_index);
+  CHECK_EQUAL(at(r, 0, 0, 0), integer_type{});
+  CHECK_EQUAL(at(r, 0, 0, 1), boolean_type{});
+  CHECK_EQUAL(at(r, 0, 1)->index(), record_index);
+  CHECK_EQUAL(at(r, 0, 1, 0)->index(), record_index);
+  CHECK_EQUAL(at(r, 0, 1, 0, 0), address_type{});
+  CHECK_EQUAL(at(r, 0, 1, 1), real_type{});
+  CHECK_EQUAL(at(r, 0, 2), boolean_type{});
+  CHECK_EQUAL(at(r, 1)->index(), record_index);
+  CHECK_EQUAL(at(r, 1, 0), boolean_type{});
+  MESSAGE("check keys of record r");
+  std::vector<std::string> keys;
   for (auto& i : record_type::each{r})
-    if (i.offset == offset{0, 1, 0, 0})
-      CHECK_EQUAL(i.key(), "x.m.y.a");
-    else if (i.offset == offset{1, 0})
-      CHECK_EQUAL(i.key(), "y.b");
+    keys.emplace_back(i.key());
+  std::vector<std::string> expected_keys{"x.y.z", "x.y.k", "x.m.y.a",
+                                         "x.m.f", "x.b",   "y.b"};
+  CHECK_EQUAL(keys, expected_keys);
 }
 
 TEST(record resolving) {
@@ -505,7 +522,7 @@ TEST(printable) {
   CHECK_EQUAL(to_string(s), "set<port> &skip &tokenize=/rx/");
   // Nested types
   t = s;
-  t = t.attributes({attr});
+  t.attributes({attr});
   t = map_type{count_type{}, t};
   CHECK_EQUAL(to_string(t), "map<count, set<port> &skip>");
   MESSAGE("signature");
@@ -605,7 +622,7 @@ TEST(json) {
   auto e = enumeration_type{{"foo", "bar", "baz"}};
   e = e.name("e");
   auto t = map_type{boolean_type{}, count_type{}};
-  t = t.name("bit_table");
+  t.name("bit_table");
   auto r = record_type{
     {"x", address_type{}.attributes({{"skip"}})},
     {"y", boolean_type{}.attributes({{"default", "F"}})},

--- a/libvast/test/type_test.hpp
+++ b/libvast/test/type_test.hpp
@@ -1,0 +1,40 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "vast/offset.hpp"
+#include "vast/type.hpp"
+
+#include "test.hpp"
+
+/// Returns the type at `offset{xs...}`.
+template <class... Offsets>
+const vast::type& at(const vast::record_type& rec, Offsets... xs) {
+  auto ptr = rec.at(vast::offset{static_cast<size_t>(xs)...});
+  if (!ptr)
+    FAIL("offset lookup failed at " << std::vector<int>{xs...});
+  return *ptr;
+};
+
+/// Returns the record type at `offset{xs...}`.
+template <class... Offsets>
+const vast::record_type& rec_at(const vast::record_type& rec, Offsets... xs) {
+  auto& t = at(rec, xs...);
+  if (!caf::holds_alternative<vast::record_type>(t))
+    FAIL("expected a record type at offset " << std::vector<int>{xs...});
+  return caf::get<vast::record_type>(t);
+};

--- a/libvast/vast/concept/parseable/vast/schema.hpp
+++ b/libvast/vast/concept/parseable/vast/schema.hpp
@@ -35,7 +35,7 @@ struct schema_parser : parser<schema_parser> {
       // to create an alias.
       if (!ty.name().empty())
         ty = alias_type{ty}; // TODO: attributes
-      ty = ty.name(name);
+      ty.name(name);
       symbols.add(name, ty);
       return ty;
     };

--- a/libvast/vast/concept/parseable/vast/type.hpp
+++ b/libvast/vast/concept/parseable/vast/type.hpp
@@ -39,7 +39,7 @@ public:
   bool add(const std::string& name, type t) {
     if (name.empty() || name != t.name())
       return false;
-    t = t.name(name);
+    t.name(name);
     symbols_.symbols.insert({name, t});
     return true;
   }

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -232,7 +232,7 @@ public:
   /// @returns the index of this type in `concrete_types`.
   virtual int index() const noexcept = 0;
 
-  virtual abstract_type_ptr copy() const = 0;
+  virtual abstract_type* copy() const = 0;
 
   /// @endcond
 
@@ -317,8 +317,8 @@ protected:
     return static_cast<concrete_type&>(x);
   }
 
-  abstract_type_ptr copy() const final {
-    return abstract_type_ptr{caf::make_counted<Derived>(derived())};
+  concrete_type* copy() const final {
+    return new Derived(derived());
   }
 
 private:


### PR DESCRIPTION
Currently, `type` makes deep copies in its copy ctor and assignment operator. After this change, `type` makes shallow copies instead and uses copy-on-write for modifiers.