### PR TITLE
Remove vast send subcommand

### DIFF
--- a/doc/vast.1
+++ b/doc/vast.1
@@ -1,4 +1,4 @@
-.TH VAST 1 "September 04, 2018" 0.1 "Visibility Across Space and Time"
+.TH VAST 1 "November 06, 2018" 0.1 "Visibility Across Space and Time"
 .SH NAME
 .PP
 \fB\fCvast\fR \-\- manage a VAST topology
@@ -95,7 +95,6 @@ commands exist:
     \fIshow\fP          shows various properties of a topology
     \fIspawn\fP         creates a new component
     \fIkill\fP          terminates an component
-    \fIsend\fP          send a message to an component
     \fIimport\fP        imports data from standard input
     \fIexport\fP        exports query results to standard output
 .SS start
@@ -254,24 +253,6 @@ Synopsis:
 \fIkill\fP \fIlabel\fP
 .PP
 Terminates a component. The argument \fIlabel\fP refers to a component label.
-.SS send
-.PP
-Synopsis:
-.IP
-\fIsend\fP \fIlabel\fP \fImessage\fP
-.PP
-Sends a message to a component. The argument \fIlabel\fP refers to the component to
-run. The argument \fImessage\fP represents the data to send to the component.
-.PP
-Available messages:
-.TP
-\fIrun\fP
-Tells a component to start operating. Most components do not need to be told
-to run explicitly. Only components having a multi\-stage setup phase (e.g.,
-sources and exporters) can be run explicitly.
-.TP
-\fIflush\fP
-Tells a component to flush its state to the file system.
 .SS import
 .PP
 Synopsis:

--- a/doc/vast.1.md
+++ b/doc/vast.1.md
@@ -108,7 +108,6 @@ commands exist:
     *show*          shows various properties of a topology
     *spawn*         creates a new component
     *kill*          terminates an component
-    *send*          send a message to an component
     *import*        imports data from standard input
     *export*        exports query results to standard output
 
@@ -273,25 +272,6 @@ Synopsis:
   *kill* *label*
 
 Terminates a component. The argument *label* refers to a component label.
-
-### send
-
-Synopsis:
-
-  *send* *label* *message*
-
-Sends a message to a component. The argument *label* refers to the component to
-run. The argument *message* represents the data to send to the component.
-
-Available messages:
-
-*run*
-  Tells a component to start operating. Most components do not need to be told
-  to run explicitly. Only components having a multi-stage setup phase (e.g.,
-  sources and exporters) can be run explicitly.
-
-*flush*
-  Tells a component to flush its state to the file system.
 
 ### import
 

--- a/libvast/src/system/default_application.cpp
+++ b/libvast/src/system/default_application.cpp
@@ -60,7 +60,6 @@ default_application::default_application() {
   add<remote_command>("stop");
   add<remote_command>("show");
   add<remote_command>("spawn");
-  add<remote_command>("send");
   add<remote_command>("kill");
   add<remote_command>("peer");
 }


### PR DESCRIPTION
`vast send <run|flush>` is an implementation detail that should not be exposed to the user.