### PR TITLE
Add make random table slices utility function

### DIFF
--- a/libvast/vast/format/test.hpp
+++ b/libvast/vast/format/test.hpp
@@ -63,7 +63,14 @@ public:
   /// @param seed A seed for the random number generator.
   /// @param n The numer of events to generate.
   /// @param id The base event ID to start at.
-  reader(size_t seed = 0, uint64_t n = 100);
+  /// @param sch The event schema.
+  reader(size_t seed, uint64_t n, vast::schema sch);
+
+  /// Constructs a test reader.
+  /// @param seed A seed for the random number generator.
+  /// @param n The numer of events to generate.
+  /// @param id The base event ID to start at.
+  explicit reader(size_t seed = 0, uint64_t n = 100);
 
   expected<event> read() override;
 

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -129,6 +129,18 @@ protected:
 table_slice_ptr make_table_slice(record_type layout, caf::actor_system& sys,
                                  caf::atom_value impl);
 
+/// Constructs table slices filled with random content for testing purposes.
+/// @param num_slices The number of table slices to generate.
+/// @param slice_size The number of rows per table slices.
+/// @param layout The layout of the table slice.
+/// @param offset The offset of the first table slize.
+/// @param seed The seed value for initializing the random-number generator.
+/// @returns a list of randomnly filled table slices or an error.
+/// @relates table_slice
+expected<std::vector<table_slice_ptr>>
+make_random_table_slices(size_t num_slices, size_t slice_size,
+                         record_type layout, id offset = 0, size_t seed = 0);
+
 /// @relates table_slice
 bool operator==(const table_slice& x, const table_slice& y);
 


### PR DESCRIPTION
This function is needed for implementing the new benchmarks, but could also be used for unit testing.

We might eventually want to move this function to `libvast_test`.