### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -24,6 +24,7 @@
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder.hpp"
 #include "vast/uuid.hpp"
+#include "vast/view.hpp"
 
 using namespace vast;
 
@@ -56,7 +57,7 @@ struct generator {
     auto builder = default_table_slice::make_builder(layout);
     auto str = "foo";
     for (size_t i = 0; i < num; ++i) {
-      auto ts = epoch + std::chrono::seconds(i + offset);
+      timestamp ts = epoch + std::chrono::seconds(i + offset);
       builder->add(make_data_view(ts));
       builder->add(make_data_view(str));
     }

--- a/libvast/test/synopsis.cpp
+++ b/libvast/test/synopsis.cpp
@@ -37,10 +37,10 @@ const timestamp epoch;
 TEST(min-max synopsis) {
   auto x = make_synopsis(timestamp_type{});
   REQUIRE(x);
-  x->add(epoch + 4s);
-  x->add(epoch + 7s);
+  x->add(timestamp{epoch + 4s});
+  x->add(timestamp{epoch + 7s});
   MESSAGE("[4,7] op 0");
-  auto zero = epoch + 0s;
+  timestamp zero = epoch + 0s;
   CHECK(!x->lookup(equal, zero));
   CHECK(x->lookup(not_equal, zero));
   CHECK(!x->lookup(less, zero));
@@ -48,7 +48,7 @@ TEST(min-max synopsis) {
   CHECK(x->lookup(greater, zero));
   CHECK(x->lookup(greater_equal, zero));
   MESSAGE("[4,7] op 4");
-  auto four = epoch + 4s;
+  timestamp four = epoch + 4s;
   CHECK(x->lookup(equal, four));
   CHECK(!x->lookup(not_equal, four));
   CHECK(!x->lookup(less, four));
@@ -56,7 +56,7 @@ TEST(min-max synopsis) {
   CHECK(x->lookup(greater, four));
   CHECK(x->lookup(greater_equal, four));
   MESSAGE("[4,7] op 6");
-  auto six = epoch + 6s;
+  timestamp six = epoch + 6s;
   CHECK(x->lookup(equal, six));
   CHECK(!x->lookup(not_equal, six));
   CHECK(x->lookup(less, six));
@@ -64,7 +64,7 @@ TEST(min-max synopsis) {
   CHECK(x->lookup(greater, six));
   CHECK(x->lookup(greater_equal, six));
   MESSAGE("[4,7] op 7");
-  auto seven = epoch + 7s;
+  timestamp seven = epoch + 7s;
   CHECK(x->lookup(equal, seven));
   CHECK(!x->lookup(not_equal, seven));
   CHECK(x->lookup(less, seven));
@@ -72,7 +72,7 @@ TEST(min-max synopsis) {
   CHECK(!x->lookup(greater, seven));
   CHECK(x->lookup(greater_equal, seven));
   MESSAGE("[4,7] op 9");
-  auto nine = epoch + 9s;
+  timestamp nine = epoch + 9s;
   CHECK(!x->lookup(equal, nine));
   CHECK(x->lookup(not_equal, nine));
   CHECK(x->lookup(less, nine));


### PR DESCRIPTION
This is an interesting issue. When adding a value of type `std::chrono::seconds` to `(caf::)timestamp`, we don't get a `timestamp` back! Here's why:

```cpp
template <class C, class D1, class R2, class P2>
constexpr time_point<C, typename std::common_type<D1, duration<R2,P2>>::type>
operator+(const time_point<C, D1>& pt, const duration<R2,P2>& d);
```

The culprit is this type:

```cpp
typename std::common_type<D1, duration<R2, P2>>::type
```

If it would evaluate to `D1`, we'd be fine. But it becomes `duration<R2, P2>`. Now, what does the standard say for `std::chrono::seconds`?

  `duration</*signed integer type of at least 35 bits*/>`

In other words: undefined.

Apparently FreeBSD uses a different "signed integer type" than
`caf::duration`.