### PR TITLE
Support table slice builder in test reader

### DIFF
--- a/libvast/src/default_table_slice_builder.cpp
+++ b/libvast/src/default_table_slice_builder.cpp
@@ -18,8 +18,8 @@
 namespace vast {
 
 default_table_slice_builder::default_table_slice_builder(record_type layout)
-  : layout_{flatten(layout)},
-    row_(layout_.fields.size()),
+  : super{flatten(layout)},
+    row_(super::layout().fields.size()),
     col_{0} {
   VAST_ASSERT(!row_.empty());
 }
@@ -27,12 +27,12 @@ default_table_slice_builder::default_table_slice_builder(record_type layout)
 bool default_table_slice_builder::append(data x) {
   lazy_init();
   // TODO: consider an unchecked version for improved performance.
-  if (!type_check(layout_.fields[col_].type, x))
+  if (!type_check(layout().fields[col_].type, x))
     return false;
   row_[col_++] = std::move(x);
-  if (col_ == layout_.fields.size()) {
+  if (col_ == layout().fields.size()) {
     slice_->xs_.push_back(std::move(row_));
-    row_ = vector(layout_.fields.size());
+    row_ = vector(layout().fields.size());
     col_ = 0;
   }
   return true;
@@ -50,7 +50,7 @@ table_slice_ptr default_table_slice_builder::finish() {
   // Populate slice.
   // TODO: this feels messy, but allows for non-virtual parent accessors.
   slice_->rows_ = slice_->xs_.size();
-  slice_->columns_ = layout_.fields.size();
+  slice_->columns_ = layout().fields.size();
   return table_slice_ptr{slice_.release(), false};
 }
 
@@ -65,8 +65,8 @@ void default_table_slice_builder::reserve(size_t num_rows) {
 
 void default_table_slice_builder::lazy_init() {
   if (slice_ == nullptr) {
-    slice_.reset(new default_table_slice(layout_));
-    row_ = vector(layout_.fields.size());
+    slice_.reset(new default_table_slice(layout()));
+    row_ = vector(layout().fields.size());
     col_ = 0;
   }
 }

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -130,12 +130,8 @@ make_random_table_slices(size_t num_slices, size_t slice_size,
   result.reserve(num_slices);
   default_table_slice_builder builder{std::move(layout)};
   for (size_t i = 0; i < num_slices; ++i) {
-    for (size_t j = 0; j < slice_size; ++j) {
-      if (auto e = src.read(); !e)
-        return std::move(e.error());
-      else if (!builder.recursive_add(e->data(), e->type()))
-        return make_error(ec::unspecified, "recursive_add failed");
-    }
+    if (auto e = src.read(builder, slice_size))
+      return e;
     if (auto ptr = builder.finish(); ptr == nullptr) {
       return make_error(ec::unspecified, "finish failed");
     } else {

--- a/libvast/src/table_slice_builder.cpp
+++ b/libvast/src/table_slice_builder.cpp
@@ -20,6 +20,11 @@
 
 namespace vast {
 
+table_slice_builder::table_slice_builder(record_type layout)
+  : layout_(std::move(layout)) {
+  // nop
+}
+
 table_slice_builder::~table_slice_builder() {
   // nop
 }

--- a/libvast/vast/default_table_slice_builder.hpp
+++ b/libvast/vast/default_table_slice_builder.hpp
@@ -22,6 +22,10 @@ namespace vast {
 /// The default implementation of `table_slice_builder`.
 class default_table_slice_builder final : public table_slice_builder {
 public:
+  // -- member types -----------------------------------------------------------
+
+  using super = table_slice_builder;
+
   // -- constructors, destructors, and assignment operators --------------------
 
   default_table_slice_builder(record_type layout);
@@ -46,7 +50,6 @@ private:
 
   // -- member variables -------------------------------------------------------
 
-  record_type layout_;
   vector row_;
   size_t col_;
   std::unique_ptr<default_table_slice> slice_;

--- a/libvast/vast/format/test.hpp
+++ b/libvast/vast/format/test.hpp
@@ -22,6 +22,7 @@
 #include "vast/event.hpp"
 #include "vast/expected.hpp"
 #include "vast/format/reader.hpp"
+#include "vast/fwd.hpp"
 #include "vast/schema.hpp"
 
 #include "vast/detail/random.hpp"
@@ -73,6 +74,8 @@ public:
   explicit reader(size_t seed = 0, uint64_t n = 100);
 
   expected<event> read() override;
+
+  caf::error read(table_slice_builder& builder, size_t num);
 
   expected<void> schema(vast::schema sch) override;
 

--- a/libvast/vast/table_slice_builder.hpp
+++ b/libvast/vast/table_slice_builder.hpp
@@ -26,7 +26,7 @@ class table_slice_builder : public caf::ref_counted {
 public:
   // -- constructors, destructors, and assignment operators --------------------
 
-  table_slice_builder() = default;
+  table_slice_builder(record_type layout);
 
   ~table_slice_builder();
 
@@ -54,6 +54,13 @@ public:
   /// Allows the table slice builder to allocate sufficient storage for up to
   /// `num_rows` rows.
   virtual void reserve(size_t num_rows);
+
+  const record_type& layout() const noexcept {
+    return layout_;
+  }
+
+private:
+  record_type layout_;
 };
 
 /// @relates table_slice_builder

--- a/libvast/vast/table_slice_builder.hpp
+++ b/libvast/vast/table_slice_builder.hpp
@@ -55,6 +55,7 @@ public:
   /// `num_rows` rows.
   virtual void reserve(size_t num_rows);
 
+  /// @returns the table layout.
   const record_type& layout() const noexcept {
     return layout_;
   }


### PR DESCRIPTION
Working with the test reader for generating table slices is tedious, because the reader only generates `vast::event`.