### PR TITLE
Make cmake installation relocatable

### DIFF
--- a/cmake/FindBroker.cmake
+++ b/cmake/FindBroker.cmake
@@ -40,12 +40,20 @@ endif ()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  Broker
+  BROKER
   DEFAULT_MSG
   BROKER_LIBRARY
-  BROKER_INCLUDE_DIR)
+  BROKER_INCLUDE_DIRS)
 
 mark_as_advanced(
   BROKER_ROOT_DIR
   BROKER_LIBRARY
-  BROKER_INCLUDE_DIR)
+  BROKER_INCLUDE_DIRS)
+
+# create IMPORTED target
+if (BROKER_FOUND AND NOT TARGET broker::broker)
+  add_library(broker::broker UNKNOWN IMPORTED)
+  set_target_properties(broker::broker PROPERTIES
+    IMPORTED_LOCATION ${BROKER_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES "${BROKER_INCLUDE_DIRS}")
+endif()

--- a/cmake/FindCAF.cmake
+++ b/cmake/FindCAF.cmake
@@ -118,3 +118,36 @@ mark_as_advanced(CAF_ROOT_DIR
                  CAF_LIBRARIES
                  CAF_INCLUDE_DIRS)
 
+if (CAF_core_FOUND AND NOT TARGET caf::core)
+  add_library(caf::core UNKNOWN IMPORTED)
+  set_target_properties(caf::core PROPERTIES
+    IMPORTED_LOCATION "${CAF_LIBRARY_CORE}")
+  set_target_properties(caf::core PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CAF_INCLUDE_DIR_CORE}")
+endif ()
+if (CAF_io_FOUND AND NOT TARGET caf::io)
+  add_library(caf::io UNKNOWN IMPORTED)
+  set_target_properties(caf::io PROPERTIES
+    IMPORTED_LOCATION "${CAF_LIBRARY_IO}")
+  set_target_properties(caf::io PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${CAF_INCLUDE_DIR_IO}")
+endif ()
+if (CAF_openssl_FOUND AND NOT TARGET caf::openssl)
+  add_library(caf::openssl UNKNOWN IMPORTED)
+  set_target_properties(caf::openssl PROPERTIES
+    IMPORTED_LOCATION "${CAF_LIBRARY_OPENSSL}")
+  set_target_properties(caf::openssl PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CAF_INCLUDE_DIR_OPENSSL}")
+endif ()
+if (CAF_opencl_FOUND AND NOT TARGET caf::opencl)
+  add_library(caf::opencl UNKNOWN IMPORTED)
+  set_target_properties(caf::opencl PROPERTIES
+    IMPORTED_LOCATION "${CAF_LIBRARY_OPENCL}")
+  set_target_properties(caf::opencl PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CAF_INCLUDE_DIR_OPENCL}")
+endif ()
+if (CAF_test_FOUND AND NOT TARGET caf::test)
+  add_library(caf::test INTERFACE IMPORTED)
+  set_target_properties(caf::test PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CAF_INCLUDE_DIR_TEST}")
+endif ()

--- a/cmake/FindGperftools.cmake
+++ b/cmake/FindGperftools.cmake
@@ -49,3 +49,15 @@ mark_as_advanced(
   GPERFTOOLS_TCMALLOC_AND_PROFILER
   GPERFTOOLS_LIBRARIES
   GPERFTOOLS_INCLUDE_DIR)
+
+# create IMPORTED targets
+if (Gperftools_FOUND AND NOT TARGET gperftools::tcmalloc)
+  add_library(gperftools::tcmalloc UNKNOWN IMPORTED)
+  set_target_properties(gperftools::tcmalloc PROPERTIES
+    IMPORTED_LOCATION ${GPERFTOOLS_TCMALLOC}
+    INTERFACE_INCLUDE_DIRECTORIES "${GPERFTOOLS_INCLUDE_DIR}")
+  add_library(gperftools::profiler UNKNOWN IMPORTED)
+  set_target_properties(gperftools::profiler PROPERTIES
+    IMPORTED_LOCATION ${GPERFTOOLS_PROFILER}
+    INTERFACE_INCLUDE_DIRECTORIES "${GPERFTOOLS_INCLUDE_DIR}")
+endif()

--- a/cmake/FindPCAP.cmake
+++ b/cmake/FindPCAP.cmake
@@ -36,3 +36,10 @@ mark_as_advanced(
   PCAP_ROOT_DIR
   PCAP_LIBRARIES
   PCAP_INCLUDE_DIR)
+
+# create IMPORTED target for libpcap dependency
+if (PCAP_FOUND AND NOT TARGET pcap::pcap)
+  add_library(pcap::pcap UNKNOWN IMPORTED)
+  set_target_properties(pcap::pcap PROPERTIES
+    IMPORTED_LOCATION ${PCAP_LIBRARIES})
+endif()

--- a/cmake/FindSnappy.cmake
+++ b/cmake/FindSnappy.cmake
@@ -36,3 +36,10 @@ mark_as_advanced(
   SNAPPY_ROOT_DIR
   SNAPPY_LIBRARIES
   SNAPPY_INCLUDE_DIR)
+
+# create IMPORTED target
+if (SNAPPY_FOUND AND NOT TARGET snappy::snappy)
+  add_library(snappy::snappy UNKNOWN IMPORTED)
+  set_target_properties(snappy::snappy PROPERTIES
+    IMPORTED_LOCATION ${SNAPPY_LIBRARIES})
+endif()

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -5,9 +5,6 @@
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/vast/config.hpp.in
                ${CMAKE_CURRENT_BINARY_DIR}/vast/config.hpp)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
 # Some CMake generators (e.g., XCode) require header files in
 # addition to the sources.
 file(GLOB_RECURSE libvast_headers "${CMAKE_CURRENT_SOURCE_DIR}/vast/*.hpp")
@@ -122,30 +119,6 @@ if (PCAP_FOUND)
   )
 endif ()
 
-set(libvast_libs ${CAF_LIBRARIES})
-
-if (VAST_ENABLE_ASSERTIONS)
-  set(libvast_libs ${libvast_libs} ${Backtrace_LIBRARIES})
-endif ()
-
-if (SNAPPY_FOUND)
-  set(libvast_libs ${libvast_libs} ${SNAPPY_LIBRARIES})
-endif ()
-
-if (PCAP_FOUND)
-  set(libvast_libs ${libvast_libs} ${PCAP_LIBRARIES})
-endif ()
-
-# Always link with -lprofile if we have Gperftools.
-if (GPERFTOOLS_FOUND)
-  set(libvast_libs ${libvast_libs} ${GPERFTOOLS_PROFILER})
-endif ()
-
-# Only link against tcmalloc if requested.
-if (GPERFTOOLS_FOUND AND VAST_USE_PERFTOOLS_HEAP_PROFILER)
-  set(libvast_libs ${libvast_libs} ${GPERFTOOLS_TCMALLOC})
-endif ()
-
 add_library(libvast SHARED ${libvast_sources} ${libvast_headers})
 set_target_properties(libvast
   PROPERTIES
@@ -158,7 +131,36 @@ target_include_directories(libvast PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_link_libraries(libvast ${libvast_libs})
+target_link_libraries(libvast PUBLIC caf::core caf::io)
+if (VAST_USE_OPENSSL)
+  target_link_libraries(libvast PUBLIC caf::openssl)
+endif ()
+
+if (VAST_USE_OPENCL)
+  target_link_libraries(libvast PUBLIC caf::opencl)
+endif ()
+
+if (VAST_ENABLE_ASSERTIONS)
+  target_link_libraries(libvast PRIVATE ${Backtrace_LIBRARIES})
+endif ()
+
+if (SNAPPY_FOUND)
+  target_link_libraries(libvast PRIVATE snappy::snappy)
+endif ()
+
+if (PCAP_FOUND)
+  target_link_libraries(libvast PRIVATE pcap::pcap)
+endif ()
+
+# Always link with -lprofile if we have Gperftools.
+if (GPERFTOOLS_FOUND)
+  target_link_libraries(libvast PUBLIC gperftools::profiler)
+endif ()
+
+# Only link against tcmalloc if requested.
+if (GPERFTOOLS_FOUND AND VAST_USE_PERFTOOLS_HEAP_PROFILER)
+  target_link_libraries(libvast PUBLIC gperftools::tcmalloc)
+endif ()
 
 # Install libvast in PREFIX/lib and headers in PREFIX/include/vast.
 install(TARGETS libvast
@@ -175,12 +177,6 @@ install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/vast/"
 # ----------------------------------------------------------------------------
 #                                 unit tests
 # ----------------------------------------------------------------------------
-
-include_directories(
-  ${CMAKE_SOURCE_DIR}/libvast
-  ${CMAKE_BINARY_DIR}/libvast
-  ${CMAKE_CURRENT_SOURCE_DIR}/test
-  ${CMAKE_CURRENT_BINARY_DIR}/test)
 
 set(tests
   test/address.cpp


### PR DESCRIPTION
This patch adds imported targets to the cmake find modules. The `libvast` target uses those targets instead of the library files directly to cut the dependencies to the full paths to these files.