### PR TITLE
Remove superfluous message

### DIFF
--- a/libvast/src/system/source_command.cpp
+++ b/libvast/src/system/source_command.cpp
@@ -130,7 +130,6 @@ caf::message source_command(const command& cmd, caf::actor_system& sys,
     return make_message(std::move(err));
   // Start the source.
   bool stop = false;
-  self->send(src, system::run_atom::value);
   self->monitor(src);
   self->do_receive(
     [&](const down_msg& msg) {


### PR DESCRIPTION
Fixes the following warning when running VAST:

```
*** unexpected message [id: 7, name: bro-reader]: ('run')
```