### PR TITLE
Improve telemetry details in accountant (WIP)

### DIFF
--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -54,7 +54,7 @@ void init(accountant_actor* self, const path& filename) {
   file << "time\thost\tpid\taid\tkey\tvalue\n";
   if (!file)
     self->quit(make_error(ec::filesystem_error));
-  // Kick off flush loop.
+  VAST_DEBUG(self, "kicks off flush loop");
   self->send(self, flush_atom::value);
 }
 
@@ -77,7 +77,7 @@ void record(accountant_actor* self, const std::string& key, T x) {
   // Flush after at most 10 seconds.
   if (!st.flush_pending) {
     st.flush_pending = true;
-    self->delayed_send(self, seconds(10), flush_atom::value);
+    self->delayed_send(self, 10s, flush_atom::value);
   }
 }
 

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -247,7 +247,8 @@ void node_state::init(std::string init_name, path init_dir) {
   // Set member variables.
   name = std::move(init_name);
   dir = std::move(init_dir);
-  // Bring up the accountant.
+  // Bring up the accountant here where we know the log path. The tracker shuts
+  // it down upon termination.
   auto accountant_log = dir / "log" / "current" / "accounting.log";
   accountant = self->spawn<monitored>(system::accountant,
                                       std::move(accountant_log));

--- a/libvast/src/system/source_command.cpp
+++ b/libvast/src/system/source_command.cpp
@@ -110,7 +110,14 @@ caf::message source_command(const command& cmd, caf::actor_system& sys,
   caf::actor importer;
   self->request(node, infinite, get_atom::value).receive(
     [&](const std::string& id, system::registry& reg) {
-      auto er = reg.components[id].equal_range("importer");
+      // Assign accountant to source.
+      VAST_DEBUG(&cmd, "assigns accountant from node", id, "to new source");
+      auto er = reg.components[id].equal_range("accountant");
+      VAST_ASSERT(er.first != er.second);
+      auto accountant = er.first->second.actor;
+      self->send(src, actor_cast<accountant_type>(accountant));
+      // Assign IMPORTER to SOURCE and start streaming.
+      er = reg.components[id].equal_range("importer");
       if (er.first == er.second) {
         err = make_error(ec::no_importer);
       } else if (reg.components[id].count("importer") > 1) {

--- a/libvast/src/system/tracker.cpp
+++ b/libvast/src/system/tracker.cpp
@@ -134,13 +134,13 @@ tracker(tracker_type::stateful_pointer<tracker_state> self, std::string node) {
   self->set_down_handler(
     [=](const down_msg& msg) {
       auto pred = [&](auto& p) { return p.second.actor == msg.source; };
-      for (auto& peer : self->state.registry.components) {
-        auto i = std::find_if(peer.second.begin(), peer.second.end(), pred);
-        if (i != peer.second.end()) {
+      for (auto& [node, comp_state] : self->state.registry.components) {
+        auto i = std::find_if(comp_state.begin(), comp_state.end(), pred);
+        if (i != comp_state.end()) {
           if (i->first == "tracker")
-            self->state.registry.components.erase(peer.first);
+            self->state.registry.components.erase(node);
           else
-            peer.second.erase(i);
+            comp_state.erase(i);
           return;
         }
       }

--- a/libvast/vast/system/accountant.hpp
+++ b/libvast/vast/system/accountant.hpp
@@ -35,14 +35,13 @@ struct accountant_state {
 
 using accountant_type =
   caf::typed_actor<
-    caf::reacts_to<shutdown_atom>,
-    caf::reacts_to<flush_atom>,
     caf::reacts_to<std::string, std::string>,
     caf::reacts_to<std::string, timespan>,
     caf::reacts_to<std::string, timestamp>,
     caf::reacts_to<std::string, int64_t>,
     caf::reacts_to<std::string, uint64_t>,
-    caf::reacts_to<std::string, double>
+    caf::reacts_to<std::string, double>,
+    caf::reacts_to<flush_atom>
   >;
 
 /// Accumulates various performance metrics in a key-value format and writes

--- a/libvast/vast/system/datagram_source.hpp
+++ b/libvast/vast/system/datagram_source.hpp
@@ -49,10 +49,10 @@
 namespace vast::system {
 
 template <class Reader>
-struct datagram_source_state : source_state<Reader> {
+struct datagram_source_state : source_state<Reader, caf::io::broker> {
   // -- member types -----------------------------------------------------------
 
-  using super = source_state<Reader>;
+  using super = source_state<Reader, caf::io::broker>;
 
   // -- constructors, destructors, and assignment operators --------------------
 


### PR DESCRIPTION
This PR fixes the empty accounting.log and adds extra telemetry to better understand VAST's internals.

- [x] Fix accountant
- [x] Add telemetry from SOURCEs
- [ ] Add telemetry from SINKs
- [ ] Add telemetry from INDEX
- [ ] Add telemetry from ARCHIVE
- [ ] Add telemetry from EXPORTERs