### PR TITLE
Rename "show" to "status" command

### DIFF
--- a/doc/vast.1.md
+++ b/doc/vast.1.md
@@ -130,7 +130,7 @@ commands exist:
     *start*         starts a node
     *stop*          stops a node
     *peer*          peers with another node
-    *show*          shows various properties of a topology
+    *status*        shows various properties of a topology
     *spawn*         creates a new component
     *kill*          terminates a component
     *import*        imports data from STDIN or file
@@ -161,11 +161,11 @@ Synopsis:
 Joins a topology through a node identified by *endpoint*.
 See **OPTIONS** for a description of the *endpoint* syntax.
 
-### show
+### status
 
 Synopsis:
 
-  *show*
+  *status*
 
 Displays various properties of a topology.
 
@@ -359,7 +359,7 @@ Make the node at 10.0.0.1 peer with 10.0.0.2:
 
 Connect to a node running at 1.2.3.4 on port 31337 and display topology details:
 
-    vast -e 1.2.3.4:31337 show
+    vast -e 1.2.3.4:31337 status
 
 FORMATS
 -------

--- a/libvast/src/system/default_application.cpp
+++ b/libvast/src/system/default_application.cpp
@@ -48,10 +48,11 @@ default_application::default_application() {
   // Add standalone commands.
   add(start_command, "start", "starts a node", opts());
   add(remote_command, "stop", "stops a node", opts());
-  add(remote_command, "show", "shows various properties of a topology", opts());
   add(remote_command, "spawn", "creates a new component", opts());
   add(remote_command, "kill", "terminates a component", opts());
   add(remote_command, "peer", "peers with another node", opts());
+  add(remote_command, "status", "shows various properties of a topology",
+      opts());
   // Add "import" command and its children.
   import_ = add(nullptr, "import", "imports data from STDIN or file",
                 opts()

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -79,7 +79,7 @@ void peer(node_ptr self, message args) {
   rp.delegate(*peer, peer_atom::value, t, self->state.name);
 }
 
-void show(node_ptr self, message /* args */) {
+void status(node_ptr self, message /* args */) {
   auto rp = self->make_response_promise();
   self->request(self->state.tracker, infinite, get_atom::value).then(
     [=](const registry& reg) mutable {
@@ -267,8 +267,8 @@ caf::behavior node(node_ptr self, std::string id, path dir) {
         stop(self);
       } else if (cmd == "peer") {
         peer(self, args);
-      } else if (cmd == "show") {
-        show(self, args);
+      } else if (cmd == "status") {
+        status(self, args);
       } else if (cmd == "spawn") {
         spawn(self, args);
       } else if (cmd == "kill") {


### PR DESCRIPTION
This reflects our intention to have this command print more than "just" the topology. For example, partition size, total number of events, etc.