### PR TITLE
Enrich status command with actor system stats

### DIFF
--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -90,6 +90,12 @@ void status(node_ptr self, message /* args */) {
           xs.push_back(json{pair.second.label});
         result.emplace(peer.first, std::move(xs));
       }
+      json::object sys_stats;
+      auto& sys = self->system();
+      sys_stats.emplace("running-actors", sys.registry().running());
+      sys_stats.emplace("detached-actors", sys.detached_actors());
+      sys_stats.emplace("worker-threads", sys.scheduler().num_workers());
+      result.emplace("system", std::move(sys_stats));
       rp.deliver(to_string(json{std::move(result)}));
     }
   );


### PR DESCRIPTION
Adds 1) nr. of running actors, 2) nr. of detached actors, and 3) nr. of worker threads to the output of `vast status`.

This is by no means an exhaustive list and we might add more CAF stats in the future.