### PR TITLE
Remove magic numbers for the log level from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,18 @@ list(GET version_numbers 0 VERSION_MAJOR)
 list(GET version_numbers 1 VERSION_MINOR)
 set(VERSION_MAJ_MIN "${VERSION_MAJOR}.${VERSION_MINOR}")
 
-set(default_log_level "4")
-if (CMAKE_BUILD_TYPE STREQUAL Release OR CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
-  set(default_log_level "2")
+# make sure log level is defined and all-uppercase
+if (NOT VAST_LOG_LEVEL)
+  # use INFO as default level for release builds and TRACE otherwise
+  if (CMAKE_BUILD_TYPE STREQUAL Release OR CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
+    set(VAST_LOG_LEVEL "INFO")
+  else ()
+    set(VAST_LOG_LEVEL "TRACE")
+  endif ()
+else ()
+  string(TOUPPER "${VAST_LOG_LEVEL}" VAST_LOG_LEVEL)
 endif ()
+
 set(VAST_LOG_LEVEL ${default_log_level} CACHE STRING
     "maximum log level that can be set during runtime execution")
 
@@ -475,27 +483,6 @@ display(VAST_ENABLE_ASSERTIONS yes assertions_summary)
 display(ASAN_FOUND yes asan_summary)
 display(ENABLE_GCOV yes gcov_summary)
 
-if (VAST_LOG_LEVEL EQUAL -1)
-  set(log_level_summary quiet)
-elseif (VAST_LOG_LEVEL EQUAL 0)
-  set(log_level_summary error)
-elseif (VAST_LOG_LEVEL EQUAL 1)
-  set(log_level_summary warning)
-elseif (VAST_LOG_LEVEL EQUAL 2)
-  set(log_level_summary info)
-elseif (VAST_LOG_LEVEL EQUAL 3)
-  set(log_level_summary debug)
-elseif (VAST_LOG_LEVEL EQUAL 4)
-  set(log_level_summary trace)
-else ()
-  # Pick default level based on build type.
-  if (CMAKE_BUILD_TYPE STREQUAL "Release")
-    set(log_level_summary info)
-  else ()
-    set(log_level_summary debug)
-  endif ()
-endif ()
-
 # Figure out whether we point to a build directory or a prefix.
 set(caf_dir ${CAF_LIBRARY_CORE})
 get_filename_component(caf_dir ${caf_dir} PATH)
@@ -537,7 +524,7 @@ set(summary
     "\nInstall prefix:   ${CMAKE_INSTALL_PREFIX}"
     "\n"
     "\nBuild type:       ${CMAKE_BUILD_TYPE}"
-    "\nLog level:        ${log_level_summary}"
+    "\nLog level:        ${VAST_LOG_LEVEL}"
     "\nShow time report: ${time_report_summary}"
     "\nAssertions:       ${assertions_summary}"
     "\nAddressSanitizer: ${asan_summary}"

--- a/configure
+++ b/configure
@@ -72,33 +72,6 @@ append_cache_entry() {
   CMakeCacheEntries="$CMakeCacheEntries -D \"$1:$2=$3\""
 }
 
-levelize() {
-  case "$1" in
-    quiet)
-      echo -1
-      ;;
-    error)
-      echo 0
-      ;;
-    warning)
-      echo 1
-      ;;
-    info)
-      echo 2
-      ;;
-    debug)
-      echo 3
-      ;;
-    trace)
-      echo 4
-      ;;
-    *)
-      echo "invalid log level specification, use:"
-      echo "  quiet|error|warning|info|debug|trace"
-      exit 1;
-  esac
-}
-
 # Set defaults
 builddir=build
 CMakeCacheEntries=""
@@ -153,7 +126,7 @@ while [ $# -ne 0 ]; do
         append_cache_entry MORE_WARNINGS BOOL yes
         ;;
     --log-level=*)
-      append_cache_entry VAST_LOG_LEVEL INTEGER $(levelize $optarg)
+      append_cache_entry VAST_LOG_LEVEL STRING "$optarg"
       ;;
     --disable-assertions)
       append_cache_entry VAST_ENABLE_ASSERTIONS BOOL false

--- a/libvast/vast/config.hpp.in
+++ b/libvast/vast/config.hpp.in
@@ -12,7 +12,7 @@
 #include <caf/config.hpp>
 
 #define VAST_VERSION @VERSION_MAJ_MIN@
-#define VAST_LOG_LEVEL @VAST_LOG_LEVEL@
+#define VAST_LOG_LEVEL CAF_LOG_LEVEL_@VAST_LOG_LEVEL@
 
 #if defined(CAF_CLANG)
 #  define VAST_CLANG


### PR DESCRIPTION
PR https://github.com/actor-framework/actor-framework/pull/797 changes the values for the log levels upstream. These changes remove magic numbers entirely from the build system, adapting to the recent CAF changes while also making our CMake robust to changes in the future.