### PR TITLE
Add regression test for IMPORTER stream errors

### DIFF
--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -133,7 +133,7 @@ using deterministic_fixture_base
 
 struct deterministic_fixture : deterministic_fixture_base {
   deterministic_fixture() : deterministic_fixture_base(100u) {
-    MESSAGE(")run initialization code");
+    MESSAGE("run initialization code");
     run();
   }
 


### PR DESCRIPTION
We recently fixed a bug where failing sources of the IMPORTER killed ARCHIVE and INDEX. This regression test makes sure that this won't happen again.