### PR TITLE
Migrate attribute extractor data from string to atom

### DIFF
--- a/libvast/src/expression.cpp
+++ b/libvast/src/expression.cpp
@@ -19,8 +19,8 @@ namespace vast {
 
 // -- attribute_extractor ------------------------------------------------------
 
-attribute_extractor::attribute_extractor(std::string str)
-  : attr{std::move(str)} {
+attribute_extractor::attribute_extractor(caf::atom_value str) : attr{str} {
+  // nop
 }
 
 bool operator==(const attribute_extractor& x, const attribute_extractor& y) {

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -25,6 +25,7 @@
 #include "vast/die.hpp"
 #include "vast/event.hpp"
 #include "vast/expression_visitors.hpp"
+#include "vast/system/atoms.hpp"
 #include "vast/type.hpp"
 
 namespace vast {
@@ -244,11 +245,13 @@ expected<void> validator::operator()(const predicate& p) {
 
 expected<void> validator::operator()(const attribute_extractor& ex,
                                      const data& d) {
-  if (ex.attr == "type" && !caf::holds_alternative<std::string>(d))
+  if (ex.attr == system::type_atom::value
+      && !caf::holds_alternative<std::string>(d))
     return make_error(ec::syntax_error,
                       "type attribute extractor requires string operand",
                       ex.attr, op_, d);
-  else if (ex.attr == "time" && !caf::holds_alternative<timestamp>(d))
+  else if (ex.attr == system::time_atom::value
+           && !caf::holds_alternative<timestamp>(d))
     return make_error(ec::syntax_error,
                       "time attribute extractor requires timestamp operand",
                       ex.attr, op_, d);
@@ -499,9 +502,9 @@ bool event_evaluator::operator()(const predicate& p) {
 bool event_evaluator::operator()(const attribute_extractor& e, const data& d) {
   // FIXME: perform a transformation on the AST that replaces the attribute
   // with the corresponding function object.
-  if (e.attr == "type")
+  if (e.attr == system::type_atom::value)
     return evaluate(event_.type().name(), op_, d);
-  if (e.attr == "time")
+  if (e.attr == system::time_atom::value)
     return evaluate(event_.timestamp(), op_, d);
   return false;
 }
@@ -560,10 +563,10 @@ bool matcher::operator()(const predicate& p) {
 }
 
 bool matcher::operator()(const attribute_extractor& e, const data& d) {
-  if (e.attr == "type") {
+  if (e.attr == system::type_atom::value) {
     VAST_ASSERT(caf::holds_alternative<std::string>(d));
     return evaluate(d, op_, type_.name());
-  } else if (e.attr == "time") {
+  } else if (e.attr == system::time_atom::value) {
     return true; // Every event has a timestamp.
   }
   return false;

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -15,6 +15,7 @@
 
 #include "vast/expression.hpp"
 #include "vast/logger.hpp"
+#include "vast/system/atoms.hpp"
 #include "vast/table_index.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/time.hpp"
@@ -130,7 +131,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
       };
       return caf::visit(detail::overload(
         [&](const attribute_extractor& lhs, const data&) -> result_type {
-          if (lhs.attr == "time") {
+          if (lhs.attr == system::time_atom::value) {
             auto pred = [](auto& field) {
               // FIXME: we should really just look at the &timestamp attribute
               // and not all fields of type time. [ch3843]

--- a/libvast/src/table_index.cpp
+++ b/libvast/src/table_index.cpp
@@ -22,6 +22,7 @@
 
 #include "vast/detail/overload.hpp"
 #include "vast/detail/string.hpp"
+#include "vast/system/atoms.hpp"
 
 namespace vast {
 namespace {
@@ -249,14 +250,14 @@ caf::expected<bitmap> table_index::lookup_impl(const predicate& pred,
                                                const attribute_extractor& ex,
                                                const data& x) {
   VAST_TRACE(VAST_ARG(pred), VAST_ARG(ex), VAST_ARG(x));
-  if (ex.attr == "type") {
+  if (ex.attr == system::type_atom::value) {
     VAST_ASSERT(caf::holds_alternative<std::string>(x));
     // No hits if the queries name doesn't match our type.
     if (layout().name() != caf::get<std::string>(x))
       return ids{};
     // Otherwise all rows match.
     return row_ids_;
-  } else if (ex.attr == "time") {
+  } else if (ex.attr == system::time_atom::value) {
     // TODO: reconsider whether we still want to support "&time ..." queries.
     VAST_ASSERT(caf::holds_alternative<timestamp>(x));
     if (layout().fields.empty() || layout().fields[0].type != timestamp_type{})

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -39,7 +39,8 @@ struct fixture : fixtures::deterministic_actor_system {
   fixture() {
     // expr0 := !(x.y.z <= 42 && &foo == T)
     auto p0 = predicate{key_extractor{"x.y.z"}, less_equal, data{42}};
-    auto p1 = predicate{attribute_extractor{{"foo"}}, equal, data{true}};
+    auto p1 = predicate{attribute_extractor{caf::atom("foo")},
+                        equal, data{true}};
     auto conj = conjunction{p0, p1};
     expr0 = negation{conj};
     // expr0 || :real > 4.2

--- a/libvast/test/expression_parseable.cpp
+++ b/libvast/test/expression_parseable.cpp
@@ -11,17 +11,23 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include "vast/concept/parseable/to.hpp"
+#define SUITE expression
+
 #include "vast/concept/parseable/vast/expression.hpp"
+
+#include "vast/test/test.hpp"
+
+#include "vast/concept/parseable/to.hpp"
 #include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/expression.hpp"
-
-#define SUITE expression
-#include "vast/test/test.hpp"
+#include "vast/system/atoms.hpp"
 
 using namespace vast;
 using namespace std::string_literals;
+
+using vast::system::time_atom;
+using vast::system::type_atom;
 
 TEST(parseable/printable - predicate) {
   predicate pred;
@@ -42,7 +48,7 @@ TEST(parseable/printable - predicate) {
   // LHS: type, RHS: data
   str = "&type != \"foo\"";
   CHECK(parsers::predicate(str, pred));
-  CHECK(pred.lhs == attribute_extractor{"type"});
+  CHECK(pred.lhs == attribute_extractor{type_atom::value});
   CHECK(pred.op == not_equal);
   CHECK(pred.rhs == data{"foo"});
   CHECK_EQUAL(to_string(pred), str);
@@ -65,7 +71,7 @@ TEST(parseable/printable - predicate) {
   CHECK(parsers::predicate(str, pred));
   CHECK(caf::holds_alternative<data>(pred.lhs));
   CHECK(pred.op == greater);
-  CHECK(pred.rhs == attribute_extractor{"time"});
+  CHECK(pred.rhs == attribute_extractor{time_atom::value});
   str = "x.a_b == y.c_d";
   CHECK(parsers::predicate(str, pred));
   CHECK(pred.lhs == key_extractor{"x.a_b"});

--- a/libvast/vast/concept/parseable/vast/expression.hpp
+++ b/libvast/vast/concept/parseable/vast/expression.hpp
@@ -32,7 +32,7 @@ struct predicate_parser : parser<predicate_parser> {
     using parsers::chr;
     using namespace parser_literals;
     auto to_attr_extractor = [](std::string str) -> predicate::operand {
-      return attribute_extractor{std::move(str)};
+      return attribute_extractor{caf::atom_from_string(str)};
     };
     auto to_type_extractor = [](type t) -> predicate::operand {
       return type_extractor{t};

--- a/libvast/vast/concept/printable/vast/expression.hpp
+++ b/libvast/vast/concept/printable/vast/expression.hpp
@@ -64,7 +64,7 @@ struct expression_printer : printer<expression_printer> {
     }
 
     bool operator()(const attribute_extractor& e) const {
-      return ('&' << printers::str)(out_, e.attr);
+      return ('&' << printers::str)(out_, to_string(e.attr));
     }
 
     bool operator()(const type_extractor& e) const {

--- a/libvast/vast/expression.hpp
+++ b/libvast/vast/expression.hpp
@@ -18,6 +18,7 @@
 #include <type_traits>
 #include <vector>
 
+#include <caf/atom.hpp>
 #include <caf/default_sum_type_access.hpp>
 #include <caf/detail/type_list.hpp>
 #include <caf/none.hpp>
@@ -39,9 +40,9 @@ class expression;
 
 /// Extracts a specific attributes from an event.
 struct attribute_extractor : detail::totally_ordered<attribute_extractor> {
-  attribute_extractor(std::string str = {});
+  attribute_extractor(caf::atom_value str = caf::atom(""));
 
-  std::string attr;
+  caf::atom_value attr;
 };
 
 bool operator==(const attribute_extractor& x, const attribute_extractor& y);

--- a/libvast/vast/system/atoms.hpp
+++ b/libvast/vast/system/atoms.hpp
@@ -102,5 +102,9 @@ using worker_atom = caf::atom_constant<caf::atom("worker")>;
 using exporter_atom = caf::atom_constant<caf::atom("exporter")>;
 using importer_atom = caf::atom_constant<caf::atom("importer")>;
 
+// Attributes
+using time_atom = caf::atom_constant<caf::atom("time")>;
+using type_atom = caf::atom_constant<caf::atom("type")>;
+
 } // namespace vast::system
 


### PR DESCRIPTION
This makes the attribute extractor more lightweight and dispatching on attributes cheaper.