### PR TITLE
Introduce simple_store

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -87,6 +87,7 @@ set(libvast_sources
   src/system/profiler.cpp
   src/system/remote_command.cpp
   src/system/signal_monitor.cpp
+  src/system/simple_store.cpp
   src/system/sink_command.cpp
   src/system/source_command.cpp
   src/system/spawn.cpp

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -243,6 +243,7 @@ set(tests
   test/system/partition.cpp
   test/system/queries.cpp
   test/system/replicated_store.cpp
+  test/system/simple_store.cpp
   test/system/sink.cpp
   test/system/source.cpp
   test/system/task.cpp

--- a/libvast/src/system/default_application.cpp
+++ b/libvast/src/system/default_application.cpp
@@ -45,8 +45,10 @@ default_application::default_application() {
     .add<bool>("version,v", "print version and exit");
   // Default options for commands.
   auto opts = [] { return command::opts(); };
+  auto backend_opt = caf::make_config_option<std::string>(
+    "global", "store-backend", "The backend for the meta store (simple|raft)");
   // Add standalone commands.
-  add(start_command, "start", "starts a node", opts());
+  add(start_command, "start", "starts a node", opts().add(backend_opt));
   add(remote_command, "stop", "stops a node", opts());
   add(remote_command, "spawn", "creates a new component", opts());
   add(remote_command, "kill", "terminates a component", opts());
@@ -59,7 +61,8 @@ default_application::default_application() {
                   .add<bool>("node,n",
                              "spawn a node instead of connecting to one")
                   .add<bool>("blocking,b",
-                             "block until the IMPORTER forwarded all data"));
+                             "block until the IMPORTER forwarded all data")
+                  .add(backend_opt));
   import_->add(reader_command<format::bro::reader>, "bro",
                "imports Bro logs from STDIN or file", src_opts());
   import_->add(reader_command<format::mrt::reader>, "mrt",
@@ -79,7 +82,8 @@ default_application::default_application() {
                   .add<bool>("continuous,c", "marks a query as continuous")
                   .add<bool>("historical,h", "marks a query as historical")
                   .add<bool>("unified,u", "marks a query as unified")
-                  .add<size_t>("events,e", "maximum number of results"));
+                  .add<size_t>("events,e", "maximum number of results")
+                  .add(backend_opt));
   export_->add(writer_command<format::bro::writer>, "bro",
                "exports query results in Bro format", snk_opts());
   export_->add(writer_command<format::csv::writer>, "csv",

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -31,7 +31,6 @@
 #include "vast/logger.hpp"
 
 #include "vast/system/accountant.hpp"
-#include "vast/system/consensus.hpp"
 #include "vast/system/node.hpp"
 #include "vast/system/spawn.hpp"
 

--- a/libvast/src/system/simple_store.cpp
+++ b/libvast/src/system/simple_store.cpp
@@ -1,0 +1,88 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/system/simple_store.hpp"
+
+#include <caf/all.hpp>
+#include <caf/none.hpp>
+
+#include "vast/filesystem.hpp"
+#include "vast/load.hpp"
+#include "vast/save.hpp"
+
+
+namespace vast::system {
+
+namespace {
+
+void spawn_metastore(caf::local_actor* self) {
+  auto store = self->spawn(simple_store, "");
+}
+
+}
+
+caf::error simple_store_state::init(actor_ptr self, path dir) {
+  file = std::move(dir) / "store";
+  if (exists(file)) {
+    if (auto err = vast::load(self->system(), file, store)) {
+      VAST_WARNING_ANON(name, "unable to load state file:", file);
+      return err;
+    }
+  }
+  return caf::none;
+}
+
+caf::error simple_store_state::save(caf::actor_system& sys) {
+  return vast::save(sys, file, store);
+}
+
+/// A key-value store that stores its data in a `std::unordered_map`.
+/// @param self The actor handle.
+meta_store_type::behavior_type
+simple_store(simple_store_state::actor_ptr self, path dir) {
+  using behavior_type = meta_store_type::behavior_type;
+  if (auto err = self->state.init(self, std::move(dir))) {
+    self->quit(std::move(err));
+    return behavior_type::make_empty_behavior();
+  }
+  return {
+    [=](put_atom, const std::string& key, data& value) -> caf::result<ok_atom> {
+      self->state.store[key] = std::move(value);
+      if (auto err = self->state.save(self->system()))
+        return err;
+      return ok_atom::value;
+    },
+    [=](add_atom, const std::string& key, const data& value) -> caf::result<data> {
+      auto& v = self->state.store[key];
+      auto old = v;
+      v += value;
+      if (auto err = self->state.save(self->system()))
+        return err;
+      return old;
+    },
+    [=](delete_atom, const std::string& key) -> caf::result<ok_atom> {
+      self->state.store.erase(key);
+      if (auto err = self->state.save(self->system()))
+        return err;
+      return ok_atom::value;
+    },
+    [=](get_atom, const std::string& key) -> caf::result<optional<data>> {
+      auto i = self->state.store.find(key);
+      if (i == self->state.store.end())
+        return caf::none;
+      return i->second;
+    }
+  };
+}
+
+} // namespace vast::system

--- a/libvast/src/system/simple_store.cpp
+++ b/libvast/src/system/simple_store.cpp
@@ -25,11 +25,14 @@ namespace vast::system {
 
 namespace {
 
+// TODO: Without this workaround *actor_ptr is not
+//       fully defined below. This should be replaced
+//       by the corret explicit instantiation(s).
 void spawn_metastore(caf::local_actor* self) {
   auto store = self->spawn(simple_store, "");
 }
 
-}
+} // namespace <anonymous>
 
 caf::error simple_store_state::init(actor_ptr self, path dir) {
   file = std::move(dir) / "store";

--- a/libvast/src/system/simple_store.cpp
+++ b/libvast/src/system/simple_store.cpp
@@ -23,19 +23,12 @@
 
 namespace vast::system {
 
-namespace {
-
-// TODO: Without this workaround *actor_ptr is not
-//       fully defined below. This should be replaced
-//       by the corret explicit instantiation(s).
-void spawn_metastore(caf::local_actor* self) {
-  auto store = self->spawn(simple_store, "");
+simple_store_state::simple_store_state(actor_ptr self)
+  : self{self} {
+  // nop
 }
 
-} // namespace <anonymous>
-
-caf::error simple_store_state::init(actor_ptr self, path dir) {
-  this->self = self;
+caf::error simple_store_state::init(path dir) {
   file = std::move(dir) / "store";
   if (exists(file)) {
     if (auto err = vast::load(self->system(), file, store)) {
@@ -55,7 +48,7 @@ caf::error simple_store_state::save() {
 meta_store_type::behavior_type
 simple_store(simple_store_state::actor_ptr self, path dir) {
   using behavior_type = meta_store_type::behavior_type;
-  if (auto err = self->state.init(self, std::move(dir))) {
+  if (auto err = self->state.init(std::move(dir))) {
     self->quit(std::move(err));
     return behavior_type::make_empty_behavior();
   }

--- a/libvast/src/system/spawn.cpp
+++ b/libvast/src/system/spawn.cpp
@@ -29,6 +29,7 @@
 
 #include "vast/system/atoms.hpp"
 #include "vast/system/archive.hpp"
+#include "vast/system/simple_store.hpp"
 #include "vast/system/importer.hpp"
 #include "vast/system/index.hpp"
 #include "vast/system/exporter.hpp"
@@ -148,7 +149,7 @@ expected<actor> spawn_index(local_actor* self, options& opts) {
                      taste_parts, num_collectors);
 }
 
-expected<actor> spawn_metastore(local_actor* self, options& opts) {
+expected<actor> spawn_metastore_raft(local_actor* self, options& opts) {
   auto id = raft::server_id{0};
   auto r = opts.params.extract_opts({
     {"id,i", "the server ID of the consensus module", id},
@@ -170,6 +171,26 @@ expected<actor> spawn_metastore(local_actor* self, options& opts) {
     }
   );
   return actor_cast<actor>(s);
+}
+
+expected<actor> spawn_metastore_simple(local_actor* self,
+                                       options& opts) {
+  auto store = self->spawn(simple_store<std::string, data>,
+                           opts.dir / "simple_store");
+  return actor_cast<actor>(store);
+}
+
+expected<actor> spawn_metastore(local_actor* self, options& opts) {
+  auto backend = "simple"s;
+  auto r = opts.params.extract_opts({
+    {"store-backend", "the store backend (simple|raft)", backend},
+  });
+  opts.params = r.remainder;
+  if (backend == "simple")
+    return spawn_metastore_simple(self, opts);
+  if (backend == "raft")
+    return spawn_metastore_raft(self, opts);
+  return make_error(ec::unrecognized_option, backend);
 }
 
 #ifdef VAST_HAVE_GPERFTOOLS

--- a/libvast/src/system/spawn.cpp
+++ b/libvast/src/system/spawn.cpp
@@ -175,7 +175,7 @@ expected<actor> spawn_metastore_raft(local_actor* self, options& opts) {
 
 expected<actor> spawn_metastore_simple(local_actor* self,
                                        options& opts) {
-  auto store = self->spawn(simple_store<std::string, data>,
+  auto store = self->spawn(simple_store,
                            opts.dir / "simple_store");
   return actor_cast<actor>(store);
 }

--- a/libvast/test/system/simple_store.cpp
+++ b/libvast/test/system/simple_store.cpp
@@ -1,0 +1,95 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include <caf/all.hpp>
+
+#include "vast/system/atoms.hpp"
+#include "vast/system/simple_store.hpp"
+
+#define SUITE simple_store
+#include "vast/test/test.hpp"
+#include "vast/test/fixtures/actor_system.hpp"
+
+using namespace caf;
+using namespace vast;
+using namespace vast::system;
+
+FIXTURE_SCOPE(simple_store_tests, fixtures::actor_system)
+
+TEST(simple store) {
+  auto store_dir = directory / "simple-store";
+  {
+    auto store = self->spawn(simple_store<std::string, int>, store_dir);
+    MESSAGE("put two values");
+    self->request(store, infinite, put_atom::value, "foo", 42).receive(
+      [&](ok_atom) {},
+      error_handler()
+    );
+    MESSAGE("get a key with a single value");
+    self->request(store, infinite, get_atom::value, "foo").receive(
+      [&](optional<int> result) {
+        REQUIRE(result);
+        CHECK_EQUAL(*result, 42);
+      },
+      error_handler()
+    );
+    MESSAGE("get an invalid key value");
+    self->request(store, infinite, get_atom::value, "bar").receive(
+      [&](optional<int> result) {
+        CHECK(!result);
+      },
+      error_handler()
+    );
+    MESSAGE("add to an existing single value");
+    self->request(store, infinite, add_atom::value, "foo", 1).receive(
+      [&](int old) {
+        CHECK_EQUAL(old, 42);
+      },
+      error_handler()
+    );
+    MESSAGE("add to a non-existing single value");
+    self->request(store, infinite, add_atom::value, "baz", 1).receive(
+      [&](int old) {
+        CHECK_EQUAL(old, 0);
+      },
+      error_handler()
+    );
+    MESSAGE("delete a key");
+    self->request(store, infinite, delete_atom::value, "foo").receive(
+      [](ok_atom) { /* nop */ },
+      error_handler()
+    );
+    MESSAGE("restart the store, forcing a serialize -> deserialize loop");
+    self->send_exit(store, exit_reason::user_shutdown);
+  }
+  {
+    auto store = self->spawn(simple_store<std::string, int>, store_dir);
+    MESSAGE("get a value from the store's previous lifetime");
+    self->request(store, infinite, get_atom::value, "baz").receive(
+      [&](optional<int> result) {
+        REQUIRE(result);
+        CHECK_EQUAL(*result, 1);
+      },
+      error_handler()
+    );
+    MESSAGE("get a key that was deleted during the store's previous lfetime");
+    self->request(store, infinite, get_atom::value, "foo").receive(
+      [&](optional<int> result) {
+        CHECK(!result);
+      },
+      error_handler()
+    );
+  }
+}
+
+FIXTURE_SCOPE_END()

--- a/libvast/test/system/simple_store.cpp
+++ b/libvast/test/system/simple_store.cpp
@@ -60,7 +60,7 @@ TEST(simple store) {
     MESSAGE("add to a non-existing single value");
     self->request(store, infinite, add_atom::value, "baz", data{1}).receive(
       [&](data old) {
-        CHECK_EQUAL(old, data{0});
+        CHECK_EQUAL(old, caf::none);
       },
       error_handler()
     );

--- a/libvast/test/system/simple_store.cpp
+++ b/libvast/test/system/simple_store.cpp
@@ -29,38 +29,38 @@ FIXTURE_SCOPE(simple_store_tests, fixtures::actor_system)
 TEST(simple store) {
   auto store_dir = directory / "simple-store";
   {
-    auto store = self->spawn(simple_store<std::string, int>, store_dir);
+    auto store = self->spawn(simple_store, store_dir);
     MESSAGE("put two values");
-    self->request(store, infinite, put_atom::value, "foo", 42).receive(
+    self->request(store, infinite, put_atom::value, "foo", data{42}).receive(
       [&](ok_atom) {},
       error_handler()
     );
     MESSAGE("get a key with a single value");
     self->request(store, infinite, get_atom::value, "foo").receive(
-      [&](optional<int> result) {
+      [&](optional<data> result) {
         REQUIRE(result);
-        CHECK_EQUAL(*result, 42);
+        CHECK_EQUAL(*result, data{42});
       },
       error_handler()
     );
     MESSAGE("get an invalid key value");
     self->request(store, infinite, get_atom::value, "bar").receive(
-      [&](optional<int> result) {
+      [&](optional<data> result) {
         CHECK(!result);
       },
       error_handler()
     );
     MESSAGE("add to an existing single value");
-    self->request(store, infinite, add_atom::value, "foo", 1).receive(
-      [&](int old) {
-        CHECK_EQUAL(old, 42);
+    self->request(store, infinite, add_atom::value, "foo", data{1}).receive(
+      [&](data old) {
+        CHECK_EQUAL(old, data{42});
       },
       error_handler()
     );
     MESSAGE("add to a non-existing single value");
-    self->request(store, infinite, add_atom::value, "baz", 1).receive(
-      [&](int old) {
-        CHECK_EQUAL(old, 0);
+    self->request(store, infinite, add_atom::value, "baz", data{1}).receive(
+      [&](data old) {
+        CHECK_EQUAL(old, data{0});
       },
       error_handler()
     );
@@ -73,18 +73,18 @@ TEST(simple store) {
     self->send_exit(store, exit_reason::user_shutdown);
   }
   {
-    auto store = self->spawn(simple_store<std::string, int>, store_dir);
+    auto store = self->spawn(simple_store, store_dir);
     MESSAGE("get a value from the store's previous lifetime");
     self->request(store, infinite, get_atom::value, "baz").receive(
-      [&](optional<int> result) {
+      [&](optional<data> result) {
         REQUIRE(result);
-        CHECK_EQUAL(*result, 1);
+        CHECK_EQUAL(*result, data{1});
       },
       error_handler()
     );
     MESSAGE("get a key that was deleted during the store's previous lfetime");
     self->request(store, infinite, get_atom::value, "foo").receive(
-      [&](optional<int> result) {
+      [&](optional<data> result) {
         CHECK(!result);
       },
       error_handler()

--- a/libvast/vast/save.hpp
+++ b/libvast/vast/save.hpp
@@ -27,6 +27,7 @@
 #include "vast/error.hpp"
 #include "vast/expected.hpp"
 #include "vast/filesystem.hpp"
+#include "vast/logger.hpp"
 
 namespace vast {
 

--- a/libvast/vast/system/simple_store.hpp
+++ b/libvast/vast/system/simple_store.hpp
@@ -24,24 +24,33 @@
 
 namespace vast::system {
 
-class simple_store_state {
-public:
+struct simple_store_state {
   using actor_ptr = meta_store_type::stateful_pointer<simple_store_state>;
 
   static inline const char* name = "simple-store";
-  std::unordered_map<std::string, data> store;
-  path file;
 
-  caf::error init(actor_ptr self, path dir);
+  simple_store_state(actor_ptr self);
 
+  /// Initializes the state.
+  /// @param dir The directory of the store.
+  caf::error init(path dir);
+
+  /// Saves the current state to `file`.
+  /// @pre `init()` was run successfully.
   caf::error save();
 
-private:
   actor_ptr self;
+
+  /// The data container.
+  std::unordered_map<std::string, data> store;
+
+  /// The location of the persistence file.
+  path file;
 };
 
 /// A key-value store that stores its data in a `std::unordered_map`.
 /// @param self The actor handle.
+/// @param dir The directory of the store.
 meta_store_type::behavior_type
 simple_store(simple_store_state::actor_ptr self, path dir);
 

--- a/libvast/vast/system/simple_store.hpp
+++ b/libvast/vast/system/simple_store.hpp
@@ -24,7 +24,8 @@
 
 namespace vast::system {
 
-struct simple_store_state {
+class simple_store_state {
+public:
   using actor_ptr = meta_store_type::stateful_pointer<simple_store_state>;
 
   static inline const char* name = "simple-store";
@@ -33,7 +34,10 @@ struct simple_store_state {
 
   caf::error init(actor_ptr self, path dir);
 
-  caf::error save(caf::actor_system& sys);
+  caf::error save();
+
+private:
+  actor_ptr self;
 };
 
 /// A key-value store that stores its data in a `std::unordered_map`.

--- a/libvast/vast/system/simple_store.hpp
+++ b/libvast/vast/system/simple_store.hpp
@@ -1,0 +1,98 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <unordered_map>
+
+#include <caf/none.hpp>
+
+#include "vast/data.hpp"
+#include "vast/filesystem.hpp"
+#include "vast/load.hpp"
+#include "vast/save.hpp"
+
+#include "vast/system/key_value_store.hpp"
+
+namespace vast::system {
+
+template <class Key, class Value>
+struct simple_store_state {
+  using simple_store_actor = typename key_value_store_type<
+    Key, Value>::template stateful_pointer<simple_store_state>;
+
+  static inline const char* name = "simple-store";
+  std::unordered_map<Key, Value> store;
+  path file;
+
+  caf::error init(simple_store_actor self, const path& dir) {
+    file = dir / "store";
+    if (exists(file)) {
+      if (auto err = vast::load(self->system(), file, store)) {
+        VAST_WARNING_ANON(name, "unable to load state file:", file);
+        return err;
+      }
+    }
+    return caf::none;
+  }
+
+  caf::error save(caf::actor_system& sys) {
+    return vast::save(sys, file, store);
+  }
+};
+
+/// A key-value store that stores its data in a `std::unordered_map`.
+/// @param self The actor handle.
+template <class Key, class Value>
+typename key_value_store_type<Key, Value>::behavior_type
+simple_store(
+  typename key_value_store_type<Key, Value>::template stateful_pointer<
+    simple_store_state<Key, Value>
+  > self, path dir) {
+  using behavior_type =
+    typename key_value_store_type<Key, Value>::behavior_type;
+  if (auto err = self->state.init(self, dir)) {
+    self->quit(std::move(err));
+    return behavior_type::make_empty_behavior();
+  }
+  return {
+    [=](put_atom, const Key& key, Value& value) -> caf::result<ok_atom> {
+      self->state.store[key] = std::move(value);
+      if (auto err = self->state.save(self->system()))
+        return err;
+      return ok_atom::value;
+    },
+    [=](add_atom, const Key& key, const Value& value) -> caf::result<Value> {
+      auto& v = self->state.store[key];
+      auto old = v;
+      v += value;
+      if (auto err = self->state.save(self->system()))
+        return err;
+      return old;
+    },
+    [=](delete_atom, const Key& key) -> caf::result<ok_atom> {
+      self->state.store.erase(key);
+      if (auto err = self->state.save(self->system()))
+        return err;
+      return ok_atom::value;
+    },
+    [=](get_atom, const Key& key) -> caf::result<optional<Value>> {
+      auto i = self->state.store.find(key);
+      if (i == self->state.store.end())
+        return caf::none;
+      return i->second;
+    }
+  };
+}
+
+} // namespace vast::system


### PR DESCRIPTION
Mostly self-explanatory, it is just an adaptation of `data_store` with serialization.
There are several open questions though:

- [x] Design: Ideally, we want `put`,`add`, and `delete` to return a `caf::error` to indicate if saving was successful, but that would require updates to `key_value_store_type` and `replicated_store`.
- [x] Design: Maybe it would suffice to turn `simple_store` into a concrete class with `std::string` and `vast::data` as fixed key and value types.
- [x] What should be done for testing? Should we generalize the tests for `data_store` and test the persistence in the integration tests? Any other ideas?