### PR TITLE
Fix high latency exports

### DIFF
--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -55,11 +55,22 @@ archive(archive_type::stateful_pointer<archive_state> self,
       self->quit(msg.reason);
     }
   );
+  self->set_down_handler(
+    [=](const down_msg& msg) {
+      VAST_DEBUG(self, "received DOWN from", msg.source);
+      self->state.active_exporters.erase(msg.source);
+    }
+  );
   return {
-    [=](const ids& xs) {
+    [=](const ids& xs) -> caf::result<std::vector<event>> {
       VAST_ASSERT(rank(xs) > 0);
       VAST_DEBUG(self, "got query for", rank(xs), "events in range ["
                  << select(xs, 1) << ',' << (select(xs, -1) + 1) << ')');
+      if (self->state.active_exporters.count(self->current_sender()->address())
+          == 0) {
+        VAST_DEBUG(self, "dismissing query for inactive sender");
+        return make_error(ec::no_error);
+      }
       std::vector<event> result;
       auto slices = self->state.store->get(xs);
       if (!slices)
@@ -93,6 +104,11 @@ archive(archive_type::stateful_pointer<archive_state> self,
           }
         }
       );
+    },
+    [=](exporter_atom, const actor& exporter) {
+      auto sender_addr = self->current_sender()->address();
+      self->state.active_exporters.insert(sender_addr);
+      self->monitor<caf::message_priority::high>(exporter);
     },
     [=](status_atom) {
       caf::dictionary<caf::config_value> result;

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -68,7 +68,7 @@ archive(archive_type::stateful_pointer<archive_state> self,
                  << select(xs, 1) << ',' << (select(xs, -1) + 1) << ')');
       if (self->state.active_exporters.count(self->current_sender()->address())
           == 0) {
-        VAST_DEBUG(self, "dismissing query for inactive sender");
+        VAST_DEBUG(self, "dismisses query for inactive sender");
         return make_error(ec::no_error);
       }
       std::vector<event> result;

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -135,6 +135,7 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
   self->set_exit_handler(
     [=](const exit_msg& msg) {
       VAST_DEBUG(self, "received exit from", msg.source, "with reason:", msg.reason);
+      self->send<message_priority::high>(self->state.index, self->state.id, 0);
       self->send(self->state.sink, sys_atom::value, delete_atom::value);
       self->send_exit(self->state.sink, msg.reason);
       self->quit(msg.reason);

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -259,6 +259,9 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
       self->state.archive = archive;
       if (has_continuous_option(self->state.options))
         self->monitor(archive);
+      // Register self at the archive
+      if (has_historical_option(self->state.options))
+        self->send(archive, exporter_atom::value, self);
     },
     [=](index_atom, const actor& index) {
       VAST_DEBUG(self, "registers index", index);

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -33,6 +33,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
 
   fixture() {
     a = self->spawn(system::archive, directory, 10, 1024 * 1024);
+    self->send(a, system::exporter_atom::value, self);
   }
 
   template <class T>

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <memory>
+#include <unordered_set>
 #include <vector>
 
 #include <caf/fwd.hpp>
@@ -31,12 +33,14 @@ namespace vast::system {
 /// @relates archive
 struct archive_state {
   std::unique_ptr<vast::store> store;
+  std::unordered_set<caf::actor_addr> active_exporters;
   static inline const char* name = "archive";
 };
 
 /// @relates archive
 using archive_type = caf::typed_actor<
   caf::reacts_to<caf::stream<table_slice_ptr>>,
+  caf::reacts_to<exporter_atom, caf::actor>,
   caf::replies_to<ids>::with<std::vector<event>>,
   caf::replies_to<status_atom>::with<caf::dictionary<caf::config_value>>
 >;


### PR DESCRIPTION
- Notify INDEX about dropped queries
- Dismiss zombie requests in ARCHIVE

- [ ] The average query time with 2Gb ingested conn logs still varies between 0.3 and 2.2 seconds on my machine. I suggest to open a new branch for fixing that, but I could also investigate that and add additional commits here if you prefer.
-> will be done in #343 
