### PR TITLE
Support piecemeal result extraction from the archive

### DIFF
--- a/libvast/src/store.cpp
+++ b/libvast/src/store.cpp
@@ -19,4 +19,8 @@ store::~store() {
   // nop
 }
 
+store::lookup::~lookup() {
+  // nop
+}
+
 } // namespace vast

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -72,13 +72,18 @@ archive(archive_type::stateful_pointer<archive_state> self,
         return make_error(ec::no_error);
       }
       std::vector<event> result;
-      auto slices = self->state.store->get(xs);
-      if (!slices)
-        VAST_DEBUG(self, "failed to lookup IDs in store:",
-                   self->system().render(slices.error()));
-      else
-        for (auto& slice : *slices)
-          to_events(result, *slice, xs);
+      auto session = self->state.store->extract(xs);
+      while (true) {
+        auto slice = session->next();
+        if (!slice) {
+          // Either we are done ...
+          if (!slice.error())
+            break;
+          // ... or an error occured.
+          return slice.error();
+        }
+        to_events(result, **slice, xs);
+      }
       return result;
     },
     [=](stream<table_slice_ptr> in) {

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -76,11 +76,9 @@ archive(archive_type::stateful_pointer<archive_state> self,
       while (true) {
         auto slice = session->next();
         if (!slice) {
-          // Either we are done ...
-          if (!slice.error())
+          if (!slice.error())   // Either we are done ...
             break;
-          // ... or an error occured.
-          return slice.error();
+          return slice.error(); // ... or an error occured.
         }
         to_events(result, **slice, xs);
       }

--- a/libvast/test/segment_store.cpp
+++ b/libvast/test/segment_store.cpp
@@ -30,7 +30,6 @@ FIXTURE_SCOPE(segment_store_tests,
 
 TEST(construction and querying) {
   auto path = directory / "segments";
-  rm(path);
   auto store = segment_store::make(sys, path, 512_KiB, 2);
   REQUIRE(store);
   for (auto& slice : bro_conn_log_slices)
@@ -42,7 +41,6 @@ TEST(construction and querying) {
 
 TEST(sessionized extraction) {
   auto path = directory / "segments";
-  rm(path);
   auto store = segment_store::make(sys, path, 512_KiB, 2);
   REQUIRE(store);
   for (auto& slice : bro_conn_log_slices)

--- a/libvast/test/segment_store.cpp
+++ b/libvast/test/segment_store.cpp
@@ -40,4 +40,23 @@ TEST(construction and querying) {
   REQUIRE_EQUAL(slices->size(), 2u);
 }
 
+TEST(sessionized extraction) {
+  // FIXME: use directory from fixture
+  rm("foo");
+  auto store = segment_store::make(sys, path{"foo"}, 512_KiB, 2);
+  REQUIRE(store);
+  for (auto& slice : bro_conn_log_slices)
+    REQUIRE(!store->put(slice));
+  auto session = store->extract(make_ids({0, 6, 19, 21}));
+  auto slice0 = session->next();
+  REQUIRE(slice0);
+  REQUIRE_EQUAL((*slice0)->offset(), 0u);
+  auto slice1 = session->next();
+  REQUIRE(slice1);
+  REQUIRE_EQUAL((*slice1)->offset(), 16u);
+  auto slice2 = session->next();
+  REQUIRE(!slice2);
+  REQUIRE(slice2.error() == caf::no_error);
+}
+
 FIXTURE_SCOPE_END()

--- a/libvast/test/segment_store.cpp
+++ b/libvast/test/segment_store.cpp
@@ -29,9 +29,9 @@ FIXTURE_SCOPE(segment_store_tests,
               fixtures::deterministic_actor_system_and_events)
 
 TEST(construction and querying) {
-  // FIXME: use directory from fixture
-  rm("foo");
-  auto store = segment_store::make(sys, path{"foo"}, 512_KiB, 2);
+  auto path = directory / "segments";
+  rm(path);
+  auto store = segment_store::make(sys, path, 512_KiB, 2);
   REQUIRE(store);
   for (auto& slice : bro_conn_log_slices)
     REQUIRE(!store->put(slice));
@@ -41,9 +41,9 @@ TEST(construction and querying) {
 }
 
 TEST(sessionized extraction) {
-  // FIXME: use directory from fixture
-  rm("foo");
-  auto store = segment_store::make(sys, path{"foo"}, 512_KiB, 2);
+  auto path = directory / "segments";
+  rm(path);
+  auto store = segment_store::make(sys, path, 512_KiB, 2);
   REQUIRE(store);
   for (auto& slice : bro_conn_log_slices)
     REQUIRE(!store->put(slice));

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -48,6 +48,8 @@ public:
 
   error put(table_slice_ptr xs) override;
 
+  std::unique_ptr<store::lookup> extract(const ids& xs) const override;
+
   caf::expected<std::vector<table_slice_ptr>>
   get(const ids& xs) override;
 
@@ -71,11 +73,13 @@ private:
     return dir_ / "segments";
   }
 
+  caf::expected<segment_ptr> load_segment(uuid id) const;
+
   caf::actor_system& sys_;
   path dir_;
   uint64_t max_segment_size_;
   detail::range_map<id, uuid> segments_;
-  detail::cache<uuid, segment_ptr> cache_;
+  mutable detail::cache<uuid, segment_ptr> cache_;
   segment_builder builder_;
   std::vector<segment_ptr> builder_slices_;
 };

--- a/libvast/vast/store.hpp
+++ b/libvast/vast/store.hpp
@@ -24,12 +24,29 @@ namespace vast {
 /// A key-value store for events.
 class store {
 public:
+  /// A session type for managing the state of a lookup.
+  struct lookup {
+    virtual ~lookup();
+
+    /// Obtains the next slice containing events pertaining
+    /// this lookup session.
+    /// @returns caf::no_error when finished.
+    /// @returns A new table slice upon every invocation.
+    virtual caf::expected<table_slice_ptr> next() = 0;
+  };
+
   virtual ~store();
 
   /// Adds a table slice to the store.
   /// @param xs The table slice to add.
   /// @returns No error on success.
   virtual caf::error put(table_slice_ptr xs) = 0;
+
+  /// Starts an iterative extraction session.
+  /// @param xs The IDs for the events to retrieve.
+  /// @returns A pointer to lookup session.
+  /// @relates lookup
+  virtual std::unique_ptr<lookup> extract(const ids& xs) const = 0;
 
   /// Retrieves a set of events.
   /// @param xs The IDs for the events to retrieve.


### PR DESCRIPTION
Todo:
- [x] Extend the `store` interface with a lookup state.
- [x] Implement iterative lookup support in `segment_store`.
- [x] Make use lookups in the archive.
- [x] Adjust `segment_store` unit test.