### PR TITLE
Return archive lookup results incrementally

### DIFF
--- a/libvast/src/detail/add_message_types.cpp
+++ b/libvast/src/detail/add_message_types.cpp
@@ -54,8 +54,7 @@ void add_message_types(caf::actor_system_config& cfg) {
   cfg.add_message_type<system::component_map_entry>(
     "vast::system::component_map_entry");
   cfg.add_message_type<system::registry>("vast::system::registry");
-  cfg.add_message_type<system::query_status>(
-    "vast::system::query_status");
+  cfg.add_message_type<system::query_status>("vast::system::query_status");
   cfg.add_message_type<system::actor_identity>("vast::system::actor_identity");
 #ifdef VAST_USE_OPENCL
   cfg.add_message_type<std::vector<uint32_t>>("std::vector<uint32_t>");

--- a/libvast/src/detail/add_message_types.cpp
+++ b/libvast/src/detail/add_message_types.cpp
@@ -28,7 +28,7 @@
 #include "vast/type.hpp"
 #include "vast/uuid.hpp"
 
-#include "vast/system/query_statistics.hpp"
+#include "vast/system/query_status.hpp"
 #include "vast/system/replicated_store.hpp"
 #include "vast/system/tracker.hpp"
 
@@ -54,8 +54,8 @@ void add_message_types(caf::actor_system_config& cfg) {
   cfg.add_message_type<system::component_map_entry>(
     "vast::system::component_map_entry");
   cfg.add_message_type<system::registry>("vast::system::registry");
-  cfg.add_message_type<system::query_statistics>(
-    "vast::system::query_statistics");
+  cfg.add_message_type<system::query_status>(
+    "vast::system::query_status");
   cfg.add_message_type<system::actor_identity>("vast::system::actor_identity");
 #ifdef VAST_USE_OPENCL
   cfg.add_message_type<std::vector<uint32_t>>("std::vector<uint32_t>");

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -62,7 +62,7 @@ archive(archive_type::stateful_pointer<archive_state> self,
     }
   );
   return {
-    [=](const ids& xs) -> caf::result<std::vector<event>> {
+    [=](const ids& xs) -> caf::result<done_atom, caf::error> {
       VAST_ASSERT(rank(xs) > 0);
       VAST_DEBUG(self, "got query for", rank(xs), "events in range ["
                  << select(xs, 1) << ',' << (select(xs, -1) + 1) << ')');
@@ -78,11 +78,14 @@ archive(archive_type::stateful_pointer<archive_state> self,
         if (!slice) {
           if (!slice.error())   // Either we are done ...
             break;
-          return slice.error(); // ... or an error occured.
+          // ... or an error occured.
+          return {done_atom::value, slice.error()};
         }
-        to_events(result, **slice, xs);
+        using receiver_type = caf::typed_actor<caf::reacts_to<table_slice_ptr>>;
+        self->send(caf::actor_cast<receiver_type>(
+              self->current_sender()), *slice);
       }
-      return result;
+      return {done_atom::value, make_error(ec::no_error)};
     },
     [=](stream<table_slice_ptr> in) {
       self->make_sink(

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -79,7 +79,7 @@ archive(archive_type::stateful_pointer<archive_state> self,
           if (!slice.error())   // Either we are done ...
             break;
           // ... or an error occured.
-          return {done_atom::value, slice.error()};
+          return {done_atom::value, std::move(slice.error())};
         }
         using receiver_type = caf::typed_actor<caf::reacts_to<table_slice_ptr>>;
         self->send(caf::actor_cast<receiver_type>(

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -93,8 +93,7 @@ void shutdown(stateful_actor<exporter_state>* self, caf::error err) {
 }
 
 void shutdown(stateful_actor<exporter_state>* self) {
-  if (rank(self->state.unprocessed) > 0 || !self->state.results.empty()
-      || has_continuous_option(self->state.options))
+  if (has_continuous_option(self->state.options))
     return;
   VAST_DEBUG(self, "initiates shutdown");
   self->send_exit(self, exit_reason::normal);
@@ -152,7 +151,11 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
         report_statistics(self);
     }
   );
-  auto handle_batch = [=](std::vector<event>& candidates) {
+  auto finished = [&](const query_status& qs) -> bool {
+    return qs.received == qs.expected &&
+    qs.lookups_issued == qs.lookups_complete;
+  };
+  auto handle_batch = [=](std::vector<event> candidates) {
     VAST_DEBUG(self, "got batch of", candidates.size(), "events");
     // Events can arrive in any order: sort them by ID first. Otherwise, we
     // can't compute the bitmap mask as easily.
@@ -191,7 +194,7 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
       self->state.unprocessed -= mask;
     ship_results(self);
     request_more_hits(self);
-    if (self->state.query.received == self->state.query.expected)
+    if (finished(self->state.query))
       shutdown(self);
   };
   return {
@@ -213,6 +216,7 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
         self->state.unprocessed |= hits;
         VAST_DEBUG(self, "forwards hits to archive");
         // FIXME: restrict according to configured limit.
+        ++self->state.query.lookups_issued;
         self->send(self->state.archive, std::move(hits));
       }
       // Figure out if we're done.
@@ -227,11 +231,23 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
                    "ID set(s) in", runtime);
         if (self->state.accountant)
           self->send(self->state.accountant, "exporter.hits.runtime", runtime);
-        shutdown(self);
       }
+      if (finished(self->state.query))
+        shutdown(self);
     },
-    [=](std::vector<event>& candidates) {
-      handle_batch(candidates);
+    [=](table_slice_ptr slice) {
+      handle_batch(to_events(*slice, self->state.hits));
+    },
+    [=](done_atom, const caf::error& err) {
+      auto sender = self->current_sender();
+      if (sender == self->state.archive) {
+        if (err)
+          VAST_DEBUG(self, "received error from archive:",
+              self->system().render(err));
+        ++self->state.query.lookups_complete;
+      }
+      if (finished(self->state.query))
+        shutdown(self);
     },
     [=](extract_atom) {
       if (self->state.query.requested == max_events) {
@@ -311,7 +327,7 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
         [=](caf::unit_t&, const table_slice_ptr& slice) {
           // TODO: port to new table slice API
           auto candidates = to_events(*slice);
-          handle_batch(candidates);
+          handle_batch(std::move(candidates));
         },
         [=](caf::unit_t&, const error& err) {
           VAST_IGNORE_UNUSED(err);

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -154,8 +154,8 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
     }
   );
   auto finished = [&](const query_status& qs) -> bool {
-    return qs.received == qs.expected &&
-    qs.lookups_issued == qs.lookups_complete;
+    return qs.received == qs.expected
+      && qs.lookups_issued == qs.lookups_complete;
   };
   auto handle_batch = [=](std::vector<event> candidates) {
     VAST_DEBUG(self, "got batch of", candidates.size(), "events");

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -16,6 +16,7 @@
 #include "vast/ids.hpp"
 #include "vast/system/archive.hpp"
 #include "vast/table_slice.hpp"
+#include "vast/to_events.hpp"
 
 #include "vast/detail/spawn_container_source.hpp"
 
@@ -42,9 +43,25 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     run();
   }
 
+  std::vector<event> query(const ids& ids) {
+    bool done = false;
+    std::vector<event> result;
+    self->send(a, ids);
+    run();
+    self->do_receive(
+      [&](vast::system::done_atom, const caf::error& err) {
+        REQUIRE(!err);
+        done = true;
+      },
+      [&](table_slice_ptr slice) {
+        to_events(result, *slice, ids);
+      }
+    ).until([&]{ run(); return done; });
+    return result;
+  }
+
   std::vector<event> query(std::initializer_list<id_range> ranges) {
-    auto ids = make_ids(ranges);
-    return request<std::vector<event>>(a, ids);
+    return query(make_ids(ranges));
   }
 };
 
@@ -69,7 +86,7 @@ TEST(archiving and querying) {
   push_to_archive(bgpdump_txt_slices);
   MESSAGE("query events");
   auto ids = make_ids({{24, 56}, {1076, 1096}});
-  auto result = request<std::vector<event>>(a, ids);
+  auto result = query(ids);
   REQUIRE_EQUAL(result.size(), 52u);
   // We sort because the specific compression algorithm used at the archive
   // determines the order of results.

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -56,7 +56,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
       [&](table_slice_ptr slice) {
         to_events(result, *slice, ids);
       }
-    ).until([&]{ run(); return done; });
+    ).until(done);
     return result;
   }
 

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -15,6 +15,7 @@
 
 #include <memory>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <caf/fwd.hpp>
@@ -41,7 +42,7 @@ struct archive_state {
 using archive_type = caf::typed_actor<
   caf::reacts_to<caf::stream<table_slice_ptr>>,
   caf::reacts_to<exporter_atom, caf::actor>,
-  caf::replies_to<ids>::with<std::vector<event>>,
+  caf::replies_to<ids>::with<done_atom, caf::error>,
   caf::replies_to<status_atom>::with<caf::dictionary<caf::config_value>>
 >;
 

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -42,7 +42,7 @@ struct exporter_state {
   std::deque<event> candidates;
   std::vector<event> results;
   std::chrono::steady_clock::time_point start;
-  query_status stats;
+  query_status query;
   query_options options;
   uuid id;
   static inline const char* name = "exporter";

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -37,7 +37,6 @@ struct exporter_state {
   caf::actor sink;
   accountant_type accountant;
   ids hits;
-  ids unprocessed;
   std::unordered_map<type, expression> checkers;
   std::deque<event> candidates;
   std::vector<event> results;

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -27,7 +27,7 @@
 
 #include "vast/system/accountant.hpp"
 #include "vast/system/archive.hpp"
-#include "vast/system/query_statistics.hpp"
+#include "vast/system/query_status.hpp"
 
 namespace vast::system {
 
@@ -42,7 +42,7 @@ struct exporter_state {
   std::deque<event> candidates;
   std::vector<event> results;
   std::chrono::steady_clock::time_point start;
-  query_statistics stats;
+  query_status stats;
   query_options options;
   uuid id;
   static inline const char* name = "exporter";
@@ -58,4 +58,3 @@ caf::behavior exporter(caf::stateful_actor<exporter_state>* self,
                        expression expr, query_options opts);
 
 } // namespace vast::system
-

--- a/libvast/vast/system/fwd.hpp
+++ b/libvast/vast/system/fwd.hpp
@@ -40,7 +40,7 @@ class start_command;
 // -- structs ------------------------------------------------------------------
 
 struct node_state;
-struct query_statistics;
+struct query_status;
 struct spawn_arguments;
 
 // -- templates ----------------------------------------------------------------

--- a/libvast/vast/system/query_status.hpp
+++ b/libvast/vast/system/query_status.hpp
@@ -22,15 +22,15 @@ namespace vast::system {
 
 /// Statistics about a query.
 struct query_status {
-  timespan runtime;         ///< Current runtime.
-  size_t expected = 0;      ///< Expected ID sets from INDEX.
-  size_t scheduled = 0;     ///< Scheduled partitions (ID sets) at INDEX.
-  size_t received = 0;      ///< Received ID sets from INDEX.
-  size_t lookups_issued = 0;
-  size_t lookups_complete = 0;
-  uint64_t processed = 0;   ///< Processed candidates from ARCHIVE.
-  uint64_t shipped = 0;     ///< Shipped results to sink.
-  uint64_t requested = 0;   ///< User-requested pending results to extract.
+  timespan runtime;            ///< Current runtime.
+  size_t expected = 0;         ///< Expected ID sets from INDEX.
+  size_t scheduled = 0;        ///< Scheduled partitions (ID sets) at INDEX.
+  size_t received = 0;         ///< Received ID sets from INDEX.
+  size_t lookups_issued = 0;   ///< Number of lookups sent to the ARCHIVE.
+  size_t lookups_complete = 0; ///< Number of lookups returned by the ARCHIVE.
+  uint64_t processed = 0;      ///< Processed candidates from ARCHIVE.
+  uint64_t shipped = 0;        ///< Shipped results to sink.
+  uint64_t requested = 0;      ///< User-requested pending results to extract.
 };
 
 template <class Inspector>

--- a/libvast/vast/system/query_status.hpp
+++ b/libvast/vast/system/query_status.hpp
@@ -26,6 +26,8 @@ struct query_status {
   size_t expected = 0;      ///< Expected ID sets from INDEX.
   size_t scheduled = 0;     ///< Scheduled partitions (ID sets) at INDEX.
   size_t received = 0;      ///< Received ID sets from INDEX.
+  size_t lookups_issued = 0;
+  size_t lookups_complete = 0;
   uint64_t processed = 0;   ///< Processed candidates from ARCHIVE.
   uint64_t shipped = 0;     ///< Shipped results to sink.
   uint64_t requested = 0;   ///< User-requested pending results to extract.

--- a/libvast/vast/system/query_status.hpp
+++ b/libvast/vast/system/query_status.hpp
@@ -21,7 +21,7 @@
 namespace vast::system {
 
 /// Statistics about a query.
-struct query_statistics {
+struct query_status {
   timespan runtime;         ///< Current runtime.
   size_t expected = 0;      ///< Expected ID sets from INDEX.
   size_t scheduled = 0;     ///< Scheduled partitions (ID sets) at INDEX.
@@ -32,10 +32,9 @@ struct query_statistics {
 };
 
 template <class Inspector>
-auto inspect(Inspector& f, query_statistics& qs) {
+auto inspect(Inspector& f, query_status& qs) {
   return f(qs.runtime, qs.expected, qs.scheduled, qs.received, qs.processed,
            qs.shipped, qs.requested);
 }
 
 } // namespace vast::system
-

--- a/libvast/vast/system/sink.hpp
+++ b/libvast/vast/system/sink.hpp
@@ -27,7 +27,7 @@
 #include "vast/event.hpp"
 #include "vast/format/writer.hpp"
 #include "vast/system/atoms.hpp"
-#include "vast/system/query_statistics.hpp"
+#include "vast/system/query_status.hpp"
 
 namespace vast::system {
 
@@ -83,7 +83,7 @@ caf::behavior sink(caf::stateful_actor<sink_state<Writer>>* self,
         }
       }
     },
-    [=](const uuid& id, const query_statistics&) {
+    [=](const uuid& id, const query_status&) {
       VAST_IGNORE_UNUSED(id);
       VAST_DEBUG(self, "got query statistics from", id);
     },
@@ -99,4 +99,3 @@ caf::behavior sink(caf::stateful_actor<sink_state<Writer>>* self,
 }
 
 } // namespace vast::system
-

--- a/libvast_test/src/node.cpp
+++ b/libvast_test/src/node.cpp
@@ -21,7 +21,7 @@
 #include "vast/uuid.hpp"
 
 #include "vast/system/node.hpp"
-#include "vast/system/query_statistics.hpp"
+#include "vast/system/query_status.hpp"
 
 using namespace vast;
 
@@ -90,7 +90,7 @@ std::vector<event> node::query(std::string expr) {
       result.insert(result.end(), std::make_move_iterator(xs.begin()),
                     std::make_move_iterator(xs.end()));
     },
-    [&](const uuid&, const system::query_statistics&) {
+    [&](const uuid&, const system::query_status&) {
       // ignore
     },
     [&](const caf::down_msg& msg) {
@@ -106,4 +106,3 @@ std::vector<event> node::query(std::string expr) {
 }
 
 } // namespace fixtures
-

--- a/libvast_test/vast/test/fixtures/node.hpp
+++ b/libvast_test/vast/test/fixtures/node.hpp
@@ -20,7 +20,6 @@
 #include "vast/uuid.hpp"
 
 #include "vast/system/node.hpp"
-#include "vast/system/query_statistics.hpp"
 
 #include "vast/test/data.hpp"
 #include "vast/test/fixtures/actor_system_and_events.hpp"


### PR DESCRIPTION
A little bit of cleanup is being done on the side here:
- The name `query_statistics` was misleading, the type is renamed to `query_status`.
- The exporter now uses a counter for keeping track of outstanding id look ups instead of a bitmap.
- We don't request new ids any more after handling a table slice that was sent from the importer.