### PR TITLE
Add status message handler to consensus

### DIFF
--- a/libvast/vast/system/data_store.hpp
+++ b/libvast/vast/system/data_store.hpp
@@ -15,6 +15,7 @@
 
 #include <unordered_map>
 
+#include <caf/config_value.hpp>
 #include <caf/none.hpp>
 
 #include "vast/data.hpp"
@@ -57,6 +58,11 @@ data_store(
       if (i == self->state.store.end())
         return caf::none;
       return i->second;
+    },
+    [=](status_atom) -> caf::config_value::dictionary {
+      caf::dictionary<caf::config_value> result;
+      result.emplace("store-size", self->state.store.size());
+      return result;
     }
   };
 }

--- a/libvast/vast/system/dummy_consensus.hpp
+++ b/libvast/vast/system/dummy_consensus.hpp
@@ -46,6 +46,8 @@ struct dummy_consensus_state {
 
   /// The location of the persistence file.
   path file;
+
+  caf::dictionary<caf::config_value> status() const;
 };
 
 /// A key-value store that stores its data in a `std::unordered_map`.

--- a/libvast/vast/system/key_value_store.hpp
+++ b/libvast/vast/system/key_value_store.hpp
@@ -13,8 +13,8 @@
 
 #pragma once
 
-#include <caf/stateful_actor.hpp>
 #include <caf/replies_to.hpp>
+#include <caf/stateful_actor.hpp>
 #include <caf/typed_actor.hpp>
 
 #include "vast/optional.hpp"
@@ -32,8 +32,9 @@ using key_value_store_type = caf::typed_actor<
   // Deletes a key-value pair.
   typename caf::replies_to<delete_atom, Key>::template with<ok_atom>,
   // Retrieves the value for a given key pair.
-  typename caf::replies_to<get_atom, Key>::template with<optional<Value>>
->;
+  typename caf::replies_to<get_atom, Key>::template with<optional<Value>>,
+  // Returns the runtime status in a dict.
+  typename caf::replies_to<status_atom>::template with<
+    caf::dictionary<caf::config_value>>>;
 
 } // namespace vast::system
-


### PR DESCRIPTION
I consider this extension mostly trivial. The only thing that might be questionable is in `replicated_store`, where the raft statistics now get cached in the state for no reason other than the status report.