### PR TITLE
Fix parsing of empty containers

### DIFF
--- a/libvast/test/parse_data.cpp
+++ b/libvast/test/parse_data.cpp
@@ -85,6 +85,12 @@ TEST(data) {
   CHECK(d == port{22, port::tcp});
 
   MESSAGE("vector");
+  str = "[]"s;
+  f = str.begin();
+  l = str.end();
+  CHECK(p(f, l, d));
+  CHECK(f == l);
+  CHECK(d == vector{});
   str = "[42,4.2,nil]"s;
   f = str.begin();
   l = str.end();
@@ -93,6 +99,12 @@ TEST(data) {
   CHECK(d == vector{42u, 4.2, caf::none});
 
   MESSAGE("set");
+  str = "{}"s;
+  f = str.begin();
+  l = str.end();
+  CHECK(p(f, l, d));
+  CHECK(f == l);
+  CHECK(d == set{});
   str = "{-42,+42,-1}"s;
   f = str.begin();
   l = str.end();

--- a/libvast/vast/concept/parseable/vast/data.hpp
+++ b/libvast/vast/concept/parseable/vast/data.hpp
@@ -50,9 +50,9 @@ struct access::parser<data> : vast::parser<access::parser<data>> {
       | parsers::tf
       | parsers::qq_str
       | parsers::pattern
-      | '[' >> (x % ',') >> ']' // default: vector<data>
-      | '{' >> as<set>(x % ',') >> '}'
-      | '{' >> as<map>((x >> "->" >> x) % ',') >> '}'
+      | '[' >> ~(x % ',') >> ']'
+      | '{' >> ~as<set>(x % ',') >> '}'
+      | '{' >> ~as<map>((x >> "->" >> x) % ',') >> '}'
       | as<caf::none_t>("nil"_p)
       ;
     return p;


### PR DESCRIPTION
The inner parser (after the container tokens) was not optional.