### PR TITLE
Keep unpersisted partitions until indexing is done

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -213,23 +213,23 @@ partition_ptr index_state::make_partition(uuid id) {
 }
 
 caf::actor index_state::make_indexer(path dir, type column_type, size_t column,
-                                     uuid pid) {
+                                     uuid partition_id) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column),
-             VAST_ARG(index), VAST_ARG(pid));
+             VAST_ARG(index), VAST_ARG(partition_id));
   return factory(self, std::move(dir), std::move(column_type), column,
-                 self, pid);
+                 self, partition_id);
 }
 
-caf::error index_state::decrement_indexer_count(uuid pid) {
-  if (pid == active->id())
+caf::error index_state::decrement_indexer_count(uuid partition_id) {
+  if (partition_id == active->id())
     active_partition_indexers--;
   else {
     auto i = std::find_if(unpersisted.begin(), unpersisted.end(),
-                          [&](auto& kvp) { return kvp.first->id() == pid; });
+                          [&](auto& kvp) { return kvp.first->id() == partition_id; });
     if (i == unpersisted.end())
       return ec::unspecified;
     if (--i->second == 0) {
-      VAST_DEBUG(self, "successfully persisted", pid);
+      VAST_DEBUG(self, "successfully persisted", partition_id);
       unpersisted.erase(i);
     }
   }

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -196,7 +196,8 @@ void index_state::reset_active_partition() {
       VAST_ERROR(self, "unable to persist active partition");
     // Store this partition as unpersisted to make sure we're not attempting
     // to load it from disk until it is safe to do so.
-    unpersisted.emplace_back(std::move(active), active_partition_indexers);
+    if (active_partition_indexers > 0)
+      unpersisted.emplace_back(std::move(active), active_partition_indexers);
   }
   // Create a new active partition.
   active = make_partition();

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -196,30 +196,11 @@ void index_state::reset_active_partition() {
       VAST_ERROR(self, "unable to persist active partition");
     // Store this partition as unpersisted to make sure we're not attempting
     // to load it from disk until it is safe to do so.
-    auto& element = unpersisted.emplace_back(std::move(active), 0);
-    auto& id = element.first->id();
-    auto& pending = element.second;
-    // Singal each INDEXER in the partition to persist its state.
-    element.first->for_each_indexer([&](const actor& indexer) {
-      ++pending;
-      this->self->request(indexer, infinite, persist_atom::value).then([=] {
-        auto pred = [=](auto& kvp) { return kvp.first->id() == id; };
-        auto& xs = unpersisted;
-        auto i = std::find_if(xs.begin(), xs.end(), pred);
-        if (i == xs.end()) {
-          VAST_ERROR(self,
-                     "received an invalid response to a 'persist' message");
-          return;
-        }
-        if (--i->second == 0) {
-          VAST_DEBUG(self, "successfully persisted", id);
-          xs.erase(i);
-        }
-      });
-    });
+    unpersisted.emplace_back(std::move(active), active_partition_indexers);
   }
   // Create a new active partition.
   active = make_partition();
+  active_partition_indexers = 0;
 }
 
 partition_ptr index_state::make_partition() {
@@ -231,10 +212,28 @@ partition_ptr index_state::make_partition(uuid id) {
   return std::make_unique<partition>(this, std::move(id), max_partition_size);
 }
 
-caf::actor index_state::make_indexer(path dir, type column_type,
-                                     size_t column) {
-  VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column));
-  return factory(self, std::move(dir), std::move(column_type), column);
+caf::actor index_state::make_indexer(path dir, type column_type, size_t column,
+                                     uuid pid) {
+  VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column),
+             VAST_ARG(index), VAST_ARG(pid));
+  return factory(self, std::move(dir), std::move(column_type), column,
+                 self, pid);
+}
+
+caf::error index_state::decrement_indexer_count(uuid pid) {
+  if (pid == active->id())
+    active_partition_indexers--;
+  else {
+    auto i = std::find_if(unpersisted.begin(), unpersisted.end(),
+                          [&](auto& kvp) { return kvp.first->id() == pid; });
+    if (i == unpersisted.end())
+      return ec::unspecified;
+    if (--i->second == 0) {
+      VAST_DEBUG(self, "successfully persisted", pid);
+      unpersisted.erase(i);
+    }
+  }
+  return caf::none;
 }
 
 partition* index_state::find_unpersisted(const uuid& id) {
@@ -398,6 +397,11 @@ behavior index(stateful_actor<index_state>* self, const path& dir,
     [=](worker_atom, caf::actor& worker) {
       self->state.idle_workers.emplace_back(std::move(worker));
     },
+    [=](done_atom, uuid partition_id) {
+      if (self->state.decrement_indexer_count(partition_id))
+        VAST_ERROR(self, "received done from unknown indexer:",
+                   self->current_sender());
+    },
     [=](caf::stream<table_slice_ptr> in) {
       VAST_DEBUG(self, "got a new source");
       return self->state.stage->add_inbound_path(in);
@@ -406,20 +410,23 @@ behavior index(stateful_actor<index_state>* self, const path& dir,
       return self->state.status();
     }
   );
-  return {
-    [=](worker_atom, caf::actor& worker) {
-      auto& st = self->state;
-      st.idle_workers.emplace_back(std::move(worker));
-      self->become(keep_behavior, st.has_worker);
-    },
-    [=](caf::stream<table_slice_ptr> in) {
-      VAST_DEBUG(self, "got a new source");
-      return self->state.stage->add_inbound_path(in);
-    },
-    [=](status_atom) -> caf::config_value::dictionary {
-      return self->state.status();
-    }
-  };
+  return {[=](worker_atom, caf::actor& worker) {
+            auto& st = self->state;
+            st.idle_workers.emplace_back(std::move(worker));
+            self->become(keep_behavior, st.has_worker);
+          },
+          [=](done_atom, uuid partition_id) {
+            if (self->state.decrement_indexer_count(partition_id))
+              VAST_ERROR(self, "received done from unknown indexer:",
+                         self->current_sender());
+          },
+          [=](caf::stream<table_slice_ptr> in) {
+            VAST_DEBUG(self, "got a new source");
+            return self->state.stage->add_inbound_path(in);
+          },
+          [=](status_atom) -> caf::config_value::dictionary {
+            return self->state.status();
+          }};
 }
 
 } // namespace vast::system

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -85,8 +85,7 @@ behavior indexer(stateful_actor<indexer_state>* self, path dir,
           auto& st = self->state;
           if (err && err != caf::exit_reason::user_shutdown)
             VAST_ERROR(self, "got a stream error:", self->system().render(err));
-          if (auto flush_err = st.col.flush_to_disk();
-              flush_err != caf::none)
+          if (auto flush_err = st.col.flush_to_disk())
             VAST_WARNING(self, "failed to persist state:",
                          self->system().render(flush_err));
           self->send(st.index, done_atom::value, st.partition_id);

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -39,20 +39,25 @@ indexer_state::~indexer_state() {
 }
 
 caf::error indexer_state::init(event_based_actor* self, path filename,
-                               type column_type, size_t column) {
+                               type column_type, size_t column,
+                               caf::actor index, uuid pid) {
+  this->index = std::move(index);
+  this->partition_id = pid;
   new (&col) column_index(self->system(), std::move(column_type),
                           std::move(filename), column);
   return col.init();
 }
 
 behavior indexer(stateful_actor<indexer_state>* self, path dir,
-                 type column_type, size_t column) {
+                 type column_type, size_t column, caf::actor index,
+                 uuid pid) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column));
   VAST_DEBUG(self, "operates for column", column, "of type", column_type);
   if (auto err = self->state.init(self,
                                   std::move(dir) / "fields"
                                       / std::to_string(column),
-                                  std::move(column_type), column)) {
+                                  std::move(column_type), column,
+                                  std::move(index), pid)) {
     self->quit(std::move(err));
     return {};
   }
@@ -77,14 +82,17 @@ behavior indexer(stateful_actor<indexer_state>* self, path dir,
             self->state.col.add(x);
         },
         [=](unit_t&, const error& err) {
+          auto& st = self->state;
           if (err && err != caf::exit_reason::user_shutdown)
             VAST_ERROR(self, "got a stream error:", self->system().render(err));
-        }
-      );
+          if (auto flush_err = st.col.flush_to_disk();
+              flush_err != caf::none)
+            VAST_WARNING(self, "failed to persist state:",
+                         self->system().render(flush_err));
+          self->send(st.index, done_atom::value, st.partition_id);
+        });
     },
-    [=](shutdown_atom) {
-      self->quit(exit_reason::user_shutdown);
-    },
+    [=](shutdown_atom) { self->quit(exit_reason::user_shutdown); },
   };
 }
 

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -40,9 +40,9 @@ indexer_state::~indexer_state() {
 
 caf::error indexer_state::init(event_based_actor* self, path filename,
                                type column_type, size_t column,
-                               caf::actor index, uuid pid) {
+                               caf::actor index, uuid partition_id) {
   this->index = std::move(index);
-  this->partition_id = pid;
+  this->partition_id = partition_id;
   new (&col) column_index(self->system(), std::move(column_type),
                           std::move(filename), column);
   return col.init();
@@ -50,14 +50,14 @@ caf::error indexer_state::init(event_based_actor* self, path filename,
 
 behavior indexer(stateful_actor<indexer_state>* self, path dir,
                  type column_type, size_t column, caf::actor index,
-                 uuid pid) {
+                 uuid partition_id) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column));
   VAST_DEBUG(self, "operates for column", column, "of type", column_type);
   if (auto err = self->state.init(self,
                                   std::move(dir) / "fields"
                                       / std::to_string(column),
                                   std::move(column_type), column,
-                                  std::move(index), pid)) {
+                                  std::move(index), partition_id)) {
     self->quit(std::move(err));
     return {};
   }

--- a/libvast/src/system/indexer_stage_driver.cpp
+++ b/libvast/src/system/indexer_stage_driver.cpp
@@ -67,6 +67,7 @@ void indexer_stage_driver::process(downstream_type& out, batch_type& slices) {
             auto slt = out_.parent()->add_unchecked_outbound_path<output_type>(x);
             VAST_DEBUG(state_->self, "spawned new INDEXER at slot", slt);
             out_.set_filter(slt, layout);
+            state_->active_partition_indexers++;
           }
         }
       }

--- a/libvast/src/system/spawn_indexer.cpp
+++ b/libvast/src/system/spawn_indexer.cpp
@@ -24,12 +24,12 @@
 namespace vast::system {
 
 caf::actor spawn_indexer(caf::local_actor* parent, path dir, type column_type,
-                         size_t column, caf::actor index, uuid pid) {
+                         size_t column, caf::actor index, uuid partition_id) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column),
-             VAST_ARG(index), VAST_ARG(pid));
+             VAST_ARG(index), VAST_ARG(partition_id));
   return parent->spawn<caf::lazy_init>(indexer, std::move(dir),
                                        std::move(column_type), column,
-                                       std::move(index), pid);
+                                       std::move(index), partition_id);
 }
 
 } // namespace vast::system

--- a/libvast/src/system/spawn_indexer.cpp
+++ b/libvast/src/system/spawn_indexer.cpp
@@ -24,9 +24,12 @@
 namespace vast::system {
 
 caf::actor spawn_indexer(caf::local_actor* parent, path dir, type column_type,
-                         size_t column) {
-  VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column));
-  return parent->spawn<caf::lazy_init>(indexer, dir, column_type, column);
+                         size_t column, caf::actor index, uuid pid) {
+  VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column),
+             VAST_ARG(index), VAST_ARG(pid));
+  return parent->spawn<caf::lazy_init>(indexer, std::move(dir),
+                                       std::move(column_type), column,
+                                       std::move(index), pid);
 }
 
 } // namespace vast::system

--- a/libvast/src/system/table_indexer.cpp
+++ b/libvast/src/system/table_indexer.cpp
@@ -89,7 +89,8 @@ caf::actor& table_indexer::indexer_at(size_t column) {
   auto& result = indexers_[column];
   if (!result) {
     result = state().make_indexer(column_file(column),
-                                  layout().fields[column].type, column);
+                                  layout().fields[column].type, column,
+                                  partition_->id());
     VAST_ASSERT(result != nullptr);
   }
   return result;

--- a/libvast/test/system/indexer.cpp
+++ b/libvast/test/system/indexer.cpp
@@ -40,7 +40,8 @@ namespace {
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
   void init(type col_type) {
-    indexer = system::spawn_indexer(self.ptr(), directory, col_type, 0);
+    indexer = system::spawn_indexer(self.ptr(), directory, col_type, 0, self,
+                                    partition_id);
     run();
   }
 
@@ -82,6 +83,8 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
 
   /// Number size of our ID space.
   size_t num_ids = 0;
+
+  uuid partition_id = uuid::random();
 
   /// Our actors-under-test.
   actor indexer;

--- a/libvast/test/system/indexer_stage_driver.cpp
+++ b/libvast/test/system/indexer_stage_driver.cpp
@@ -59,7 +59,8 @@ behavior dummy_sink(stateful_actor<sink_state>* self) {
   }};
 }
 
-caf::actor spawn_sink(caf::local_actor* self, path, type, size_t) {
+caf::actor spawn_sink(caf::local_actor* self, path, type, size_t, caf::actor,
+                      uuid) {
   auto result = self->spawn(dummy_sink);
   all_sinks.emplace_back(result);
   return result;

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -127,7 +127,7 @@ struct index_state {
                           uuid partition_id);
 
   /// Decrements the indexer count for a partition.
-  caf::error decrement_indexer_count(uuid pid);
+  void decrement_indexer_count(uuid pid);
 
   /// @returns the unpersisted partition matching `id` or `nullptr` if no
   ///          partition matches.

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -123,7 +123,10 @@ struct index_state {
   partition_ptr make_partition(uuid id);
 
   /// @returns a new INDEXER actor.
-  caf::actor make_indexer(path dir, type column_type, size_t column);
+  caf::actor make_indexer(path dir, type column_type, size_t column, uuid pid);
+
+  /// Decrements the indexer count for a partition.
+  caf::error decrement_indexer_count(uuid pid);
 
   /// @returns the unpersisted partition matching `id` or `nullptr` if no
   ///          partition matches.
@@ -174,6 +177,9 @@ struct index_state {
   /// Our current partition.
   partition_ptr active;
 
+  /// Our current partition.
+  size_t active_partition_indexers;
+
   /// Recently accessed partitions.
   partition_cache_type lru_partitions;
 
@@ -197,4 +203,3 @@ caf::behavior index(caf::stateful_actor<index_state>* self, const path& dir,
                     size_t taste_partitions, size_t num_workers);
 
 } // namespace vast::system
-

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -178,7 +178,7 @@ struct index_state {
   /// Our current partition.
   partition_ptr active;
 
-  /// Our current partition.
+  /// Active indexer count for the current partition.
   size_t active_partition_indexers;
 
   /// Recently accessed partitions.

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -123,7 +123,8 @@ struct index_state {
   partition_ptr make_partition(uuid id);
 
   /// @returns a new INDEXER actor.
-  caf::actor make_indexer(path dir, type column_type, size_t column, uuid pid);
+  caf::actor make_indexer(path dir, type column_type, size_t column,
+                          uuid partition_id);
 
   /// Decrements the indexer count for a partition.
   caf::error decrement_indexer_count(uuid pid);

--- a/libvast/vast/system/indexer.hpp
+++ b/libvast/vast/system/indexer.hpp
@@ -22,6 +22,7 @@
 #include "vast/filesystem.hpp"
 #include "vast/column_index.hpp"
 #include "vast/type.hpp"
+#include "vast/uuid.hpp"
 
 namespace vast::system {
 
@@ -33,11 +34,15 @@ struct indexer_state {
   ~indexer_state();
 
   caf::error init(caf::event_based_actor* self, path filename, type column_type,
-                  size_t column);
+                  size_t column, caf::actor index, uuid pid);
 
   // -- member variables -------------------------------------------------------
 
   union { column_index col; };
+
+  caf::actor index;
+
+  uuid partition_id;
 
   static inline const char* name = "indexer";
 };
@@ -47,8 +52,11 @@ struct indexer_state {
 /// @param dir The directory where to store the indexes in.
 /// @param column_type The type of the indexed column.
 /// @param column The indexed column.
+/// @param index A handle to the index actor.
+/// @param pid The partition ID that this INDEXER belongs to.
 /// @returns the initial behavior of the INDEXER.
 caf::behavior indexer(caf::stateful_actor<indexer_state>* self, path dir,
-                      type column_type, size_t column);
+                      type column_type, size_t column, caf::actor index,
+                      uuid pid);
 
 } // namespace vast::system

--- a/libvast/vast/system/indexer.hpp
+++ b/libvast/vast/system/indexer.hpp
@@ -19,8 +19,8 @@
 #include <caf/event_based_actor.hpp>
 #include <caf/stateful_actor.hpp>
 
-#include "vast/filesystem.hpp"
 #include "vast/column_index.hpp"
+#include "vast/filesystem.hpp"
 #include "vast/type.hpp"
 #include "vast/uuid.hpp"
 
@@ -34,7 +34,7 @@ struct indexer_state {
   ~indexer_state();
 
   caf::error init(caf::event_based_actor* self, path filename, type column_type,
-                  size_t column, caf::actor index, uuid pid);
+                  size_t column, caf::actor index, uuid partition_id);
 
   // -- member variables -------------------------------------------------------
 
@@ -53,10 +53,10 @@ struct indexer_state {
 /// @param column_type The type of the indexed column.
 /// @param column The indexed column.
 /// @param index A handle to the index actor.
-/// @param pid The partition ID that this INDEXER belongs to.
+/// @param partition_id The partition ID that this INDEXER belongs to.
 /// @returns the initial behavior of the INDEXER.
 caf::behavior indexer(caf::stateful_actor<indexer_state>* self, path dir,
                       type column_type, size_t column, caf::actor index,
-                      uuid pid);
+                      uuid partition_id);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_indexer.hpp
+++ b/libvast/vast/system/spawn_indexer.hpp
@@ -26,8 +26,10 @@ namespace vast::system {
 /// @param dir Base directory for persistent state.
 /// @param column_type The type of the indexed field.
 /// @param column The column ID for the indexed field.
+/// @param index A handle to the index actor.
+/// @param pid The partition ID that this INDEXER belongs to.
 /// @returns the new INDEXER actor.
-caf::actor spawn_indexer(caf::local_actor* parent, path dir,
-                         type column_type, size_t column);
+caf::actor spawn_indexer(caf::local_actor* parent, path dir, type column_type,
+                         size_t column, caf::actor index, uuid pid);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_indexer.hpp
+++ b/libvast/vast/system/spawn_indexer.hpp
@@ -27,9 +27,9 @@ namespace vast::system {
 /// @param column_type The type of the indexed field.
 /// @param column The column ID for the indexed field.
 /// @param index A handle to the index actor.
-/// @param pid The partition ID that this INDEXER belongs to.
+/// @param partition_id The partition ID that this INDEXER belongs to.
 /// @returns the new INDEXER actor.
 caf::actor spawn_indexer(caf::local_actor* parent, path dir, type column_type,
-                         size_t column, caf::actor index, uuid pid);
+                         size_t column, caf::actor index, uuid partition_id);
 
 } // namespace vast::system

--- a/libvast_test/src/dummy_index.cpp
+++ b/libvast_test/src/dummy_index.cpp
@@ -35,7 +35,8 @@ behavior dummy_indexer(stateful_actor<dummy_index::dummy_indexer_state>*) {
   }};
 }
 
-actor spawn_dummy_indexer(local_actor* self, path, type, size_t) {
+actor spawn_dummy_indexer(local_actor* self, path, type, size_t, caf::actor,
+                          uuid) {
   return self->spawn(dummy_indexer);
 }
 


### PR DESCRIPTION
This patch fixes a bug where an indexer could be triggered to flush its data before all items in its inbound stream were consumed, loading to an incomplete column_index on disk.