### PR TITLE
Support choice of table slice type on command line

### DIFF
--- a/libvast/src/defaults.cpp
+++ b/libvast/src/defaults.cpp
@@ -45,6 +45,7 @@ const char* node_id = "node";
 
 namespace system {
 
+const char* table_slice_type = "default";
 size_t table_slice_size = 100;
 size_t max_partition_size = 1_Mi;
 size_t max_in_mem_partitions = 10;

--- a/libvast/src/defaults.cpp
+++ b/libvast/src/defaults.cpp
@@ -45,7 +45,7 @@ const char* node_id = "node";
 
 namespace system {
 
-const char* table_slice_type = "default";
+caf::atom_value table_slice_type = caf::atom("default");
 size_t table_slice_size = 100;
 size_t max_partition_size = 1_Mi;
 size_t max_in_mem_partitions = 10;

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -375,13 +375,14 @@ void node_state::init(std::string init_name, path init_dir) {
             .add<bool>("cpu,c", "start the CPU profiler")
             .add<bool>("heap,h", "start the heap profiler")
             .add<size_t>("resolution,r", "seconds between measurements"));
-  // Add spawn sink commands.
+  // Add spawn source commands.
   auto src
     = sp->add(nullptr, "source", "creates a new source",
               opts()
                 .add<std::string>("read,r", "path to input")
-                .add<bool>("uds,d", "treat -w as UNIX domain socket")
-                .add<std::string>("schema,s", "path to alternate schema"));
+                .add<std::string>("schema,s", "path to alternate schema")
+                .add<std::string>("table-slice,t", "table slice type")
+                .add<bool>("uds,d", "treat -w as UNIX domain socket"));
   src->add(spawn_command, "pcap", "creates a new PCAP source",
            opts()
              .add<size_t>("cutoff,c", "skip flow packets after this many bytes")

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -381,7 +381,7 @@ void node_state::init(std::string init_name, path init_dir) {
               opts()
                 .add<std::string>("read,r", "path to input")
                 .add<std::string>("schema,s", "path to alternate schema")
-                .add<std::string>("table-slice,t", "table slice type")
+                .add<caf::atom_value>("table-slice,t", "table slice type")
                 .add<bool>("uds,d", "treat -w as UNIX domain socket"));
   src->add(spawn_command, "pcap", "creates a new PCAP source",
            opts()

--- a/libvast/vast/add_table_slice.hpp
+++ b/libvast/vast/add_table_slice.hpp
@@ -1,0 +1,41 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <caf/atom.hpp>
+
+#include "vast/table_slice.hpp"
+#include "vast/table_slice_builder.hpp"
+
+namespace vast {
+
+/// Register a table slice along with a builder type.
+/// @tparam TableSlice The table slice type.
+/// @tparam TableSliceBuilder The table slice builder that builds instances of
+///         type `TableSlice`.
+/// @param id The ID to associate with the table slice and builder factories.
+/// @returns `true` if the factory registration succeeded.
+template <class TableSlice, class TableSliceBuilder>
+bool add_table_slice(caf::atom_value id) {
+  // Make sure the ID isn't registered in both factories.
+  if (get_table_slice_factory(id) != nullptr
+      || get_table_slice_builder_factory(id) != nullptr)
+    return false;
+  // Add the table slice and builder factories
+  add_table_slice_factory<TableSlice>();
+  add_table_slice_builder_factory<TableSliceBuilder>(id);
+  return true;
+}
+
+} // namespace vast

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -71,6 +71,9 @@ extern const char* node_id;
 
 namespace system {
 
+/// The default table slice type.
+extern const char* table_slice_type;
+
 /// Maximum size for sources that generate table slices.
 extern size_t table_slice_size;
 

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -17,6 +17,8 @@
 #include <cstdint>
 #include <string>
 
+#include <caf/atom.hpp>
+
 namespace vast::defaults {
 
 namespace command {
@@ -72,7 +74,7 @@ extern const char* node_id;
 namespace system {
 
 /// The default table slice type.
-extern const char* table_slice_type;
+extern caf::atom_value table_slice_type;
 
 /// Maximum size for sources that generate table slices.
 extern size_t table_slice_size;

--- a/libvast/vast/system/datagram_source.hpp
+++ b/libvast/vast/system/datagram_source.hpp
@@ -76,7 +76,7 @@ template <class Reader>
 caf::behavior
 datagram_source(datagram_source_actor<Reader>* self,
                 uint16_t udp_listening_port, Reader reader,
-                typename source_state<Reader>::factory_type factory,
+                table_slice_builder_factory factory,
                 size_t table_slice_size) {
   using namespace caf;
   using namespace std::chrono;
@@ -89,7 +89,7 @@ datagram_source(datagram_source_actor<Reader>* self,
   }
   VAST_DEBUG(self, "starts listening at port", udp_res->second);
   // Initialize state.
-  self->state.init(self, std::move(reader), std::move(factory));
+  self->state.init(self, std::move(reader), factory);
   // Spin up the stream manager for the source.
   self->state.mgr = self->make_continuous_source(
     // init

--- a/libvast/vast/system/default_application.hpp
+++ b/libvast/vast/system/default_application.hpp
@@ -36,7 +36,7 @@ public:
       .add<std::string>("read,r", "path to input where to read events from")
       .add<std::string>("schema-file,s", "path to alternate schema")
       .add<std::string>("schema,S", "alternate schema as string")
-      .add<std::string>("table-slice,t", "table slice type")
+      .add<caf::atom_value>("table-slice,t", "table slice type")
       .add<bool>("uds,d", "treat -r as listening UNIX domain socket");
   }
 

--- a/libvast/vast/system/default_application.hpp
+++ b/libvast/vast/system/default_application.hpp
@@ -33,9 +33,10 @@ public:
   /// @returns default options for source commands.
   static auto src_opts() {
     return command::opts()
+      .add<std::string>("read,r", "path to input where to read events from")
       .add<std::string>("schema-file,s", "path to alternate schema")
       .add<std::string>("schema,S", "alternate schema as string")
-      .add<std::string>("read,r", "path to input where to read events from")
+      .add<std::string>("table-slice,t", "table slice type")
       .add<bool>("uds,d", "treat -r as listening UNIX domain socket");
   }
 

--- a/libvast/vast/system/reader_command.hpp
+++ b/libvast/vast/system/reader_command.hpp
@@ -23,9 +23,11 @@
 #include "vast/command.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/make_io_stream.hpp"
+#include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/system/source.hpp"
 #include "vast/system/source_command.hpp"
+#include "vast/table_slice_builder.hpp"
 
 namespace vast::system {
 
@@ -40,11 +42,20 @@ caf::message reader_command(const command& cmd, caf::actor_system& sys,
   VAST_TRACE(VAST_ARG(options), VAST_ARG("args", first, last));
   auto input = get_or(options, "read", defaults::command::read_path);
   auto uds = get_or(options, "uds", false);
+  auto table_slice = get_or(options, "table-slice",
+                            defaults::system::table_slice_type);
+  auto table_slice_id = caf::atom_from_string(table_slice);
+  auto factory = get_table_slice_builder_factory(table_slice_id);
+  if (factory == nullptr)
+    return caf::make_message(make_error(ec::unspecified,
+                                        "unknown table_slice_builder factory"));
   auto in = detail::make_input_stream(input, uds);
   if (!in)
     return caf::make_message(std::move(in.error()));
   Reader reader{std::move(*in)};
-  auto src = sys.spawn(default_source<Reader>, std::move(reader));
+  auto slice_size = get_or(options, "table-slice-size",
+                           defaults::system::table_slice_size);
+  auto src = sys.spawn(source<Reader>, std::move(reader), factory, slice_size);
   return source_command(cmd, sys, std::move(src), options, first, last);
 }
 

--- a/libvast/vast/system/reader_command.hpp
+++ b/libvast/vast/system/reader_command.hpp
@@ -44,8 +44,7 @@ caf::message reader_command(const command& cmd, caf::actor_system& sys,
   auto uds = get_or(options, "uds", false);
   auto table_slice = get_or(options, "table-slice",
                             defaults::system::table_slice_type);
-  auto table_slice_id = caf::atom_from_string(table_slice);
-  auto factory = get_table_slice_builder_factory(table_slice_id);
+  auto factory = get_table_slice_builder_factory(table_slice);
   if (factory == nullptr)
     return caf::make_message(make_error(ec::unspecified,
                                         "unknown table_slice_builder factory"));

--- a/libvast/vast/table_slice_builder.hpp
+++ b/libvast/vast/table_slice_builder.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <caf/make_counted.hpp>
 #include <caf/ref_counted.hpp>
 
 #include "vast/fwd.hpp"
@@ -72,5 +73,37 @@ private:
 
 /// @relates table_slice_builder
 using table_slice_builder_ptr = caf::intrusive_ptr<table_slice_builder>;
+
+/// The factory function to construct a table slice builder for a layout.
+/// @relates table_slice_builder
+using table_slice_builder_factory = table_slice_builder_ptr (*)(record_type);
+
+/// Registers a table slice builder factory.
+/// @param id The unique implementation ID for the table slice type.
+/// @param f The factory how to construct the table slice builder.
+/// @returns `true` iff the *f* was successfully associated with *id*.
+/// @relates table_slice get_table_slice_builder_factory
+bool add_table_slice_builder_factory(caf::atom_value id,
+                                     table_slice_builder_factory f);
+
+/// Convenience overload for the two-argument version of this function.
+template <class T>
+bool add_table_slice_builder_factory(caf::atom_value id) {
+  static auto factory = [](record_type layout) {
+    return T::make(std::move(layout));
+  };
+  return add_table_slice_builder_factory(id, factory);
+}
+
+/// Retrieves a table slice builder factory.
+/// @relates table_slice_builder add_table_slice_builder_factory
+table_slice_builder_factory get_table_slice_builder_factory(caf::atom_value id);
+
+/// Constructs a builder for a given table slice type.
+/// @param id The (registered) implementation ID of the slice type.
+/// @returns A table slice builder pointer or `nullptr` on failure.
+/// @relates table_slice_builder add_table_slice_builder_factory
+table_slice_builder_ptr make_table_slice_builder(caf::atom_value id,
+                                                 record_type layout);
 
 } // namespace vast


### PR DESCRIPTION
This PR adds a new factory for table slice builders such that it becomes possible to select a builder dynamically at runtime. We use this feature to support selection of a particular table slice type on the command line.