### PR TITLE
Make actor system in save/load optional

### DIFF
--- a/libvast/src/column_index.cpp
+++ b/libvast/src/column_index.cpp
@@ -57,7 +57,7 @@ caf::error column_index::init() {
   // Materialize the index when encountering persistent state.
   if (exists(filename_)) {
     detail::value_index_inspect_helper tmp{index_type_, idx_};
-    if (auto err = load(sys_, filename_, last_flush_, tmp)) {
+    if (auto err = load(nullptr, filename_, last_flush_, tmp)) {
       VAST_ERROR(this, "failed to load value index from disk", sys_.render(err));
       return err;
     } else {
@@ -86,7 +86,7 @@ caf::error column_index::flush_to_disk() {
              "new/total bits)");
   last_flush_ = offset;
   detail::value_index_inspect_helper tmp{index_type_, idx_};
-  return save(sys_, filename_, last_flush_, tmp);
+  return save(nullptr, filename_, last_flush_, tmp);
 }
 
 // -- properties -------------------------------------------------------------

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -36,10 +36,9 @@ T to_little_endian(T x) {
 
 } // namespace <anonymous>
 
-segment_builder::segment_builder(caf::actor_system& sys)
-  : actor_system_{sys},
-    table_slice_streambuf_{table_slice_buffer_},
-    table_slice_serializer_{actor_system_, table_slice_streambuf_} {
+segment_builder::segment_builder()
+  : table_slice_streambuf_{table_slice_buffer_},
+    table_slice_serializer_{table_slice_streambuf_} {
   reset();
 }
 
@@ -86,7 +85,7 @@ caf::expected<segment_ptr> segment_builder::finish() {
               table_slice_buffer_.size());
   // Move the complete segment buffer into a chunk.
   auto chk = chunk::make(std::move(segment_buffer_));
-  auto result = caf::make_counted<segment>(actor_system_, chk);
+  auto result = caf::make_counted<segment>(chk);
   result->header_ = *chk->as<segment::header>();
   result->meta_ = std::move(meta_);
   return result;

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -35,19 +35,19 @@
 
 namespace vast {
 
-segment_store_ptr segment_store::make(caf::actor_system& sys, path dir,
-                                      size_t max_segment_size,
+segment_store_ptr segment_store::make(path dir, size_t max_segment_size,
                                       size_t in_memory_segments) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(max_segment_size),
              VAST_ARG(in_memory_segments));
   VAST_ASSERT(max_segment_size > 0);
-  auto x = std::make_unique<segment_store>(
-    sys, std::move(dir), max_segment_size, in_memory_segments);
+  auto x = std::make_unique<segment_store>(std::move(dir), max_segment_size,
+                                           in_memory_segments);
   // Materialize meta data of existing segments.
   if (exists(x->meta_path())) {
     VAST_DEBUG_ANON(__func__, "loads segment meta data from", x->meta_path());
     if (auto err = load(nullptr, x->meta_path(), x->segments_)) {
-      VAST_ERROR_ANON(__func__, "failed to unarchive meta data:", sys.render(err));
+      VAST_ERROR_ANON(__func__, "failed to unarchive meta data from",
+                      x->meta_path());
       return nullptr;
     }
   }
@@ -77,13 +77,13 @@ caf::error segment_store::flush() {
     return x.error();
   auto seg_ptr = *x;
   auto filename = segment_path() / to_string(seg_ptr->id());
-  if (auto err = save(&sys_, filename, seg_ptr))
+  if (auto err = save(nullptr, filename, seg_ptr))
     return err;
   // Keep new segment in the cache.
   cache_.emplace(seg_ptr->id(), seg_ptr);
   VAST_DEBUG(this, "wrote new segment to", filename.trim(-3));
   VAST_DEBUG(this, "saves segment meta data");
-  return save(&sys_, meta_path(), segments_);
+  return save(nullptr, meta_path(), segments_);
 }
 
 caf::expected<segment_ptr> segment_store::load_segment(uuid id) const {
@@ -91,7 +91,7 @@ caf::expected<segment_ptr> segment_store::load_segment(uuid id) const {
   auto fname = segment_path() / to_string(id);
   VAST_DEBUG(this, "loads segment from", fname);
   if (auto err = load(nullptr, fname, seg_ptr)) {
-    VAST_ERROR(this, "cannot load segment:", sys_.render(err));
+    VAST_ERROR(this, "cannot load segment from", fname);
     return err;
   }
   return seg_ptr;
@@ -217,7 +217,7 @@ segment_store::get(const ids& xs) {
         VAST_DEBUG(this, "got cache miss for segment", id);
         auto fname = segment_path() / to_string(id);
         if (auto err = load(nullptr, fname, seg_ptr)) {
-          VAST_ERROR(this, "unable to load segment:", sys_.render(err));
+          VAST_ERROR(this, "unable to load segment from", fname);
           return err;
         }
         i = cache_.emplace(id, seg_ptr).first;
@@ -257,13 +257,11 @@ void segment_store::inspect_status(caf::dictionary<caf::config_value>& dict) {
   put(current, "size", builder_.table_slice_bytes());
 }
 
-segment_store::segment_store(caf::actor_system& sys, path dir,
-                             uint64_t max_segment_size, size_t in_memory_segments)
-  : sys_{sys},
-    dir_{std::move(dir)},
+segment_store::segment_store(path dir, uint64_t max_segment_size,
+                             size_t in_memory_segments)
+  : dir_{std::move(dir)},
     max_segment_size_{max_segment_size},
-    cache_{in_memory_segments},
-    builder_{sys_} {
+    cache_{in_memory_segments} {
   // nop
 }
 

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -45,8 +45,7 @@ archive(archive_type::stateful_pointer<archive_state> self,
   // arguments of the actor. This way, users can provide their own store
   // implementation conveniently.
   VAST_INFO(self, "spawned:", VAST_ARG(capacity), VAST_ARG(max_segment_size));
-  self->state.store = segment_store::make(
-    self->system(), dir, max_segment_size, capacity);
+  self->state.store = segment_store::make(dir, max_segment_size, capacity);
   VAST_ASSERT(self->state.store != nullptr);
   self->set_exit_handler(
     [=](const exit_msg& msg) {

--- a/libvast/src/system/consensus.cpp
+++ b/libvast/src/system/consensus.cpp
@@ -40,13 +40,13 @@ log::log(caf::actor_system& sys, path dir) : dir_{std::move(dir)}, sys_(sys) {
   auto entries_filename = dir_ / "entries";
   if (exists(dir_)) {
     if (exists(meta_filename))
-      if (load(sys_, meta_filename, start_))
+      if (load(&sys_, meta_filename, start_))
         die("failed to load raft log meta data");
     if (exists(entries_filename)) {
       std::ifstream entries{entries_filename.str(), std::ios::binary};
       while (entries.peek() != std::ifstream::traits_type::eof()) {
         std::vector<log_entry> xs;
-        if (load(sys_, entries, xs))
+        if (load(&sys_, entries, xs))
           die("failed to load raft log entries");
         std::move(xs.begin(), xs.end(), std::back_inserter(entries_));
       }
@@ -127,7 +127,7 @@ expected<void> log::append(std::vector<log_entry> xs) {
     }
   }
   // Serialize the entries...
-  if (auto err =  save(sys_, entries_file_, xs))
+  if (auto err = save(nullptr, entries_file_, xs))
     return err;
   // ...and make them persistent...
   entries_file_.flush();
@@ -150,14 +150,14 @@ uint64_t bytes(log& l) {
 }
 
 expected<void> log::persist_meta_data() {
-  if (auto err = save(sys_, dir_ / "meta", start_))
+  if (auto err = save(nullptr, dir_ / "meta", start_))
     return err;
   return caf::unit;
 }
 
 expected<void> log::persist_entries() {
   entries_file_.close();
-  if (auto err = save(sys_, dir_ / "entries", entries_))
+  if (auto err = save(nullptr, dir_ / "entries", entries_))
     return err;
   return caf::unit;
 }
@@ -208,7 +208,7 @@ std::string role(Actor* self) {
 
 template <class Actor>
 expected<void> save_state(Actor* self) {
-  if (auto err = save(self->system(), self->state.dir / "state", self->state.id,
+  if (auto err = save(nullptr, self->state.dir / "state", self->state.id,
                       self->state.current_term, self->state.voted_for))
     return err;
   VAST_DEBUG(role(self), "saved persistent state: id =",
@@ -220,7 +220,7 @@ expected<void> save_state(Actor* self) {
 
 template <class Actor>
 expected<void> load_state(Actor* self) {
-  if (auto err = load(self->system(), self->state.dir / "state", self->state.id,
+  if (auto err = load(nullptr, self->state.dir / "state", self->state.id,
                       self->state.current_term, self->state.voted_for))
     return err;
   VAST_DEBUG(role(self), "loaded persistent state: id =",
@@ -294,7 +294,7 @@ result<index_type> save_snapshot(Actor* self, index_type index,
   snapshot_header hdr;
   hdr.last_included_index = index;
   hdr.last_included_term = self->state.log->at(index).term;
-  if (auto err = save(self->system(), self->state.dir / "snapshot",
+  if (auto err = save(nullptr, self->state.dir / "snapshot",
                       hdr, snapshot))
     return err;
   VAST_DEBUG(role(self), "completed snapshotting, last included term =",
@@ -316,7 +316,7 @@ expected<void> load_snapshot_header(Actor* self) {
   VAST_DEBUG(role(self), "loads snapshot header");
   snapshot_header hdr;
   // Read snapshot header from filesystem.
-  if (auto err = load(self->system(), self->state.dir / "snapshot", hdr))
+  if (auto err = load(nullptr, self->state.dir / "snapshot", hdr))
     return err;
   if (hdr.version != 1)
     return make_error(ec::version_error, "needed version 1, got", hdr.version);
@@ -348,7 +348,7 @@ expected<std::vector<char>> load_snapshot_data(Actor* self) {
   VAST_DEBUG(role(self), "loads snapshot data");
   snapshot_header hdr;
   std::vector<char> data;
-  if (auto err = load(self->system(), self->state.dir / "snapshot", hdr, data))
+  if (auto err = load(nullptr, self->state.dir / "snapshot", hdr, data))
     return err;
   if (hdr.version != 1)
     return make_error(ec::version_error, "needed version 1, got", hdr.version);

--- a/libvast/src/system/dummy_consensus.cpp
+++ b/libvast/src/system/dummy_consensus.cpp
@@ -32,7 +32,7 @@ dummy_consensus_state::dummy_consensus_state(actor_ptr self) : self{self} {
 caf::error dummy_consensus_state::init(path dir) {
   file = std::move(dir) / "store";
   if (exists(file)) {
-    if (auto err = vast::load(self->system(), file, store)) {
+    if (auto err = vast::load(&self->system(), file, store)) {
       VAST_WARNING_ANON(name, "unable to load state file:", file);
       return err;
     }
@@ -41,7 +41,7 @@ caf::error dummy_consensus_state::init(path dir) {
 }
 
 caf::error dummy_consensus_state::save() {
-  return vast::save(self->system(), file, store);
+  return vast::save(&self->system(), file, store);
 }
 
 caf::dictionary<caf::config_value> dummy_consensus_state::status() const {

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -117,7 +117,7 @@ caf::error index_state::load_from_disk() {
     return caf::none;
   }
   if (auto fname = meta_index_filename(); exists(fname)) {
-    if (auto err = load(self->system(), fname, meta_idx)) {
+    if (auto err = load(&self->system(), fname, meta_idx)) {
       VAST_ERROR(self, "failed to load meta index:",
                  self->system().render(err));
       return err;
@@ -131,7 +131,7 @@ caf::error index_state::flush_to_disk() {
   VAST_TRACE("");
   auto flush_all = [this]() -> caf::error {
     // Flush meta index to disk.
-    if (auto err = save(self->system(), meta_index_filename(), meta_idx))
+    if (auto err = save(&self->system(), meta_index_filename(), meta_idx))
       return err;
     // Flush active partition.
     if (active != nullptr)

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -59,7 +59,7 @@ caf::error partition::init() {
   auto file_path = meta_file();
   if (!exists(file_path))
     return ec::no_such_file;
-  if (auto err = load(state_->self->system(), file_path , meta_data_))
+  if (auto err = load(nullptr, file_path , meta_data_))
     return err;
   VAST_DEBUG(state_->self, "loaded partition", id_, "from disk with",
              meta_data_.types.size(), "layouts");
@@ -69,7 +69,7 @@ caf::error partition::init() {
 caf::error partition::flush_to_disk() {
   if (meta_data_.dirty) {
     // Write all layouts to disk.
-    if (auto err = save(state_->self->system(), meta_file(), meta_data_))
+    if (auto err = save(nullptr, meta_file(), meta_data_))
       return err;
     meta_data_.dirty = false;
   }

--- a/libvast/src/system/table_indexer.cpp
+++ b/libvast/src/system/table_indexer.cpp
@@ -57,7 +57,7 @@ caf::error table_indexer::init() {
   VAST_TRACE("");
   auto filename = row_ids_file();
   if (exists(filename))
-    if (auto err = load(self()->system(), filename, row_ids_))
+    if (auto err = load(nullptr, filename, row_ids_))
       return err;
   set_clean();
   return caf::none;
@@ -68,7 +68,7 @@ caf::error table_indexer::flush_to_disk() {
   VAST_TRACE("");
   if (!dirty())
     return caf::none;
-  if (auto err = save(self()->system(), row_ids_file(), row_ids_))
+  if (auto err = save(nullptr, row_ids_file(), row_ids_))
     return err;
   set_clean();
   return caf::none;

--- a/libvast/test/bitmap_index.cpp
+++ b/libvast/test/bitmap_index.cpp
@@ -14,7 +14,6 @@
 #define SUITE bitmap_index
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system.hpp"
 
 #include "vast/bitmap_index.hpp"
 #include "vast/concept/printable/to_string.hpp"
@@ -26,8 +25,6 @@
 
 using namespace vast;
 using namespace std::chrono_literals;
-
-FIXTURE_SCOPE(bitmap_index_tests, fixtures::deterministic_actor_system)
 
 TEST(boolean bitmap index) {
   bitmap_index<bool, singleton_coder<null_bitmap>> bmi;
@@ -285,11 +282,9 @@ TEST(serialization) {
   bmi1.append(-100);
   CHECK_EQUAL(to_string(bmi1.lookup(not_equal, 100)), "11011");
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, bmi1), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, bmi1), caf::none);
   auto bmi2 = bitmap_index_type{};
-  CHECK_EQUAL(load(sys, buf, bmi2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, bmi2), caf::none);
   CHECK(bmi1 == bmi2);
   CHECK_EQUAL(to_string(bmi2.lookup(not_equal, 100)), "11011");
 }
-
-FIXTURE_SCOPE_END()

--- a/libvast/test/bitvector.cpp
+++ b/libvast/test/bitvector.cpp
@@ -14,7 +14,6 @@
 #define SUITE bitvector
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system.hpp"
 
 #include "vast/bitvector.hpp"
 #include "vast/concept/printable/to_string.hpp"
@@ -24,8 +23,6 @@
 #include "vast/save.hpp"
 
 using namespace vast;
-
-FIXTURE_SCOPE(bitvector_tests, fixtures::deterministic_actor_system)
 
 TEST(default construction) {
   bitvector<uint8_t> x;
@@ -213,8 +210,8 @@ TEST(serializable) {
   x.resize(1024, false);
   x[1000] = true;
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, x), caf::none);
-  CHECK_EQUAL(load(sys, buf, y), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, x), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, y), caf::none);
   REQUIRE_EQUAL(x, y);
   CHECK(y[1000]);
 }
@@ -259,5 +256,3 @@ TEST(rank) {
   CHECK_EQUAL(rank<0>(x), 1023u);
   CHECK_EQUAL(rank<1>(x), 1025u + 2048);
 }
-
-FIXTURE_SCOPE_END()

--- a/libvast/test/cache.cpp
+++ b/libvast/test/cache.cpp
@@ -14,7 +14,6 @@
 #define SUITE detail
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system.hpp"
 
 #include <vast/load.hpp>
 #include <vast/save.hpp>
@@ -25,7 +24,7 @@ using namespace vast;
 namespace {
 
 template <class Policy>
-struct fixture : fixtures::deterministic_actor_system {
+struct fixture {
   fixture() {
     CHECK(xs.emplace("foo", 1).second);
     CHECK(xs.emplace("bar", 2).second);
@@ -80,9 +79,9 @@ TEST(LRU cache insertion) {
 
 TEST(cache serialization) {
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, xs), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, xs), caf::none);
   decltype(xs) ys;
-  CHECK_EQUAL(load(sys, buf, ys), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, ys), caf::none);
   CHECK(xs == ys);
 }
 

--- a/libvast/test/chunk.cpp
+++ b/libvast/test/chunk.cpp
@@ -16,7 +16,6 @@
 #include "vast/chunk.hpp"
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system.hpp"
 
 #include "vast/load.hpp"
 #include "vast/save.hpp"
@@ -24,8 +23,6 @@
 #include "vast/span.hpp"
 
 using namespace vast;
-
-FIXTURE_SCOPE(chunk_tests, fixtures::deterministic_actor_system)
 
 TEST(deleter) {
   char buf[100];
@@ -62,11 +59,9 @@ TEST(serialization) {
   char str[] = "foobarbaz";
   auto x = chunk::make(make_const_byte_span(str));
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, x), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, x), caf::none);
   chunk_ptr y;
-  CHECK_EQUAL(load(sys, buf, y), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, y), caf::none);
   REQUIRE_NOT_EQUAL(y, nullptr);
   CHECK(std::equal(x->begin(), x->end(), y->begin(), y->end()));
 }
-
-FIXTURE_SCOPE_END()

--- a/libvast/test/coder.cpp
+++ b/libvast/test/coder.cpp
@@ -55,8 +55,6 @@ void fill(Coder& c, Ts... xs) {
 
 } // namespace <anonymous>
 
-FIXTURE_SCOPE(coder_tests, fixtures::deterministic_actor_system)
-
 TEST(bitwise total ordering (integral)) {
   using detail::order;
   MESSAGE("unsigned identities");
@@ -480,8 +478,8 @@ TEST(serialization range coder) {
   range_coder<null_bitmap> x{100}, c;
   fill(x, 42, 84, 42, 21, 30);
   std::string buf;
-  CHECK_EQUAL(save(sys, buf, x), caf::none);
-  CHECK_EQUAL(load(sys, buf, c), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, x), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, c), caf::none);
   CHECK_EQUAL(x, c);
   CHECK_DECODE(equal,     21, "00010");
   CHECK_DECODE(equal,     30, "00001");
@@ -505,9 +503,9 @@ TEST(serialization multi-level coder) {
   auto x = coder_type{base{10, 10}};
   fill(x, 42, 84, 42, 21, 30);
   std::string buf;
-  CHECK_EQUAL(save(sys, buf, x), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, x), caf::none);
   auto c = coder_type{};
-  CHECK_EQUAL(load(sys, buf, c), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, c), caf::none);
   CHECK_EQUAL(x, c);
   CHECK_DECODE(equal,     21, "00010");
   CHECK_DECODE(equal,     30, "00001");
@@ -531,5 +529,3 @@ TEST(printable) {
                   "4\t00001";
   CHECK_EQUAL(to_string(c), expected);
 }
-
-FIXTURE_SCOPE_END()

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -14,7 +14,6 @@
 #define SUITE data
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system.hpp"
 
 #include "vast/data.hpp"
 #include "vast/json.hpp"
@@ -29,8 +28,6 @@
 #include "vast/concept/printable/vast/json.hpp"
 
 using namespace vast;
-
-FIXTURE_SCOPE(data_tests, fixtures::deterministic_actor_system)
 
 TEST(vector) {
   REQUIRE(std::is_same_v<std::vector<data>, vector>);
@@ -192,9 +189,9 @@ TEST(serialization) {
   xs.emplace(port{8, port::icmp});
   auto x0 = data{xs};
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, x0), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, x0), caf::none);
   data x1;
-  CHECK_EQUAL(load(sys, buf, x1), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, x1), caf::none);
   CHECK(x0 == x1);
 }
 
@@ -322,5 +319,3 @@ TEST(json) {
 })__";
   CHECK_EQUAL(to_string(to_json(x, t)), expected);
 }
-
-FIXTURE_SCOPE_END()

--- a/libvast/test/event.cpp
+++ b/libvast/test/event.cpp
@@ -14,7 +14,6 @@
 #define SUITE event
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system.hpp"
 
 #include "vast/event.hpp"
 #include "vast/json.hpp"
@@ -29,7 +28,7 @@ using namespace vast;
 
 namespace {
 
-struct fixture : fixtures::deterministic_actor_system {
+struct fixture {
   fixture() {
     // Type
     t = record_type{
@@ -80,9 +79,9 @@ TEST(printable) {
 
 TEST(serialization) {
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, e), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, e), caf::none);
   event e2;
-  CHECK_EQUAL(load(sys, buf, e2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, e2), caf::none);
   CHECK_EQUAL(e, e2);
 }
 

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -14,6 +14,7 @@
 #define SUITE expression
 
 #include "vast/test/test.hpp"
+#include <caf/test/dsl.hpp>
 
 #include <string>
 

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -14,7 +14,6 @@
 #define SUITE expression
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system.hpp"
 
 #include <string>
 
@@ -47,7 +46,7 @@ expression to_expr(T&& x) {
   return unbox(to<expression>(std::forward<T>(x)));
 };
 
-struct fixture : fixtures::deterministic_actor_system {
+struct fixture {
   fixture() {
     // expr0 := !(x.y.z <= 42 && &foo == T)
     auto p0 = predicate{key_extractor{"x.y.z"}, less_equal, data{42}};
@@ -89,8 +88,8 @@ TEST(construction) {
 TEST(serialization) {
   expression ex0, ex1;
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, expr0, expr1), caf::none);
-  CHECK_EQUAL(load(sys, buf, ex0, ex1), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, expr0, expr1), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, ex0, ex1), caf::none);
   auto d = caf::get_if<disjunction>(&ex1);
   REQUIRE(d);
   REQUIRE(!d->empty());

--- a/libvast/test/range_map.cpp
+++ b/libvast/test/range_map.cpp
@@ -14,7 +14,6 @@
 #define SUITE range_map
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system.hpp"
 
 #include "vast/detail/range_map.hpp"
 #include "vast/load.hpp"
@@ -22,8 +21,6 @@
 
 using namespace vast;
 using namespace vast::detail;
-
-FIXTURE_SCOPE(range_map_tests, fixtures::deterministic_actor_system)
 
 TEST(range_map insertion) {
   range_map<int, std::string> rm;
@@ -192,12 +189,10 @@ TEST(range_map serialization) {
   x.insert(80, 90, 'b');
   x.insert(20, 30, 'c');
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, x), caf::none);
-  CHECK_EQUAL(load(sys, buf, y), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, x), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, y), caf::none);
   REQUIRE_EQUAL(y.size(), 3u);
   auto i = y.lookup(50);
   REQUIRE(i);
   CHECK(*i == 'a');
 }
-
-FIXTURE_SCOPE_END()

--- a/libvast/test/save_load.cpp
+++ b/libvast/test/save_load.cpp
@@ -60,13 +60,13 @@ FIXTURE_SCOPE(serialization_tests, fixtures::deterministic_actor_system)
 
 TEST(variadic) {
   std::string buf;
-  CHECK_EQUAL(save<compression::lz4>(sys, buf, 42, 4.2, 1337u, "foo"s),
+  CHECK_EQUAL(save<compression::lz4>(nullptr, buf, 42, 4.2, 1337u, "foo"s),
               caf::none);
   int i;
   double d;
   unsigned u;
   std::string s;
-  CHECK_EQUAL(load<compression::lz4>(sys, buf, i, d, u, s), caf::none);
+  CHECK_EQUAL(load<compression::lz4>(nullptr, buf, i, d, u, s), caf::none);
   CHECK_EQUAL(i, 42);
   CHECK_EQUAL(d, 4.2);
   CHECK_EQUAL(u, 1337u);
@@ -77,9 +77,9 @@ TEST(custom type modeling serializable) {
   std::vector<char> buf;
   foo x;
   x.i = 42;
-  CHECK_EQUAL(save(sys, buf, x), caf::none);
+  CHECK_EQUAL(save(&sys, buf, x), caf::none);
   foo y;
-  CHECK_EQUAL(load(sys, buf, y), caf::none);
+  CHECK_EQUAL(load(&sys, buf, y), caf::none);
   CHECK_EQUAL(x.i, y.i);
 }
 
@@ -87,9 +87,9 @@ TEST(custom type modeling state) {
   std::vector<char> buf;
   bar x;
   x.set(42);
-  CHECK_EQUAL(save(sys, buf, x), caf::none);
+  CHECK_EQUAL(save(&sys, buf, x), caf::none);
   bar y;
-  CHECK_EQUAL(load(sys, buf, y), caf::none);
+  CHECK_EQUAL(load(&sys, buf, y), caf::none);
   CHECK_EQUAL(x.get(), y.get());
 }
 

--- a/libvast/test/schema.cpp
+++ b/libvast/test/schema.cpp
@@ -15,7 +15,6 @@
 
 #include "vast/test/test.hpp"
 #include "type_test.hpp"
-#include "vast/test/fixtures/actor_system.hpp"
 
 #include "vast/json.hpp"
 #include "vast/load.hpp"
@@ -34,8 +33,6 @@ using namespace vast;
 using caf::get;
 using caf::get_if;
 using caf::holds_alternative;
-
-FIXTURE_SCOPE(schema_tests, fixtures::deterministic_actor_system)
 
 TEST(offset finding) {
   std::string str = R"__(
@@ -98,9 +95,9 @@ TEST(serialization) {
   sch.add(t);
   // Save & load
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, sch), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, sch), caf::none);
   schema sch2;
-  CHECK_EQUAL(load(sys, buf, sch2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, sch2), caf::none);
   // Check integrity
   auto u = sch2.find("foo");
   REQUIRE(u);
@@ -285,5 +282,3 @@ TEST(json) {
 })__";
   CHECK_EQUAL(to_string(to_json(s)), expected);
 }
-
-FIXTURE_SCOPE_END()

--- a/libvast/test/schema.cpp
+++ b/libvast/test/schema.cpp
@@ -14,6 +14,8 @@
 #define SUITE schema
 
 #include "vast/test/test.hpp"
+#include <caf/test/dsl.hpp>
+
 #include "type_test.hpp"
 
 #include "vast/json.hpp"

--- a/libvast/test/segment_store.cpp
+++ b/libvast/test/segment_store.cpp
@@ -16,7 +16,8 @@
 #include "vast/segment_store.hpp"
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system_and_events.hpp"
+#include "vast/test/fixtures/events.hpp"
+#include "vast/test/fixtures/filesystem.hpp"
 
 #include "vast/ids.hpp"
 #include "vast/si_literals.hpp"
@@ -25,12 +26,13 @@
 using namespace vast;
 using namespace binary_byte_literals;
 
-FIXTURE_SCOPE(segment_store_tests,
-              fixtures::deterministic_actor_system_and_events)
+struct fixture : fixtures::events, fixtures::filesystem {};
+
+FIXTURE_SCOPE(segment_store_tests, fixture)
 
 TEST(construction and querying) {
   auto path = directory / "segments";
-  auto store = segment_store::make(sys, path, 512_KiB, 2);
+  auto store = segment_store::make(path, 512_KiB, 2);
   REQUIRE(store);
   for (auto& slice : bro_conn_log_slices)
     REQUIRE(!store->put(slice));
@@ -41,7 +43,7 @@ TEST(construction and querying) {
 
 TEST(sessionized extraction) {
   auto path = directory / "segments";
-  auto store = segment_store::make(sys, path, 512_KiB, 2);
+  auto store = segment_store::make(path, 512_KiB, 2);
   REQUIRE(store);
   for (auto& slice : bro_conn_log_slices)
     REQUIRE(!store->put(slice));

--- a/libvast/test/value.cpp
+++ b/libvast/test/value.cpp
@@ -14,7 +14,6 @@
 #define SUITE value
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system.hpp"
 
 #include "vast/load.hpp"
 #include "vast/json.hpp"
@@ -32,8 +31,6 @@ using caf::get_if;
 using caf::holds_alternative;
 
 using namespace vast;
-
-FIXTURE_SCOPE(value_tests, fixtures::deterministic_actor_system)
 
 // An *invalid* value has neither a type nor data.
 // This is the default-constructed state.
@@ -129,8 +126,8 @@ TEST(serialization) {
   value v{s, t};
   value w;
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, v), caf::none);
-  CHECK_EQUAL(load(sys, buf, w), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, v), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, w), caf::none);
   CHECK(v == w);
   CHECK(to_string(w) == "{80/tcp, 53/udp, 8/icmp}");
 }
@@ -182,5 +179,3 @@ TEST(json)
 })__";
   CHECK_EQUAL(to_string(*j), str);
 }
-
-FIXTURE_SCOPE_END()

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -14,7 +14,7 @@
 #define SUITE value_index
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system_and_events.hpp"
+#include "vast/test/fixtures/events.hpp"
 
 #include "vast/value_index.hpp"
 #include "vast/load.hpp"
@@ -31,8 +31,7 @@
 using namespace vast;
 using namespace std::string_literals;
 
-FIXTURE_SCOPE(value_index_tests,
-              fixtures::deterministic_actor_system_and_events)
+FIXTURE_SCOPE(value_index_tests, fixtures::events)
 
 TEST(boolean) {
   arithmetic_index<boolean> idx;
@@ -58,9 +57,9 @@ TEST(boolean) {
   CHECK_EQUAL(to_string(*multi), "11111111");
   MESSAGE("serialization");
   std::string buf;
-  CHECK_EQUAL(save(sys, buf, idx), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
   arithmetic_index<boolean> idx2;
-  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   t = idx2.lookup(equal, make_data_view(true));
   REQUIRE(t);
   CHECK_EQUAL(to_string(*t), "11010001");
@@ -92,9 +91,9 @@ TEST(integer) {
   CHECK_EQUAL(to_string(*multi), "0101011");
   MESSAGE("serialization");
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, idx), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
   auto idx2 = arithmetic_index<integer>{};
-  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   less_than_leet = idx2.lookup(less, make_data_view(31337));
   REQUIRE(less_than_leet);
   CHECK(to_string(*less_than_leet) == "1111011");
@@ -122,9 +121,9 @@ TEST(floating-point with custom binner) {
   CHECK_EQUAL(to_string(*result), "1110111");
   MESSAGE("serialization");
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, idx), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
   auto idx2 = index_type{};
-  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   result = idx2.lookup(not_equal, make_data_view(4711.14));
   CHECK_EQUAL(to_string(*result), "1110111");
 }
@@ -188,9 +187,9 @@ TEST(timestamp) {
   CHECK(to_string(*eighteen) == "000101");
   MESSAGE("serialization");
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, idx), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
   auto idx2 = decltype(idx){};
-  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   eighteen = idx2.lookup(greater_equal, make_data_view(*t));
   CHECK(to_string(*eighteen) == "000101");
 }
@@ -251,9 +250,9 @@ TEST(string) {
   CHECK_EQUAL(to_string(*result), "1111110000");
   MESSAGE("serialization");
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, idx), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
   string_index idx2{};
-  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   result = idx2.lookup(equal, make_data_view("foo"));
   CHECK_EQUAL(to_string(*result), "1001100000");
   result = idx2.lookup(equal, make_data_view("bar"));
@@ -328,9 +327,9 @@ TEST(address) {
   CHECK_EQUAL(idx.lookup(equal, make_data_view(x)), str);
   MESSAGE("serialization");
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, idx), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
   address_index idx2{};
-  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   CHECK_EQUAL(idx2.lookup(equal, make_data_view(x)), str);
 }
 
@@ -384,9 +383,9 @@ TEST(subnet) {
   CHECK_EQUAL(to_string(*multi), "111100");
   MESSAGE("serialization");
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, idx), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
   subnet_index idx2;
-  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   bm = idx2.lookup(not_equal, make_data_view(s1));
   REQUIRE(bm);
   CHECK_EQUAL(to_string(*bm), "101111");
@@ -420,9 +419,9 @@ TEST(port) {
   CHECK_EQUAL(to_string(*multi), "1010010");
   MESSAGE("serialization");
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, idx), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
   port_index idx2;
-  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   bm = idx2.lookup(less_equal, make_data_view(priv));
   REQUIRE(bm);
   CHECK_EQUAL(to_string(*bm), "1111010");
@@ -449,9 +448,9 @@ TEST(container) {
   CHECK_EQUAL(to_string(*idx.lookup(ni, make_data_view(x))), "00000000");
   MESSAGE("serialization");
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, idx), caf::none);
+  CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
   sequence_index idx2;
-  CHECK_EQUAL(load(sys, buf, idx2), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   x = "foo";
   CHECK_EQUAL(to_string(*idx2.lookup(ni, make_data_view(x))), "11000000");
 }
@@ -473,11 +472,11 @@ TEST(polymorphic) {
   CHECK_EQUAL(to_string(*idx->lookup(ni, make_data_view(44))), "0000");
   MESSAGE("serialization");
   std::vector<char> buf;
-  CHECK_EQUAL(save(sys, buf, detail::value_index_inspect_helper{t, idx}),
+  CHECK_EQUAL(save(nullptr, buf, detail::value_index_inspect_helper{t, idx}),
               caf::none);
   std::unique_ptr<value_index> idx2;
   detail::value_index_inspect_helper helper{t, idx2};
-  CHECK_EQUAL(load(sys, buf, helper), caf::none);
+  CHECK_EQUAL(load(nullptr, buf, helper), caf::none);
   REQUIRE(idx2);
   CHECK_EQUAL(to_string(*idx2->lookup(ni, make_data_view(42))), "1001");
   MESSAGE("attributes");

--- a/libvast/vast/segment.hpp
+++ b/libvast/vast/segment.hpp
@@ -17,7 +17,6 @@
 #include <memory>
 #include <vector>
 
-#include <caf/actor_system.hpp>
 #include <caf/expected.hpp>
 #include <caf/fwd.hpp>
 #include <caf/intrusive_ptr.hpp>
@@ -102,10 +101,8 @@ public:
   };
 
   /// Constructs a segment.
-  /// @param sys The actor system that stores factory to deserialize table
-  ///            slices.
   /// @param chunk The chunk holding the segment data.
-  static caf::expected<segment_ptr> make(caf::actor_system& sys, chunk_ptr chunk);
+  static caf::expected<segment_ptr> make(chunk_ptr chunk);
 
   /// @returns The unique ID of this segment.
   const uuid& id() const;
@@ -124,7 +121,7 @@ public:
 
   /// @cond PRIVATE
 
-  segment(caf::actor_system& sys, chunk_ptr chunk);
+  explicit segment(chunk_ptr chunk);
 
   /// @endcond
 
@@ -132,7 +129,6 @@ private:
   caf::expected<table_slice_ptr>
   make_slice(const table_slice_synopsis& slice) const;
 
-  caf::actor_system& actor_system_;
   chunk_ptr chunk_;
   header header_;
   meta_data meta_;

--- a/libvast/vast/segment_builder.hpp
+++ b/libvast/vast/segment_builder.hpp
@@ -16,7 +16,6 @@
 #include <cstddef>
 #include <vector>
 
-#include <caf/actor_system.hpp>
 #include <caf/expected.hpp>
 #include <caf/fwd.hpp>
 #include <caf/stream_serializer.hpp>
@@ -33,9 +32,7 @@ namespace vast {
 class segment_builder {
 public:
   /// Constructs a segment builder.
-  /// @param sys The actor system used to construct segments (and deserialize
-  ///            table slices).
-  segment_builder(caf::actor_system& sys);
+  segment_builder();
 
   /// Adds a table slice to the segment.
   /// @returns An error if adding the table slice failed.
@@ -64,7 +61,6 @@ private:
   // Resets the builder state to start with a new segment.
   void reset();
 
-  caf::actor_system& actor_system_;
   // Segment state
   std::vector<char> segment_buffer_;
   segment::meta_data meta_;

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -34,14 +34,11 @@ using segment_store_ptr = std::unique_ptr<segment_store>;
 class segment_store : public store {
 public:
   /// Constructs a segment store.
-  /// @param sys A reference to an actor system for table slice
-  ///            deserialization.
   /// @param dir The directory where to store state.
   /// @param max_segment_size The maximum segment size in bytes.
   /// @param in_memory_segments The number of semgents to cache in memory.
   /// @pre `max_segment_size > 0`
-  static segment_store_ptr make(caf::actor_system& sys,
-                                path dir, size_t max_segment_size,
+  static segment_store_ptr make(path dir, size_t max_segment_size,
                                 size_t in_memory_segments);
 
   ~segment_store();
@@ -59,8 +56,7 @@ public:
 
   /// @cond PRIVATE
 
-  segment_store(caf::actor_system& sys, path dir, uint64_t max_segment_size,
-                size_t in_memory_segments);
+  segment_store(path dir, uint64_t max_segment_size, size_t in_memory_segments);
 
   /// @endcond
 
@@ -75,7 +71,6 @@ private:
 
   caf::expected<segment_ptr> load_segment(uuid id) const;
 
-  caf::actor_system& sys_;
   path dir_;
   uint64_t max_segment_size_;
   detail::range_map<id, uuid> segments_;

--- a/libvast/vast/system/raft.hpp
+++ b/libvast/vast/system/raft.hpp
@@ -83,7 +83,7 @@ public:
   /// Constructs a log and attempts to read persistent state from the
   /// filesystem.
   /// @param dir The directory where the log stores persistent state.
-  log(caf::actor_system& sys, path dir);
+  log(path dir);
 
   /// Retrieves the first log entry.
   /// @pre `!empty()`
@@ -127,7 +127,6 @@ private:
   std::ofstream meta_file_;
   std::ofstream entries_file_;
   path dir_;
-  caf::actor_system& sys_;
 };
 
 /// A snapshot covering log entries indices in *[1, L]* where *L* is the last

--- a/libvast/vast/system/raft.hpp
+++ b/libvast/vast/system/raft.hpp
@@ -334,4 +334,3 @@ struct server_state {
 caf::behavior consensus(caf::stateful_actor<server_state>* self, path dir);
 
 } // namespace vast::system::raft
-


### PR DESCRIPTION
The lvalue reference to an actor system in `save` and `load` induces a very strong requirement: the presence of an `actor_system` object. This is not always available and not especially not always needed. We have numerous cases in VAST where the public API of a component contains a reference to an actor system, although this is not nessary.

This PR makes `save`/`load` more flexible by switching the first argument to a pointer instead. This makes the absence of an actor system clear in the code: the first argument is `nullptr`.