### PR TITLE
Support parsing of empty map

### DIFF
--- a/libvast/test/parse_data.cpp
+++ b/libvast/test/parse_data.cpp
@@ -113,6 +113,12 @@ TEST(data) {
   CHECK(d == set{-42, 42, -1});
 
   MESSAGE("map");
+  str = "{-}"s;
+  f = str.begin();
+  l = str.end();
+  CHECK(p(f, l, d));
+  CHECK(f == l);
+  CHECK(d == map{});
   str = "{T->1,F->0}"s;
   f = str.begin();
   l = str.end();

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -33,7 +33,7 @@ using namespace vast::parser_literals;
 
 // -- core --------------------------------------------------------------------
 
-TEST(choice) {
+TEST(choice - LHS and RHS) {
   using namespace parsers;
   auto p = chr{'x'} | i32;
   caf::variant<char, int32_t> x;
@@ -45,6 +45,17 @@ TEST(choice) {
   auto c = caf::get_if<char>(&x);
   REQUIRE(c);
   CHECK_EQUAL(*c, 'x');
+}
+
+TEST(choice - unused LHS) {
+  using namespace parsers;
+  auto p = 'x' | i32;
+  int32_t i;
+  CHECK(p("123", i));
+  CHECK_EQUAL(i, 123);
+  i = 0;
+  CHECK(p("x", i));
+  CHECK_EQUAL(i, 0); // didn't mess with i
 }
 
 TEST(choice triple) {

--- a/libvast/vast/concept/parseable/core/choice.hpp
+++ b/libvast/vast/concept/parseable/core/choice.hpp
@@ -73,41 +73,36 @@ public:
   template <class Iterator, class Attribute>
   bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     auto save = f;
-    if (parse_left(f, l, a))
+    if (do_parse(lhs_, f, l, a))
       return true;
     f = save;
-    if (parse_right(f, l, a))
+    if (do_parse(rhs_, f, l, a))
       return true;
     f = save;
     return false;
   }
 
 private:
-  template <class Iterator, class Attribute>
-  bool parse_left(Iterator& f, const Iterator& l, Attribute& a) const {
+  template <class Parser, class Iterator, class Attribute>
+  bool do_parse(const Parser& p, Iterator& f, const Iterator& l,
+                Attribute& a) const {
     using detail::is_any_v;
-    if constexpr (is_choice_parser_v<Lhs>) {
-      return lhs_(f, l, a); // recurse
-    } else if constexpr (is_any_v<unused_type, Attribute, lhs_attribute>) {
-      return lhs_(f, l, unused);
+    using parser_attribute = typename Parser::attribute;
+    if constexpr (is_choice_parser_v<Parser>) {
+      // If LHS/RHS is a choice parser, we can recurse because the passed-in
+      // attribute will also be valid for the sub parser.
+      return p(f, l, a);
+    } else if constexpr (is_any_v<unused_type, Attribute, parser_attribute>) {
+      // If LHS/RHS has an unused attribute or the passed-in attribute is
+      // unused, then we won't have to parse into a concrete object.
+      return p(f, l, unused);
     } else {
-      lhs_attribute al;
-      if (!lhs_(f, l, al))
+      // Parse one element of the variant and assign it to the passed-in
+      // attribute.
+      parser_attribute attr;
+      if (!p(f, l, attr))
         return false;
-      a = std::move(al);
-      return true;
-    }
-  }
-
-  template <class Iterator, class Attribute>
-  bool parse_right(Iterator& f, const Iterator& l, Attribute& a) const {
-    if constexpr (detail::is_any_v<unused_type, Attribute, rhs_attribute>) {
-      return rhs_(f, l, unused);
-    } else {
-      rhs_attribute ar;
-      if (!rhs_(f, l, ar))
-        return false;
-      a = std::move(ar);
+      a = std::move(attr);
       return true;
     }
   }
@@ -117,4 +112,3 @@ private:
 };
 
 } // namespace vast
-

--- a/libvast/vast/concept/parseable/vast/data.hpp
+++ b/libvast/vast/concept/parseable/vast/data.hpp
@@ -59,15 +59,8 @@ struct access::parser<data> : vast::parser<access::parser<data>> {
     return p;
   }
 
-  template <class Iterator>
-  bool parse(Iterator& f, const Iterator& l, unused_type) const {
-    static auto p = make<Iterator>();
-    return p(f, l, unused);
-  }
-
-  template <class Iterator>
-  bool parse(Iterator& f, const Iterator& l, data& a) const {
-    using namespace parsers;
+  template <class Iterator, class Attribute>
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     static auto p = make<Iterator>();
     return p(f, l, a);
   }
@@ -84,4 +77,3 @@ static auto const data = make_parser<vast::data>();
 
 } // namespace parsers
 } // namespace vast
-

--- a/libvast/vast/concept/parseable/vast/data.hpp
+++ b/libvast/vast/concept/parseable/vast/data.hpp
@@ -39,6 +39,7 @@ struct access::parser<data> : vast::parser<access::parser<data>> {
     rule<Iterator, data> p;
     auto ws = ignore(*parsers::space);
     auto x = ws >> p >> ws;
+    auto kvp = x >> "->" >> x;
     p = parsers::timespan
       | parsers::timestamp
       | parsers::net
@@ -51,8 +52,8 @@ struct access::parser<data> : vast::parser<access::parser<data>> {
       | parsers::qq_str
       | parsers::pattern
       | '[' >> ~(x % ',') >> ']'
+      | '{' >> ('-' | as<map>(kvp % ',')) >> '}'
       | '{' >> ~as<set>(x % ',') >> '}'
-      | '{' >> ~as<map>((x >> "->" >> x) % ',') >> '}'
       | as<caf::none_t>("nil"_p)
       ;
     return p;

--- a/libvast/vast/concept/printable/vast/data.hpp
+++ b/libvast/vast/concept/printable/vast/data.hpp
@@ -100,10 +100,12 @@ struct map_printer : printer<map_printer> {
   using attribute = map;
 
   template <class Iterator>
-  bool print(Iterator& out, const map& t) const {
-    auto pair = (data_printer{} << " -> " << data_printer{});
-    auto p = '{' << ~(pair % ", ") << '}';
-    return p.print(out, t);
+  bool print(Iterator& out, const map& xs) const {
+    if (xs.empty())
+      return printers::str.print(out, "{-}");
+    auto kvp = printers::data << " -> " << printers::data;
+    auto p = '{' << (kvp % ", ") << '}';
+    return p.print(out, xs);
   }
 };
 

--- a/libvast_test/src/table_slices.cpp
+++ b/libvast_test/src/table_slices.cpp
@@ -52,7 +52,7 @@ table_slices::table_slices() : sink{sys, buf} {
     "[T, +7, 42, 4.2, 1337ms, 2018-12-24, \"foo\", /foo.*bar/, 127.0.0.1,"
     " 10.0.0.0/8, 80/tcp, [1, 2, 3], {T, F}, {1 -> T, 2 -> F, 3 -> T}]",
     "[F, -7, 43, 0.42, -1337ms, 2018-12-25, \"bar\", nil, ::1, 64:ff9b::/96,"
-    " 53/udp, [42], {T}, nil]",
+    " 53/udp, [], {}, {-}]",
   };
   for (auto& row : rows) {
     auto xs = unbox(to<data>(row));


### PR DESCRIPTION
Until now it was impossible to parse an empty map with the data parser, because the string `{}` represented both an empty set and and empty map. Now we're using `{-}` to represent an empty map.