### PR TITLE
Use &time attribute to signal event time

### DIFF
--- a/libvast/src/default_table_slice_builder.cpp
+++ b/libvast/src/default_table_slice_builder.cpp
@@ -20,7 +20,7 @@
 namespace vast {
 
 default_table_slice_builder::default_table_slice_builder(record_type layout)
-  : super{flatten(layout)},
+  : super{std::move(layout)},
     row_(super::layout().fields.size()),
     col_{0} {
   VAST_ASSERT(!row_.empty());

--- a/libvast/src/format/bgpdump.cpp
+++ b/libvast/src/format/bgpdump.cpp
@@ -20,7 +20,7 @@ namespace bgpdump {
 bgpdump_parser::bgpdump_parser() {
   // Announce type.
   auto fields = std::vector<record_field>{
-    {"timestamp", timestamp_type{}},
+    {"timestamp", timestamp_type{}.attributes({{"time"}})},
     {"source_ip", address_type{}},
     {"source_as", count_type{}},
     {"prefix", subnet_type{}},
@@ -38,7 +38,7 @@ bgpdump_parser::bgpdump_parser() {
   // Route & withdraw type.
   route_type = record_type{std::move(fields)}.name("bgpdump::routing");
   auto withdraw_fields = std::vector<record_field>{
-    {"timestamp", timestamp_type{}},
+    {"timestamp", timestamp_type{}.attributes({{"time"}})},
     {"source_ip", address_type{}},
     {"source_as", count_type{}},
     {"prefix", subnet_type{}},
@@ -47,7 +47,7 @@ bgpdump_parser::bgpdump_parser() {
     record_type{std::move(withdraw_fields)}.name("bgpdump::withdrawn");
   // State-change type.
   auto state_change_fields = std::vector<record_field>{
-    {"timestamp", timestamp_type{}},
+    {"timestamp", timestamp_type{}.attributes({{"time"}})},
     {"source_ip", address_type{}},
     {"source_as", count_type{}},
     {"old_state", string_type{}},

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -139,9 +139,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
         [&](const attribute_extractor& lhs, const data& d) -> result_type {
           if (lhs.attr == system::time_atom::value) {
             auto pred = [](auto& field) {
-              // FIXME: we should really just look at the &timestamp attribute
-              // and not all fields of type time. [ch3843]
-              return caf::holds_alternative<timestamp_type>(field.type);
+              return has_attribute(field.type, "time");
             };
             return search(pred);
           } else if (lhs.attr == system::type_atom::value) {

--- a/libvast/src/to_events.cpp
+++ b/libvast/src/to_events.cpp
@@ -27,11 +27,10 @@ namespace vast {
 namespace {
 
 optional<size_t> find_time_column(record_type layout) {
-  auto result = caf::optional<size_t>{caf::none};
   for (size_t i = 0; i < layout.fields.size(); ++i)
     if (has_attribute(layout.fields[i].type, "time"))
       return i;
-  return result;
+  return caf::none;
 }
 
 event to_event(const table_slice& slice, id eid, type event_layout,

--- a/libvast/test/column_index.cpp
+++ b/libvast/test/column_index.cpp
@@ -90,7 +90,7 @@ TEST(bro conn log) {
   auto col_offset = unbox(row_type.resolve("id.orig_h"));
   auto col_type = row_type.at(col_offset);
   auto col_index = unbox(row_type.flat_index_at(col_offset));
-  REQUIRE_EQUAL(col_index, 3u);
+  REQUIRE_EQUAL(col_index, 2u); // 3rd column
   auto col = unbox(make_column_index(sys, directory, *col_type, col_index));
   for (auto slice : bro_conn_log_slices)
     col->add(slice);

--- a/libvast/test/format/bro.cpp
+++ b/libvast/test/format/bro.cpp
@@ -68,8 +68,8 @@ TEST(bro writer) {
   CHECK_EQUAL(bro_conn_log.front().type().name(), "bro::conn");
   auto record = caf::get_if<vector>(&bro_conn_log.front().data());
   REQUIRE(record);
-  REQUIRE_EQUAL(record->size(), 17u); // 20 columns, but 4 for the conn record
-  CHECK_EQUAL(record->at(3), data{"udp"}); // one after the conn record
+  REQUIRE_EQUAL(record->size(), 20u);
+  CHECK_EQUAL(record->at(6), data{"udp"}); // one after the conn record
   CHECK_EQUAL(record->back(), data{set{}}); // table[T] is actually a set
   // Perform the writing.
   auto dir = path{"vast-unit-test-bro"};

--- a/libvast/test/format/pcap.cpp
+++ b/libvast/test/format/pcap.cpp
@@ -11,18 +11,17 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include "vast/error.hpp"
-#include "vast/event.hpp"
-
-#include "vast/concept/parseable/to.hpp"
-#include "vast/concept/parseable/vast/address.hpp"
-#include "vast/filesystem.hpp"
-
-#include "vast/format/pcap.hpp"
-
 #define SUITE format
 #include "vast/test/test.hpp"
 #include "vast/test/data.hpp"
+
+#include "vast/format/pcap.hpp"
+
+#include "vast/concept/parseable/to.hpp"
+#include "vast/concept/parseable/vast/address.hpp"
+#include "vast/error.hpp"
+#include "vast/event.hpp"
+#include "vast/filesystem.hpp"
 
 using namespace vast;
 
@@ -44,9 +43,7 @@ TEST(PCAP read/write 1) {
   CHECK_EQUAL(events[0].type().name(), "pcap::packet");
   auto pkt = caf::get_if<vector>(&events.back().data());
   REQUIRE(pkt);
-  auto conn_id = caf::get_if<vector>(&pkt->at(0));
-  REQUIRE(conn_id); //[192.168.1.1, 192.168.1.71, 53/udp, 64480/udp]
-  auto src = caf::get_if<address>(&conn_id->at(0));
+  auto src = caf::get_if<address>(&pkt->at(1));
   REQUIRE(src);
   CHECK_EQUAL(*src, *to<address>("192.168.1.1"));
   MESSAGE("write out read packets");

--- a/libvast/test/format/writer.cpp
+++ b/libvast/test/format/writer.cpp
@@ -28,7 +28,7 @@ FIXTURE_SCOPE(ascii_tests, fixtures::events)
 
 namespace {
 
-auto last_bro_http_log_line = R"__(bro::http [2009-11-19+07:17:28.829] [2009-11-19+07:17:28.829, "rydI6puScNa", [192.168.1.104, 1224/?, 87.106.66.233, 80/?], 1, "POST", "87.106.66.233", "/rpc.html?e=bl", nil, "SCSDK-6.0.0", 1064, 96, 200, "OK", 100, "Continue", nil, {}, nil, nil, nil, "application/octet-stream", nil, nil])__";
+auto last_bro_http_log_line = R"__(bro::http [2009-11-19+07:17:28.829] [2009-11-19+07:17:28.829, "rydI6puScNa", 192.168.1.104, 1224/?, 87.106.66.233, 80/?, 1, "POST", "87.106.66.233", "/rpc.html?e=bl", nil, "SCSDK-6.0.0", 1064, 96, 200, "OK", 100, "Continue", nil, {}, nil, nil, nil, "application/octet-stream", nil, nil])__";
 
 auto first_csv_http_log_line = "type,id,timestamp,ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,trans_depth,method,host,uri,referrer,user_agent,request_body_len,response_body_len,status_code,status_msg,info_code,info_msg,filename,tags,username,password,proxied,mime_type,md5,extraction_file";
 
@@ -36,7 +36,7 @@ auto last_csv_http_log_line = R"__(bro::http,1095,1258615048829955072,2009-11-19
 
 auto first_ascii_bgpdump_txt_line = R"__(bgpdump::state_change [2018-01-24+11:05:17.0] [2018-01-24+11:05:17.0, 27.111.229.79, 17639, "1", "3"])__";
 
-auto first_json_bgpdump_txt_line = R"__({"id": 1096, "timestamp": 1516791917000000000, "value": {"type": {"name": "bgpdump::state_change", "kind": "record", "structure": {"timestamp": {"name": "", "kind": "timestamp", "structure": null, "attributes": {}}, "source_ip": {"name": "", "kind": "address", "structure": null, "attributes": {}}, "source_as": {"name": "", "kind": "count", "structure": null, "attributes": {}}, "old_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}, "new_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}}, "attributes": {}}, "data": {"timestamp": 1516791917000000000, "source_ip": "27.111.229.79", "source_as": 17639, "old_state": "1", "new_state": "3"}}})__";
+auto first_json_bgpdump_txt_line = R"__({"id": 1096, "timestamp": 1516791917000000000, "value": {"type": {"name": "bgpdump::state_change", "kind": "record", "structure": {"timestamp": {"name": "", "kind": "timestamp", "structure": null, "attributes": {"time": null}}, "source_ip": {"name": "", "kind": "address", "structure": null, "attributes": {}}, "source_as": {"name": "", "kind": "count", "structure": null, "attributes": {}}, "old_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}, "new_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}}, "attributes": {}}, "data": {"timestamp": 1516791917000000000, "source_ip": "27.111.229.79", "source_as": 17639, "old_state": "1", "new_state": "3"}}})__";
 
 template <class Writer>
 std::vector<std::string> generate(const std::vector<event>& xs) {

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -55,7 +55,7 @@ struct generator {
   explicit generator(std::string name, size_t first_event_id)
     : offset(first_event_id) {
     layout = record_type{
-      {"timestamp", timestamp_type{}},
+      {"timestamp", timestamp_type{}.attributes({{"time"}})},
       {"content", string_type{}}
     }.name(std::move(name));
   }

--- a/libvast/vast/format/bgpdump.hpp
+++ b/libvast/vast/format/bgpdump.hpp
@@ -44,8 +44,7 @@ struct bgpdump_parser : parser<bgpdump_parser> {
     std::string update;
     vast::address source_ip;
     count source_as;
-    auto tuple = std::tie(ts, update, source_ip, source_as);
-    if (!head(f, l, tuple))
+    if (!head(f, l, ts, update, source_ip, source_as))
       return false;
     vector v;
     v.emplace_back(ts);
@@ -95,8 +94,7 @@ struct bgpdump_parser : parser<bgpdump_parser> {
       static auto tail = -str >> '|' >> -str;
       optional<std::string> old_state;
       optional<std::string> new_state;
-      auto t = std::tie(old_state, new_state);
-      if (!tail(f, l, t))
+      if (!tail(f, l, old_state, new_state))
         return false;
       v.emplace_back(std::move(old_state));
       v.emplace_back(std::move(new_state));

--- a/libvast/vast/format/bro.hpp
+++ b/libvast/vast/format/bro.hpp
@@ -254,7 +254,7 @@ private:
   int timestamp_field_ = -1;
   vast::schema schema_;
   type type_;
-  record_type record_;
+  record_type layout_;
   std::vector<rule<iterator_type, data>> parsers_;
 };
 

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -796,12 +796,21 @@ data construct(const type& t);
 /// @relates type
 std::string to_digest(const type& x);
 
-/// Tests whether a type has a "skip" attribute.
+/// Checks whether a given type has an attribute.
+/// @param t The type to check.
+/// @param key The attribute key.
+/// @returns `true` if *t* has an attribute with key *key*.
 /// @relates type
+template <class Type>
+bool has_attribute(const Type& t, std::string_view key) {
+  auto pred = [&](auto& attr) { return attr.key == key; };
+  return std::any_of(t.attributes().begin(), t.attributes().end(), pred);
+}
+
+/// Tests whether a type has a "skip" attribute.
+/// @relates has_attribute type
 inline bool has_skip_attribute(const type& t) {
-  auto& attrs = t.attributes();
-  auto pred = [](auto& x) { return x.key == "skip"; };
-  return std::any_of(attrs.begin(), attrs.end(), pred);
+  return has_attribute(t, "skip");
 }
 
 /// @relates type
@@ -975,4 +984,3 @@ VAST_DEFINE_HASH_SPECIALIZATION(alias_type);
 #undef VAST_DEFINE_HASH_SPECIALIZATION
 
 } // namespace std
-


### PR DESCRIPTION
It is now possible to designate the event timestamp by adding the `&time` attribute to a timestamp type in a schema. The existing formats do this automatically. The meta index now looks for a `&time` attribute when it gets a predicate of the form `&time op RHS`.

While implementing the `&time` feature, it was the right time to rip out the additional timestamp column that was prepended to every table slice.

As I was working on the formats, I also flattened the layout, since this would have happened downstream anyway.

Ideally, these would have been all separate commits (and even PRs), but the order of how I approached this was sub-optimal. Sorry about that. I hope the review is still manageable.