### PR TITLE
Simplify synopsis factory logic

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -15,6 +15,7 @@ set(libvast_sources
   src/banner.cpp
   src/base.cpp
   src/bitmap.cpp
+  src/boolean_synopsis.cpp
   src/chunk.cpp
   src/column_index.cpp
   src/column_major_matrix_table_slice_builder.cpp

--- a/libvast/src/boolean_synopsis.cpp
+++ b/libvast/src/boolean_synopsis.cpp
@@ -1,0 +1,61 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/boolean_synopsis.hpp"
+
+#include <caf/deserializer.hpp>
+#include <caf/serializer.hpp>
+
+#include "vast/detail/assert.hpp"
+
+namespace vast {
+
+boolean_synopsis::boolean_synopsis(vast::type x) : synopsis{std::move(x)} {
+  VAST_ASSERT(caf::holds_alternative<boolean_type>(type()));
+}
+
+void boolean_synopsis::add(data_view x) {
+  if (auto b = caf::get_if<view<boolean>>(&x)) {
+    if (*b)
+      true_ = true;
+    else
+      false_ = true;
+  }
+}
+
+bool boolean_synopsis::lookup(relational_operator op, data_view rhs) const {
+  if (auto b = caf::get_if<view<boolean>>(&rhs)) {
+    if (op == equal)
+      return *b ? true_ : false_;
+    if (op == not_equal)
+      return *b ? false_ : true_;
+  }
+  return false;
+}
+
+bool boolean_synopsis::equals(const synopsis& other) const noexcept {
+  if (typeid(other) != typeid(boolean_synopsis))
+    return false;
+  auto& rhs = static_cast<const boolean_synopsis&>(other);
+  return type() == rhs.type() && false_ == rhs.false_ && true_ == rhs.true_;
+}
+
+caf::error boolean_synopsis::serialize(caf::serializer& sink) const {
+  return sink(false_, true_);
+}
+
+caf::error boolean_synopsis::deserialize(caf::deserializer& source) {
+  return source(false_, true_);
+}
+
+} // namespace vast

--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -19,6 +19,7 @@
 #include <caf/error.hpp>
 #include <caf/serializer.hpp>
 
+#include "vast/boolean_synopsis.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/timestamp_synopsis.hpp"
@@ -85,6 +86,7 @@ std::type_index make_factory_index(const type& t) {
 
 struct factory_initializer {
   factory_initializer() {
+    add_synopsis_factory<boolean_synopsis, boolean_type>();
     add_synopsis_factory<timestamp_synopsis, timestamp_type>();
   }
 };

--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -101,9 +101,9 @@ synopsis_ptr make_synopsis(type x, const synopsis_options& opts) {
   return nullptr;
 }
 
-void add_synopsis_factory(type x, synopsis_factory factory) {
+bool add_synopsis_factory(type x, synopsis_factory factory) {
   VAST_ASSERT(factory != nullptr);
-  factories_.insert_or_assign(make_factory_index(x), factory);
+  return factories_.emplace(make_factory_index(x), factory).second;
 }
 
 synopsis_factory get_synopsis_factory(const type& x) {

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -84,18 +84,6 @@ caf::error index_state::init(const path& dir, size_t max_partition_size,
                              size_t taste_partitions) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(max_partition_size),
              VAST_ARG(in_mem_partitions), VAST_ARG(taste_partitions));
-  // Set the synopsis factory for the meta index.
-  if (auto synopsis_factory = get_synopsis_factory(self->system())) {
-    auto [id, fun] = *synopsis_factory;
-    VAST_DEBUG(self, "uses custom meta index synopsis factory", id);
-    meta_idx.factory(id, fun);
-  } else if (synopsis_factory.error()) {
-    VAST_ERROR(self, "failed to retrieve synopsis factory",
-               self->system().render(synopsis_factory.error()));
-    return std::move(synopsis_factory.error());
-  } else {
-    VAST_DEBUG(self, "uses default meta index synopsis factory");
-  }
   put(meta_idx.factory_options(), "max-partition-size", max_partition_size);
   // Set members.
   this->dir = dir;

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -219,55 +219,7 @@ TEST(serialization) {
   CHECK_ROUNDTRIP(meta_idx);
 }
 
-// A synopsis for bools.
-class boolean_synopsis : public synopsis {
-public:
-  explicit boolean_synopsis(vast::type x) : synopsis{std::move(x)} {
-    VAST_ASSERT(caf::holds_alternative<boolean_type>(type()));
-  }
-
-  void add(data_view x) override {
-    if (auto b = caf::get_if<view<boolean>>(&x)) {
-      if (*b)
-        true_ = true;
-      else
-        false_ = true;
-    }
-  }
-
-  bool lookup(relational_operator op, data_view rhs) const override {
-    if (auto b = caf::get_if<view<boolean>>(&rhs)) {
-      if (op == equal)
-        return *b ? true_ : false_;
-      if (op == not_equal)
-        return *b ? false_ : true_;
-    }
-    return false;
-  }
-
-  bool equals(const synopsis& other) const noexcept override {
-    if (typeid(other) != typeid(boolean_synopsis))
-      return false;
-    auto& rhs = static_cast<const boolean_synopsis&>(other);
-    return type() == rhs.type() && false_ == rhs.false_ && true_ == rhs.true_;
-  }
-
-  caf::error serialize(caf::serializer& sink) const override {
-    return sink(false_, true_);
-  }
-
-  caf::error deserialize(caf::deserializer& source) override {
-    return source(false_, true_);
-  }
-
-private:
-  bool false_ = false;
-  bool true_ = false;
-};
-
-TEST(serialization with custom factory) {
-  MESSAGE("register custom synopsis factory");
-  add_synopsis_factory<boolean_synopsis, boolean_type>();
+TEST(meta index with boolean synopsis) {
   REQUIRE_NOT_EQUAL(get_synopsis_factory(boolean_type{}), nullptr);
   MESSAGE("generate slice data and add it to the meta index");
   meta_index meta_idx;

--- a/libvast/test/synopsis.cpp
+++ b/libvast/test/synopsis.cpp
@@ -34,7 +34,7 @@ const timestamp epoch;
 
 TEST(min-max synopsis) {
   auto x = make_synopsis(timestamp_type{});
-  REQUIRE(x);
+  REQUIRE_NOT_EQUAL(x, nullptr);
   x->add(timestamp{epoch + 4s});
   x->add(timestamp{epoch + 7s});
   MESSAGE("[4,7] op 0");

--- a/libvast/vast/boolean_synopsis.hpp
+++ b/libvast/vast/boolean_synopsis.hpp
@@ -1,0 +1,40 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/synopsis.hpp"
+
+namespace vast {
+
+// A synopsis for a [boolean type](@ref boolean_type).
+class boolean_synopsis : public synopsis {
+public:
+  explicit boolean_synopsis(vast::type x);
+
+  void add(data_view x) override;
+
+  bool lookup(relational_operator op, data_view rhs) const override;
+
+  bool equals(const synopsis& other) const noexcept override;
+
+  caf::error serialize(caf::serializer& sink) const override;
+
+  caf::error deserialize(caf::deserializer& source) override;
+
+private:
+  bool false_ = false;
+  bool true_ = false;
+};
+
+} // namespace vast

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 
-#include <caf/atom.hpp>
 #include <caf/fwd.hpp>
 
 #include "vast/fwd.hpp"
@@ -34,12 +33,6 @@ namespace vast {
 /// data. The meta index may return false positives but never false negatives.
 class meta_index {
 public:
-  // -- initialization ---------------------------------------------------------
-
-  meta_index();
-
-  // -- API --------------------------------------------------------------------
-
   /// Adds all data from a table slice belonging to a given partition to the
   /// index.
   /// @param slice The table slice to extract data from.
@@ -50,17 +43,6 @@ public:
   /// @param expr The expression to lookup.
   /// @returns A vector of UUIDs representing candidate partitions.
   std::vector<uuid> lookup(const expression& expr) const;
-
-  /// Replaces the synopsis factory.
-  /// @param factory_id The system-wide ID for `f`.
-  /// @param f The synopsis factory to use.
-  /// @pre `f` is registered in the runtime settings unter the key
-  ///      `factory_id`
-  void factory(caf::atom_value factory_id, synopsis_factory f);
-
-  /// Retrieves the current factory.
-  /// @returns A pair of factory ID and factory function.
-  std::pair<caf::atom_value, synopsis_factory> factory() const;
 
   /// Gets the options for the synopsis factory.
   /// @returns A reference to the synopsis options.
@@ -87,12 +69,6 @@ private:
 
   /// The factory function to construct a synopsis structure for a type.
   synopsis_options synopsis_options_;
-
-  /// The factory function to construct a synopsis structure for a type.
-  synopsis_factory make_synopsis_;
-
-  /// The implementation ID for objects created by `make_synopsis_`.
-  caf::atom_value factory_id_;
 };
 
 } // namespace vast

--- a/libvast/vast/synopsis.hpp
+++ b/libvast/vast/synopsis.hpp
@@ -109,15 +109,19 @@ using synopsis_factory = synopsis_ptr (*)(type, const synopsis_options&);
 /// Registers a synopsis factory.
 /// @param x The type to register a factory with.
 /// @param factory The factory function to associate with *x*.
+/// @returns `false` if a factory for type *x* exists already, and `true`
+///          otherwise
 /// @pre `factory != nullptr`
 /// @relates get_synopsis_factory make_synopsis
-void add_synopsis_factory(type x, synopsis_factory factory);
+bool add_synopsis_factory(type x, synopsis_factory factory);
 
 /// Registers a concrete synopsis type.
 /// @tparam Synopsis The synopsis type.
-/// @param x The type to register `Synopsis` with.
+/// @tparam Type A concrete VAST type.
+/// @returns `false` if a factory for `Type` exists already, and `true`
+///          otherwise
 template <class Synopsis, class Type>
-void add_synopsis_factory() {
+bool add_synopsis_factory() {
   static_assert(caf::detail::tl_contains<concrete_types, Type>::value,
                 "Type must be a concrete vast::type");
   static auto f = [](type x, const synopsis_options& opts) -> synopsis_ptr {
@@ -127,7 +131,7 @@ void add_synopsis_factory() {
     else
       return caf::make_counted<Synopsis>(std::move(x));
   };
-  add_synopsis_factory(type{Type{}}, f);
+  return add_synopsis_factory(type{Type{}}, f);
 }
 
 /// Retrieves a synopsis factory.


### PR DESCRIPTION
We got rid of the actor system logic, analogously to the table slice
factory.