### PR TITLE
Respect skip attribute when creating synopses

### DIFF
--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -39,9 +39,10 @@ void meta_index::add(const uuid& partition, const table_slice& slice) {
     i = part_synopsis.emplace(layout, table_synopsis{}).first;
     table_syn = &i->second;
     for (auto& field : layout.fields)
-      if (i->second.emplace_back(make_synopsis(field.type, synopsis_options_))
-          != nullptr)
-        VAST_DEBUG(this, "created new synopsis structure for type", field.type);
+      if (!has_skip_attribute(field.type))
+        if (i->second.emplace_back(make_synopsis(field.type, synopsis_options_))
+            != nullptr)
+          VAST_DEBUG(this, "created new synopsis structure for type", field.type);
     // If we couldn't create a single synopsis for the layout, we will no
     // longer attempt to create synopses in the future.
     auto is_nullptr = [](auto& x) { return x == nullptr; };


### PR DESCRIPTION
If a field has a skip attribute, it will not be considered in the index.
Then it shouldn't be considered in the meta index either.