### PR TITLE
Allow passing queries via STDIN or file

### DIFF
--- a/libvast/src/system/default_application.cpp
+++ b/libvast/src/system/default_application.cpp
@@ -74,6 +74,7 @@ default_application::default_application() {
   // Add "export" command and its children.
   export_ = add(nullptr, "export", "exports query results to STDOUT or file",
                 opts()
+                  .add<std::string>("read,r", "path for reading the query")
                   .add<bool>("node,n",
                              "spawn a node instead of connecting to one")
                   .add<bool>("continuous,c", "marks a query as continuous")


### PR DESCRIPTION
With this patch, we have several options to pass queries:

1) single CLI argument: `vast export ascii ':addr == 192.168.1.103'`
2) multiple CLI arguments: `vast export ascii :addr == 192.168.1.103`
3) Via STDIN: `echo ':addr == 192.168.1.103' | vast export -e 5 ascii`
4) Via file: `echo ':addr == 192.168.1.103' > query.txt ; vast export -r query.txt ascii`
