### PR TITLE
Fix -b flag of the import command

### DIFF
--- a/libvast/src/detail/fill_status_map.cpp
+++ b/libvast/src/detail/fill_status_map.cpp
@@ -36,7 +36,7 @@ void fill_status_map(caf::settings& xs, caf::stream_manager& mgr) {
   put(downstream, "max-capacity", out.max_capacity());
   put(downstream, "paths", out.num_paths());
   put(downstream, "stalled", out.stalled());
-  put(downstream, "clean", out.stalled());
+  put(downstream, "clean", out.clean());
   out.for_each_path([&](auto& opath) {
     auto name = "slot-" + std::to_string(opath.slots.sender);
     auto& slot = put_dictionary(downstream, name);

--- a/libvast/src/detail/fill_status_map.cpp
+++ b/libvast/src/detail/fill_status_map.cpp
@@ -51,6 +51,8 @@ void fill_status_map(caf::settings& xs, caf::stream_manager& mgr) {
   // Upstream status.
   auto& upstream = put_dictionary(xs, "upstream");
   auto& ipaths = mgr.inbound_paths();
+  if (!ipaths.empty())
+    put(xs, "inbound-paths-idle", mgr.inbound_paths_idle());
   for (auto ipath : ipaths) {
     auto name = "slot-" + std::to_string(ipath->slots.receiver);
     auto& slot = put_dictionary(upstream, name);

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -136,7 +136,8 @@ void importer_state::send_report() {
 };
 
 void importer_state::notify_flush_listeners() {
-  VAST_DEBUG(self, "forward flush subscribers to INDEX actors");
+  VAST_DEBUG(self, "forwards 'flush' subscribers to", index_actors.size(),
+             "INDEX actors");
   for (auto& listener : flush_listeners)
     for (auto& next : index_actors)
       self->send(next, subscribe_atom::value, flush_atom::value, listener);
@@ -314,8 +315,8 @@ behavior importer(stateful_actor<importer_state>* self, path dir,
       //       Adding multiple INDEX actors will cause the subscriber to
       //       receive more than one 'flush'  message, but the subscriber only
       //       expects one and will stop waiting after the first one. Once we
-      //       support multiple INDEXER actors at the IMPORTER, we also need
-      //       to revise the signaling of these 'flush' messages.
+      //       support multiple INDEX actors at the IMPORTER, we also need to
+      //       revise the signaling of these 'flush' messages.
       if (self->state.index_actors.size() > 1)
         VAST_WARNING(self, "registered more than one INDEX actor",
                      "(currently unsupported!)");

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -343,6 +343,9 @@ void index_state::notify_flush_listeners() {
 behavior index(stateful_actor<index_state>* self, const path& dir,
                size_t max_partition_size, size_t in_mem_partitions,
                size_t taste_partitions, size_t num_workers) {
+  VAST_TRACE(VAST_ARG(dir), VAST_ARG(max_partition_size),
+             VAST_ARG(in_mem_partitions), VAST_ARG(taste_partitions),
+             VAST_ARG(num_workers));
   VAST_ASSERT(max_partition_size > 0);
   VAST_ASSERT(in_mem_partitions > 0);
   VAST_INFO(self, "spawned:", VAST_ARG(max_partition_size),

--- a/libvast/src/system/indexer_stage_driver.cpp
+++ b/libvast/src/system/indexer_stage_driver.cpp
@@ -32,9 +32,9 @@ bool indexer_stage_selector::operator()(const indexer_stage_filter& f,
 }
 
 indexer_stage_driver::indexer_stage_driver(downstream_manager_type& dm,
-                                           index_state* state)
-  : super(dm), state_(state) {
-  VAST_ASSERT(state != nullptr);
+                                           self_pointer self)
+  : super(dm), self_(self) {
+  VAST_ASSERT(self_ != nullptr);
 }
 
 indexer_stage_driver::~indexer_stage_driver() noexcept {
@@ -44,19 +44,20 @@ indexer_stage_driver::~indexer_stage_driver() noexcept {
 void indexer_stage_driver::process(downstream_type& out, batch_type& slices) {
   VAST_TRACE(CAF_ARG(slices));
   VAST_ASSERT(!slices.empty());
+  auto& st = self_->state;
   for (auto& slice : slices) {
     // Spin up an initial partition if needed.
-    if (state_->active == nullptr)
-      state_->reset_active_partition();
+    if (st.active == nullptr)
+      st.reset_active_partition();
     // Update meta index.
-    state_->meta_idx.add(state_->active->id(), *slice);
+    st.meta_idx.add(st.active->id(), *slice);
     // Start new INDEXER actors when needed and add it to the stream.
     auto& layout = slice->layout();
-    auto [meta_x, added] = state_->active->get_or_add(layout);
+    auto [meta_x, added] = st.active->get_or_add(layout);
     if (added) {
-      VAST_DEBUG(state_->self, "added a new table_indexer for layout", layout);
+      VAST_DEBUG(st.self, "added a new table_indexer for layout", layout);
       if (auto err = meta_x.init()) {
-        VAST_ERROR(state_->self,
+        VAST_ERROR(st.self,
                    "failed to initialize table_indexer for layout", layout,
                    "-> all incoming logs get dropped!");
       } else {
@@ -65,9 +66,9 @@ void indexer_stage_driver::process(downstream_type& out, batch_type& slices) {
           // We'll have invalid handles at all fields with skip attribute.
           if (x) {
             auto slt = out_.parent()->add_unchecked_outbound_path<output_type>(x);
-            VAST_DEBUG(state_->self, "spawned new INDEXER at slot", slt);
+            VAST_DEBUG(st.self, "spawned new INDEXER at slot", slt);
             out_.set_filter(slt, layout);
-            state_->active_partition_indexers++;
+            st.active_partition_indexers++;
           }
         }
       }
@@ -78,18 +79,18 @@ void indexer_stage_driver::process(downstream_type& out, batch_type& slices) {
     auto slice_size = slice->rows();
     out.push(std::move(slice));
     // Reset the manager and all outbound paths when finalizing a partition.
-    if (state_->active->capacity() <= slice_size) {
-      VAST_DEBUG(state_->self, "closes slots on full partition",
+    if (st.active->capacity() <= slice_size) {
+      VAST_DEBUG(st.self, "closes slots on full partition",
                  out_.open_path_slots());
       VAST_ASSERT(out_.buf().size() != 0);
       out_.fan_out_flush();
       VAST_ASSERT(out_.buf().size() == 0);
       out_.force_emit_batches();
       out_.close();
-      state_->reset_active_partition();
-      VAST_ASSERT(state_->active->layouts().empty());
+      st.reset_active_partition();
+      VAST_ASSERT(st.active->layouts().empty());
     } else {
-      state_->active->reduce_capacity(slice_size);
+      st.active->reduce_capacity(slice_size);
     }
   }
 }

--- a/libvast/test/system/indexer_stage_driver.cpp
+++ b/libvast/test/system/indexer_stage_driver.cpp
@@ -24,6 +24,7 @@
 
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/detail/spawn_container_source.hpp"
+#include "vast/logger.hpp"
 #include "vast/meta_index.hpp"
 #include "vast/system/index.hpp"
 #include "vast/system/partition.hpp"
@@ -39,42 +40,41 @@ using std::make_shared;
 
 namespace {
 
+template <class Container>
+auto sorted(Container xs) {
+  std::sort(xs.begin(), xs.end());
+  return xs;
+}
+
 thread_local std::vector<caf::actor> all_sinks;
 
-struct sink_state {
-  std::vector<event> buf;
-};
+thread_local std::set<table_slice_ptr> all_slices;
 
-behavior dummy_sink(stateful_actor<sink_state>* self) {
+behavior dummy_sink(event_based_actor* self) {
   return {[=](stream<table_slice_ptr> in) {
     self->make_sink(in,
                     [=](unit_t&) {
                       // nop
                     },
                     [=](unit_t&, table_slice_ptr slice) {
-                      for (auto& x : to_events(*slice))
-                        self->state.buf.emplace_back(std::move(x));
+                      all_slices.emplace(std::move(slice));
                     });
     self->unbecome();
   }};
 }
 
-caf::actor spawn_sink(caf::local_actor* self, path, type, size_t, caf::actor,
-                      uuid, atomic_measurement*) {
+caf::actor spawn_sink(caf::local_actor* self, path dir, type t, size_t,
+                      caf::actor, uuid partition_id, atomic_measurement*) {
+  VAST_TRACE(VAST_ARG(dir), VAST_ARG("t", t.name()), VAST_ARG(partition_id));
   auto result = self->spawn(dummy_sink);
   all_sinks.emplace_back(result);
   return result;
 }
 
 behavior dummy_index(stateful_actor<index_state>* self, path dir) {
+  VAST_TRACE(VAST_ARG(dir));
   self->state.init(dir, std::numeric_limits<size_t>::max(), 10, 5);
   self->state.factory = spawn_sink;
-  return {[] {
-    // nop
-  }};
-}
-
-behavior test_stage(stateful_actor<index_state>* self) {
   return {[=](stream<table_slice_ptr> in) {
     auto mgr = self->make_continuous_stage<indexer_stage_driver>(self);
     mgr->add_inbound_path(in);
@@ -86,8 +86,11 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   fixture() : expected_sink_count(0) {
     // Only needed for computing how many layouts are in our data set.
     std::set<record_type> layouts;
-    // Makes sure no persistet state exists.
+    // Make sure no persistet state exists.
     rm(state_dir);
+    // Make sure we have a clean slate.
+    all_sinks.clear();
+    all_slices.clear();
     // Pick slices from various data sets.
     auto pick_from = [&](const auto& slices) {
       VAST_ASSERT(slices.size() > 0);
@@ -140,25 +143,12 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
 FIXTURE_SCOPE(indexer_stage_driver_tests, fixture)
 
 TEST(spawning sinks automatically) {
-  MESSAGE("spawn the stage");
-  auto stg = sys.spawn(test_stage);
   MESSAGE("spawn the source and run");
-  auto src = vast::detail::spawn_container_source(self->system(),
-                                                  test_slices,
-                                                  stg);
+  auto src = vast::detail::spawn_container_source(self->system(), test_slices,
+                                                  index);
   run();
   CHECK_EQUAL(all_sinks.size(), expected_sink_count);
-  /*
-  MESSAGE("check content of the shared buffer");
-  std::vector<event> rows;
-  for (auto& slice : test_slices)
-    for (auto& x : to_events(*slice))
-      rows.emplace_back(std::move(x));
-  auto& buf = state.buf;
-  std::sort(buf.begin(), buf.end());
-  CHECK_EQUAL(rows, buf);
-  anon_send_exit(stg, exit_reason::user_shutdown);
-  */
+  CHECK_EQUAL(sorted(test_slices), all_slices);
 }
 
 /*

--- a/libvast/test/system/indexer_stage_driver.cpp
+++ b/libvast/test/system/indexer_stage_driver.cpp
@@ -74,9 +74,9 @@ behavior dummy_index(stateful_actor<index_state>* self, path dir) {
   }};
 }
 
-behavior test_stage(event_based_actor* self, index_state* state) {
+behavior test_stage(stateful_actor<index_state>* self) {
   return {[=](stream<table_slice_ptr> in) {
-    auto mgr = self->make_continuous_stage<indexer_stage_driver>(state);
+    auto mgr = self->make_continuous_stage<indexer_stage_driver>(self);
     mgr->add_inbound_path(in);
     self->unbecome();
   }};
@@ -141,7 +141,7 @@ FIXTURE_SCOPE(indexer_stage_driver_tests, fixture)
 
 TEST(spawning sinks automatically) {
   MESSAGE("spawn the stage");
-  auto stg = sys.spawn(test_stage, state());
+  auto stg = sys.spawn(test_stage);
   MESSAGE("spawn the source and run");
   auto src = vast::detail::spawn_container_source(self->system(),
                                                   test_slices,

--- a/libvast/vast/detail/notifying_stream_manager.hpp
+++ b/libvast/vast/detail/notifying_stream_manager.hpp
@@ -1,0 +1,66 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <caf/detail/stream_stage_impl.hpp>
+
+namespace vast::detail {
+
+template <class Driver>
+class notifying_stream_manager : public caf::detail::stream_stage_impl<Driver> {
+public:
+  using super = caf::detail::stream_stage_impl<Driver>;
+
+  template <class Self>
+  notifying_stream_manager(Self* self)
+    : caf::stream_manager(self),
+      super(self, self) {
+    // nop
+  }
+
+  using super::handle;
+
+  void handle(caf::stream_slots slots,
+              caf::upstream_msg::ack_batch& x) override {
+    super::handle(slots, x);
+    notify_listeners_if_clean();
+  }
+
+  void input_closed(error reason) override {
+    super::input_closed(std::move(reason));
+    notify_listeners_if_clean();
+  }
+
+  void finalize(const error& reason) override {
+    super::finalize(reason);
+    notify_listeners();
+  }
+
+private:
+  void notify_listeners() {
+    auto self = this->driver_.self();
+    auto& st = self->state;
+    st.notify_flush_listeners();
+  }
+
+  void notify_listeners_if_clean() {
+    auto& st = this->driver_.self()->state;
+    if (!st.flush_listeners.empty() && this->inbound_paths().empty()
+        && this->out().clean()) {
+      notify_listeners();
+    }
+  }
+};
+
+} // namespace vast::detail

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -104,7 +104,7 @@ struct importer_state {
   /// @returns various status metrics.
   caf::dictionary<caf::config_value> status() const;
 
-  /// Sends a notification to all listeners and clears the listeners vector.
+  /// Forwards listeners to all INDEX actors and clears the listeners vector.
   void notify_flush_listeners();
 
   /// Stores how many slices inbound paths can still send us.
@@ -138,6 +138,9 @@ struct importer_state {
 
   measurement measurement_;
   stopwatch::time_point last_report;
+
+  /// Stores all actor handles of connected INDEX actors.
+  std::vector<caf::actor> index_actors;
 
   accountant_type accountant;
 

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -104,6 +104,9 @@ struct importer_state {
   /// @returns various status metrics.
   caf::dictionary<caf::config_value> status() const;
 
+  /// Sends a notification to all listeners and clears the listeners vector.
+  void notify_flush_listeners();
+
   /// Stores how many slices inbound paths can still send us.
   int32_t in_flight_slices = 0;
 

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -83,7 +83,7 @@ struct index_state {
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  index_state(caf::event_based_actor* self);
+  index_state(caf::stateful_actor<index_state>* self);
 
   ~index_state();
 
@@ -143,10 +143,16 @@ struct index_state {
 
   void send_report();
 
+  /// Adds a new flush listener.
+  void add_flush_listener(caf::actor listener);
+
+  /// Sends a notification to all listeners and clears the listeners list.
+  void notify_flush_listeners();
+
   // -- member variables -------------------------------------------------------
 
   /// Pointer to the parent actor.
-  caf::event_based_actor* self;
+  caf::stateful_actor<index_state>* self;
 
   /// Allows to select partitions with timestamps.
   meta_index meta_idx;
@@ -192,6 +198,9 @@ struct index_state {
   std::vector<std::pair<partition_ptr, size_t>> unpersisted;
 
   accountant_type accountant;
+
+  /// List of actors that wait for the next flush event.
+  std::vector<caf::actor> flush_listeners;
 
   /// Name of the INDEX actor.
   static inline const char* name = "index";

--- a/libvast/vast/system/indexer_stage_driver.hpp
+++ b/libvast/vast/system/indexer_stage_driver.hpp
@@ -56,10 +56,12 @@ public:
 
   using downstream_type = caf::downstream<output_type>;
 
+  using self_pointer = caf::stateful_actor<index_state>*;
+
   // -- constructors, destructors, and assignment operators --------------------
 
   /// @pre `state != nullptr`
-  indexer_stage_driver(downstream_manager_type& dm, index_state* state);
+  indexer_stage_driver(downstream_manager_type& dm, self_pointer self);
 
   ~indexer_stage_driver() noexcept override;
 
@@ -67,11 +69,17 @@ public:
 
   void process(downstream_type& out, batch_type& slices) override;
 
+  // -- properties -------------------------------------------------------------
+
+  self_pointer self() {
+    return self_;
+  }
+
 private:
   // -- member variables -------------------------------------------------------
 
   /// State of the INDEX actor that owns this stage.
-  index_state* state_;
+  self_pointer self_;
 };
 
 } // namespace vast::system


### PR DESCRIPTION
We previously broke the current implementation of the `-b` when making the INDEXERs parallel again. This patch fixes the "done" signaling by pushing it from the IMPORTER to the INDEX when the former is done (which in turn means that the ARCHIVE is already done).