### PR TITLE
Streamline JSON output

### DIFF
--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -356,6 +356,7 @@ namespace {
 json jsonize(const data& x) {
   return caf::visit(detail::overload(
     [&](const auto& y) { return to_json(y); },
+    [&](port p) { return json{p.number()}; }, // ignore port type
     [&](caf::none_t) { return json{}; },
     [&](const std::string& str) { return json{str}; }
   ), x);

--- a/libvast/src/value.cpp
+++ b/libvast/src/value.cpp
@@ -62,12 +62,7 @@ bool operator>(const value& lhs, const value& rhs) {
 }
 
 bool convert(const value& v, json& j) {
-  json::object o;
-  if (!convert(v.type(), o["type"]))
-    return false;
-  if (!convert(v.data(), o["data"], v.type()))
-    return false;
-  j = std::move(o);
-  return true;
+  return convert(v.data(), j, v.type());
 }
+
 } // namespace vast

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -290,7 +290,7 @@ TEST(json) {
     "foo",
     json::make_array(-42, json::make_array(1001)),
     "x",
-    "443/tcp"
+    443
   )};
   CHECK_EQUAL(to_json(x), expected);
   MESSAGE("zipped");
@@ -315,7 +315,7 @@ TEST(json) {
     }
   },
   "str": "x",
-  "port": "443/tcp"
+  "port": 443
 })__";
   CHECK_EQUAL(to_string(to_json(x, t)), expected);
 }

--- a/libvast/test/event.cpp
+++ b/libvast/test/event.cpp
@@ -86,42 +86,15 @@ TEST(serialization) {
 }
 
 TEST(json) {
-  auto expected = R"json({
+  auto expected = R"__({
   "id": 123456789,
   "timestamp": 0,
   "value": {
-    "type": {
-      "name": "foo",
-      "kind": "record",
-      "structure": {
-        "x": {
-          "name": "",
-          "kind": "bool",
-          "structure": null,
-          "attributes": {}
-        },
-        "y": {
-          "name": "",
-          "kind": "count",
-          "structure": null,
-          "attributes": {}
-        },
-        "z": {
-          "name": "",
-          "kind": "int",
-          "structure": null,
-          "attributes": {}
-        }
-      },
-      "attributes": {}
-    },
-    "data": {
-      "x": true,
-      "y": 42,
-      "z": -234987
-    }
+    "x": true,
+    "y": 42,
+    "z": -234987
   }
-})json";
+})__";
   CHECK_EQUAL(to_string(to_json(e)), expected);
 }
 

--- a/libvast/test/format/writer.cpp
+++ b/libvast/test/format/writer.cpp
@@ -36,7 +36,9 @@ auto last_csv_http_log_line = R"__(bro::http,1095,1258615048829955072,2009-11-19
 
 auto first_ascii_bgpdump_txt_line = R"__(bgpdump::state_change [2018-01-24+11:05:17.0] [2018-01-24+11:05:17.0, 27.111.229.79, 17639, "1", "3"])__";
 
-auto first_json_bgpdump_txt_line = R"__({"id": 1096, "timestamp": 1516791917000000000, "value": {"type": {"name": "bgpdump::state_change", "kind": "record", "structure": {"timestamp": {"name": "", "kind": "timestamp", "structure": null, "attributes": {"time": null}}, "source_ip": {"name": "", "kind": "address", "structure": null, "attributes": {}}, "source_as": {"name": "", "kind": "count", "structure": null, "attributes": {}}, "old_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}, "new_state": {"name": "", "kind": "string", "structure": null, "attributes": {}}}, "attributes": {}}, "data": {"timestamp": 1516791917000000000, "source_ip": "27.111.229.79", "source_as": 17639, "old_state": "1", "new_state": "3"}}})__";
+auto first_json_bgpdump_txt_line = R"__({"timestamp": 1516791917000000000, "source_ip": "27.111.229.79", "source_as": 17639, "old_state": "1", "new_state": "3"})__";
+
+auto first_bro_conn_log_line = R"__({"ts": 1258531221486539008, "uid": "Pii6cUUq1v4", "id.orig_h": "192.168.1.102", "id.orig_p": 68, "id.resp_h": "192.168.1.1", "id.resp_p": 67, "proto": "udp", "service": null, "duration": 163820000, "orig_bytes": 301, "resp_bytes": 300, "conn_state": "SF", "local_orig": null, "missed_bytes": 0, "history": "Dd", "orig_pkts": 1, "orig_ip_bytes": 329, "resp_pkts": 1, "resp_ip_bytes": 328, "tunnel_parents": []})__";
 
 template <class Writer>
 std::vector<std::string> generate(const std::vector<event>& xs) {
@@ -76,6 +78,8 @@ TEST(CSV writer) {
 TEST(JSON writer) {
   auto lines = generate<format::json::writer>(bgpdump_txt);
   CHECK_EQUAL(lines.front(), first_json_bgpdump_txt_line);
+  lines = generate<format::json::writer>(bro_conn_log);
+  CHECK_EQUAL(lines.front(), first_bro_conn_log_line);
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/value.cpp
+++ b/libvast/test/value.cpp
@@ -146,36 +146,9 @@ TEST(json)
   auto j = to<json>(v);
   REQUIRE(j);
   auto str = R"__({
-  "type": {
-    "name": "",
-    "kind": "record",
-    "structure": {
-      "foo": {
-        "name": "",
-        "kind": "port",
-        "structure": null,
-        "attributes": {}
-      },
-      "bar": {
-        "name": "",
-        "kind": "int",
-        "structure": null,
-        "attributes": {}
-      },
-      "baz": {
-        "name": "",
-        "kind": "real",
-        "structure": null,
-        "attributes": {}
-      }
-    },
-    "attributes": {}
-  },
-  "data": {
-    "foo": "53/udp",
-    "bar": -42,
-    "baz": 4.2
-  }
+  "foo": 53,
+  "bar": -42,
+  "baz": 4.2
 })__";
   CHECK_EQUAL(to_string(*j), str);
 }

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -13,10 +13,10 @@
 
 #pragma once
 
-#include "vast/json.hpp"
 #include "vast/concept/printable/vast/json.hpp"
-
+#include "vast/data.hpp"
 #include "vast/format/printer_writer.hpp"
+#include "vast/json.hpp"
 
 namespace vast::format::json {
 
@@ -26,7 +26,9 @@ struct event_printer : printer<event_printer> {
   template <class Iterator>
   bool print(Iterator& out, const event& e) const {
     vast::json j;
-    return convert(e, j) && printers::json<policy::oneline>.print(out, j);
+    if (!convert(e.data(), j, e.type()))
+      return false;
+    return printers::json<policy::oneline>.print(out, j);
   }
 };
 
@@ -40,6 +42,3 @@ public:
 };
 
 } // namespace vast::format::json
-
-
-


### PR DESCRIPTION
We had a rather unwieldy form of printing data in JSON in the past whereboth type and data had been printed separately. We now switch to"zipped" output that takes the layout field names as JSON object keysand data as their corresponding values.

Moreover, I took the liberty to tweak the JSON output of ports: instead of printing `"53/udp"` we now simply display the number `53`. Since Zeek also dumps its port in this (lossy) form, downstream data analysis tools will likely expect such a format.