### PR TITLE
Use fractional timestamps in JSON output

### DIFF
--- a/libvast/src/time.cpp
+++ b/libvast/src/time.cpp
@@ -24,7 +24,10 @@ bool convert(timespan dur, double& d) {
 }
 
 bool convert(timespan dur, json& j) {
-  j = dur.count();
+  double time_since_epoch;
+  if (!convert(dur, time_since_epoch))
+    return false;
+  j = json::number{time_since_epoch};
   return true;
 }
 

--- a/libvast/test/format/writer.cpp
+++ b/libvast/test/format/writer.cpp
@@ -36,9 +36,9 @@ auto last_csv_http_log_line = R"__(zeek::http,1095,1258615048829955072,2009-11-1
 
 auto first_ascii_bgpdump_txt_line = R"__(<2018-01-24+11:05:17.0, 27.111.229.79, 17639, "1", "3">)__";
 
-auto first_json_bgpdump_txt_line = R"__({"timestamp": 1516791917000000000, "source_ip": "27.111.229.79", "source_as": 17639, "old_state": "1", "new_state": "3"})__";
+auto first_json_bgpdump_txt_line = R"__({"timestamp": 1516791917, "source_ip": "27.111.229.79", "source_as": 17639, "old_state": "1", "new_state": "3"})__";
 
-auto first_zeek_conn_log_line = R"__({"ts": 1258531221486539008, "uid": "Pii6cUUq1v4", "id.orig_h": "192.168.1.102", "id.orig_p": 68, "id.resp_h": "192.168.1.1", "id.resp_p": 67, "proto": "udp", "service": null, "duration": 163820000, "orig_bytes": 301, "resp_bytes": 300, "conn_state": "SF", "local_orig": null, "missed_bytes": 0, "history": "Dd", "orig_pkts": 1, "orig_ip_bytes": 329, "resp_pkts": 1, "resp_ip_bytes": 328, "tunnel_parents": []})__";
+auto first_zeek_conn_log_line = R"__({"ts": 1258531221.486539, "uid": "Pii6cUUq1v4", "id.orig_h": "192.168.1.102", "id.orig_p": 68, "id.resp_h": "192.168.1.1", "id.resp_p": 67, "proto": "udp", "service": null, "duration": 0.16382, "orig_bytes": 301, "resp_bytes": 300, "conn_state": "SF", "local_orig": null, "missed_bytes": 0, "history": "Dd", "orig_pkts": 1, "orig_ip_bytes": 329, "resp_pkts": 1, "resp_ip_bytes": 328, "tunnel_parents": []})__";
 
 template <class Writer>
 std::vector<std::string> generate(const std::vector<event>& xs) {

--- a/libvast/test/json.cpp
+++ b/libvast/test/json.cpp
@@ -11,15 +11,20 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
+#define SUITE json
+
+#include "vast/test/test.hpp"
+
 #include "vast/json.hpp"
+
+#include <chrono>
+
 #include "vast/concept/parseable/vast/json.hpp"
 #include "vast/concept/printable/numeric.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/json.hpp"
 #include "vast/concept/convertible/to.hpp"
-
-#define SUITE json
-#include "vast/test/test.hpp"
+#include "vast/time.hpp"
 
 using namespace vast;
 using namespace std::string_literals;
@@ -194,24 +199,19 @@ TEST(printable) {
 }
 
 TEST(conversion) {
-  MESSAGE("bool");
-  auto t = to<json>(true);
-  REQUIRE(t);
-  CHECK(*t == json{true});
-  MESSAGE("number");
-  t = to<json>(4.2);
-  REQUIRE(t);
-  CHECK(*t == json{4.2});
-  MESSAGE("strings");
-  t = to<json>("foo");
-  REQUIRE(t);
-  CHECK(*t == json{"foo"});
+  using namespace std::chrono;
+  auto since_epoch = timespan{1258532203657267968ll};
+  auto ts = timestamp{since_epoch};
+  auto fractional_ts = duration_cast<double_seconds>(since_epoch).count();
+  CHECK_EQUAL(to_json(true), json{true});
+  CHECK_EQUAL(to_json(4.2), json{4.2});
+  CHECK_EQUAL(to_json(since_epoch), json{fractional_ts});
+  CHECK_EQUAL(to_json(ts), json{fractional_ts});
+  CHECK_EQUAL(to_json("foo"), json{"foo"});
   MESSAGE("std::vector");
-  t = to<json>(std::vector<int>{1, 2, 3});
-  REQUIRE(t);
-  CHECK(*t == json::make_array(1, 2, 3));
+  auto xs = to_json(std::vector<int>{1, 2, 3});
+  CHECK_EQUAL(xs, json::make_array(1, 2, 3));
   MESSAGE("std::map");
-  t = to<json>(std::map<unsigned, bool>{{1, true}, {2, false}});
-  REQUIRE(t);
-  CHECK(*t == json::object{{"1", json{true}}, {"2", json{false}}});
+  auto ys = to_json(std::map<unsigned, bool>{{1, true}, {2, false}});
+  CHECK_EQUAL(ys, (json::object{{"1", json{true}}, {"2", json{false}}}));
 }

--- a/libvast/vast/json.hpp
+++ b/libvast/vast/json.hpp
@@ -27,7 +27,6 @@
 #include "vast/detail/operators.hpp"
 #include "vast/detail/steady_map.hpp"
 #include "vast/detail/type_traits.hpp"
-#include "vast/time.hpp"
 
 namespace vast {
 
@@ -164,14 +163,13 @@ inline bool convert(bool b, json& j) {
 
 /// @relates json
 template <class T>
-bool convert(const T& x, json& j) {
-  if constexpr (std::is_arithmetic_v<T>) {
+bool convert(T x, json& j) {
+  if constexpr (std::is_arithmetic_v<T>)
     j = detail::narrow_cast<json::number>(x);
-  } else if constexpr (std::is_convertible_v<T, std::string>) {
-    j = json::string{x};
-  } else {
+  else if constexpr (std::is_convertible_v<T, json::string>)
+    j = json::string{std::move(x)};
+  else
     static_assert(detail::always_false_v<T>);
-  }
   return true;
 }
 

--- a/libvast/vast/json.hpp
+++ b/libvast/vast/json.hpp
@@ -23,10 +23,11 @@
 #include <caf/variant.hpp>
 
 #include "vast/concept/printable/to.hpp"
-
+#include "vast/detail/narrow.hpp"
 #include "vast/detail/operators.hpp"
 #include "vast/detail/steady_map.hpp"
 #include "vast/detail/type_traits.hpp"
+#include "vast/time.hpp"
 
 namespace vast {
 
@@ -163,13 +164,14 @@ inline bool convert(bool b, json& j) {
 
 /// @relates json
 template <class T>
-bool convert(T x, json& j) {
-  if constexpr (std::is_arithmetic_v<T>)
-    j = json::number(x);
-  else if constexpr (std::is_convertible_v<T, std::string>)
-    j = std::string(std::forward<T>(x));
-  else
+bool convert(const T& x, json& j) {
+  if constexpr (std::is_arithmetic_v<T>) {
+    j = detail::narrow_cast<json::number>(x);
+  } else if constexpr (std::is_convertible_v<T, std::string>) {
+    j = json::string{x};
+  } else {
     static_assert(detail::always_false_v<T>);
+  }
   return true;
 }
 


### PR DESCRIPTION
The nanosecond output is rather unusual. Hence the shift to fractional timestamps.