### PR TITLE
Fix three bugs in the export command

### DIFF
--- a/libvast/src/system/evaluator.cpp
+++ b/libvast/src/system/evaluator.cpp
@@ -175,7 +175,7 @@ caf::behavior evaluator(caf::stateful_actor<evaluator_state>* self,
       }
     }
     if (st.pending_responses == 0) {
-      VAST_DEBUG(self, "nothing to evaluate for expression");
+      VAST_DEBUG(self, "has nothing to evaluate for expression");
       st.promise.deliver(done_atom::value);
     }
     // We can only deal with exactly one expression/client at the moment.

--- a/libvast/src/system/evaluator.cpp
+++ b/libvast/src/system/evaluator.cpp
@@ -95,6 +95,7 @@ evaluator_state::evaluator_state(caf::event_based_actor* self) : self(self) {
 
 void evaluator_state::init(caf::actor client, expression expr,
                            caf::response_promise promise) {
+  VAST_TRACE(VAST_ARG(client), VAST_ARG(expr), VAST_ARG(promise));
   this->client = std::move(client);
   this->expr = std::move(expr);
   this->promise = std::move(promise);
@@ -154,6 +155,7 @@ evaluator_state::hits_for(const offset& position) {
 
 caf::behavior evaluator(caf::stateful_actor<evaluator_state>* self,
                         expression expr, evaluation_map eval) {
+  VAST_TRACE(VAST_ARG(expr), VAST_ARG(eval));
   VAST_ASSERT(!eval.empty());
   using std::get;
   using std::move;
@@ -171,6 +173,10 @@ caf::behavior evaluator(caf::stateful_actor<evaluator_state>* self,
                   self->state.handle_missing_result(pos, err);
                 });
       }
+    }
+    if (st.pending_responses == 0) {
+      VAST_DEBUG(self, "nothing to evaluate for expression");
+      st.promise.deliver(done_atom::value);
     }
     // We can only deal with exactly one expression/client at the moment.
     self->unbecome();

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -191,9 +191,13 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
   return {
     // The INDEX (or the EVALUATOR, to be more precise) sends us a series of
     // `ids` in response to an expression (query), terminated by 'done'.
-    [=](ids& hits) {
-      // Add `hits` to the total result set and update all stats.
+    [=](ids& hits) -> caf::result<void> {
       auto& st = self->state;
+      // Skip results that arrive before the response of the INDEX to handle
+      // them later.
+      if (st.query.expected == 0)
+        return caf::skip;
+      // Add `hits` to the total result set and update all stats.
       timespan runtime = steady_clock::now() - st.start;
       st.query.runtime = runtime;
       auto count = rank(hits);
@@ -216,6 +220,7 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
         ++st.query.lookups_issued;
         self->send(st.archive, std::move(hits));
       }
+      return caf::unit;
     },
     [=](table_slice_ptr slice) {
       handle_batch(to_events(*slice, self->state.hits));

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -193,8 +193,8 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
     // `ids` in response to an expression (query), terminated by 'done'.
     [=](ids& hits) -> caf::result<void> {
       auto& st = self->state;
-      // Skip results that arrive before the response of the INDEX to handle
-      // them later.
+      // Skip results that arrive before we got our lookup handle from the
+      // INDEX actor.
       if (st.query.expected == 0)
         return caf::skip;
       // Add `hits` to the total result set and update all stats.

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -158,7 +158,7 @@ evaluation_map partition::eval(const expression& expr) {
     if (resolved.empty())
       continue;
     // Add triples (offset, curried predicate, and INDEXER) to evaluation map.
-    auto& triples = result[layout];
+    evaluation_map::mapped_type triples;
     for (auto& kvp: resolved) {
       auto& pred = kvp.second;
       auto hdl = caf::visit(detail::overload(
@@ -180,6 +180,8 @@ evaluation_map partition::eval(const expression& expr) {
         triples.emplace_back(kvp.first, curried(pred), std::move(hdl));
       }
     }
+    if (!triples.empty())
+      result.emplace(layout, std::move(triples));
   }
   return result;
 }

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -108,7 +108,6 @@ caf::actor fetch_indexer(table_indexer& tbl, const attribute_extractor& ex,
                          relational_operator op, const data& x) {
   VAST_TRACE(VAST_ARG(tbl), VAST_ARG(ex), VAST_ARG(op), VAST_ARG(x));
   auto& layout = tbl.layout();
-  // Predicate of form "&type == ..."
   if (ex.attr == system::type_atom::value) {
     VAST_ASSERT(caf::holds_alternative<std::string>(x));
     // Doesn't apply if the query name doesn't match our type.
@@ -124,7 +123,6 @@ caf::actor fetch_indexer(table_indexer& tbl, const attribute_extractor& ex,
       return [=](const curried_predicate&) { return row_ids; };
     });
   }
-  // Predicate of form "&time == ..."
   if (ex.attr == system::time_atom::value) {
     VAST_ASSERT(caf::holds_alternative<timestamp>(x));
     // Find the column with attribute 'time'.


### PR DESCRIPTION
a) race in the EXPORTER (corrupt state if hits arrive before initial INDEX response)
b) VAST doesn't shutdown for `&time < now` queries
c) VAST produces no results for said query