### PR TITLE
Fix action and endpoint parser

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -44,6 +44,7 @@ set(libvast_sources
   src/detail/system.cpp
   src/detail/terminal.cpp
   src/die.cpp
+  src/endpoint.cpp
   src/error.cpp
   src/event.cpp
   src/ewah_bitmap.cpp

--- a/libvast/src/defaults.cpp
+++ b/libvast/src/defaults.cpp
@@ -30,7 +30,8 @@ namespace vast::defaults {
 namespace command {
 
 std::string_view directory = "vast";
-std::string_view endpoint = ":42000";
+std::string_view endpoint_host = "";
+uint16_t endpoint_port = 42000;
 std::string_view id = "";
 std::string_view read_path = "-";
 std::string_view write_path = "-";

--- a/libvast/src/endpoint.cpp
+++ b/libvast/src/endpoint.cpp
@@ -11,22 +11,17 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#pragma once
+#include "vast/endpoint.hpp"
 
 #include <string>
 
-#include <caf/optional.hpp>
+#include "vast/defaults.hpp"
 
 namespace vast {
 
-/// A transport-layer endpoint consisting of host and port.
-struct endpoint {
-  std::string host;   ///< The hostname or IP address.
-  uint64_t port = 0;  ///< The transport-layer port.
-};
-
-/// @returns an endpoint with values from the default settings.
-/// @relates endpoint make_endpoint
-endpoint make_default_endpoint();
+endpoint make_default_endpoint() {
+  namespace defs = defaults::command;
+  return endpoint{std::string{defs::endpoint_host}, defs::endpoint_port};
+}
 
 } // namespace vast

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -27,6 +27,7 @@
 
 #include "vast/concept/parseable/vast/endpoint.hpp"
 #include "vast/defaults.hpp"
+#include "vast/endpoint.hpp"
 #include "vast/error.hpp"
 #include "vast/filesystem.hpp"
 #include "vast/logger.hpp"

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -17,6 +17,7 @@
 #include <caf/actor_system_config.hpp>
 #include <caf/io/middleman.hpp>
 #include <caf/scoped_actor.hpp>
+#include <caf/settings.hpp>
 
 #include "vast/config.hpp"
 
@@ -36,17 +37,15 @@ using namespace caf;
 namespace vast::system {
 
 expected<actor> connect_to_node(scoped_actor& self, const caf::settings& opts) {
+  namespace defs = defaults::command;
   // Fetch values from config.
   auto id = get_or(opts, "id", defaults::command::node_id);
   auto dir = get_or(opts, "dir", defaults::command::directory);
   auto abs_dir = path{dir}.complete();
-  auto endpoint_str = get_or(opts, "endpoint", defaults::command::endpoint);
-  endpoint node_endpoint;
-  if (!parsers::endpoint(endpoint_str, node_endpoint)) {
-    std::string err = "invalid endpoint: ";
-    err += endpoint_str;
-    return make_error(sec::invalid_argument, std::move(err));
-  }
+  auto node_endpoint = make_default_endpoint();
+  if (auto str = get_if<std::string>(&opts, "endpoint"))
+    if (!parsers::endpoint(*str, node_endpoint))
+      make_error(ec::parse_error, "invalid endpoint", *str);
   VAST_DEBUG(self, "connects to remote node:", id);
   auto& sys_cfg = self->system().config();
   auto use_encryption = !sys_cfg.openssl_certificate.empty()

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -49,12 +49,11 @@ caf::message start_command(const command&, caf::actor_system& sys,
                         || !sys_cfg.openssl_passphrase.empty()
                         || !sys_cfg.openssl_capath.empty()
                         || !sys_cfg.openssl_cafile.empty();
-  // Fetch endpoint from config.
-  auto endpoint_str = get_or(options, "endpoint", defaults::command::endpoint);
-  endpoint node_endpoint;
-  if (!parsers::endpoint(endpoint_str, node_endpoint))
-    return caf::make_message(
-      make_error(ec::parse_error, "invalid endpoint", endpoint_str));
+  // Construct an endpoint.
+  auto node_endpoint = make_default_endpoint();
+  if (auto str = caf::get_if<std::string>(&options, "endpoint"))
+    if (!parsers::endpoint(*str, node_endpoint))
+      make_error(ec::parse_error, "invalid endpoint", *str);
   // Get a convenient and blocking way to interact with actors.
   caf::scoped_actor self{sys};
   // Spawn our node.

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -26,6 +26,7 @@
 
 #include "vast/concept/parseable/vast/endpoint.hpp"
 #include "vast/defaults.hpp"
+#include "vast/endpoint.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/scope_linked.hpp"

--- a/libvast/test/endpoint.cpp
+++ b/libvast/test/endpoint.cpp
@@ -11,28 +11,48 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
+#define SUITE endpoint
+
+#include "vast/test/test.hpp"
+
 #include "vast/concept/parseable/vast/endpoint.hpp"
 #include "vast/endpoint.hpp"
-
-#define SUITE endpoint
-#include "vast/test/test.hpp"
 
 using namespace vast;
 using namespace std::string_literals;
 
-TEST(parseable) {
-  endpoint e;
-  CHECK(parsers::endpoint(":42000", e));
-  CHECK(e.host == "");
-  CHECK(e.port == 42000);
-  CHECK(parsers::endpoint("localhost", e));
-  CHECK(e.host == "localhost");
-  CHECK(e.port == 0);
-  CHECK(parsers::endpoint("10.0.0.1:80", e));
-  CHECK(e.host == "10.0.0.1");
-  CHECK(e.port == 80);
-  CHECK(parsers::endpoint("foo-bar_baz.test", e));
-  CHECK(e.host == "foo-bar_baz.test");
-  CHECK(e.port == 0);
+namespace {
+
+struct fixture {
+  endpoint x;
+};
+
+} // namespace <anonymous>
+
+FIXTURE_SCOPE(endpoint_tests, fixture)
+
+TEST(parseable - host only) {
+  CHECK(parsers::endpoint("localhost", x));
+  CHECK(x.host == "localhost");
+  CHECK(x.port == 0);
+  MESSAGE("keep defaults");
+  x.port = 42;
+  CHECK(parsers::endpoint("foo-bar_baz.test", x));
+  CHECK(x.host == "foo-bar_baz.test");
+  CHECK(x.port == 42);
 }
 
+TEST(parseable - port only) {
+  x.host = "foo";
+  CHECK(parsers::endpoint(":42000", x));
+  CHECK(x.host == "foo");
+  CHECK(x.port == 42000);
+}
+
+TEST(parseable - host and port) {
+  CHECK(parsers::endpoint("10.0.0.1:80", x));
+  CHECK(x.host == "10.0.0.1");
+  CHECK(x.port == 80);
+}
+
+FIXTURE_SCOPE_END()

--- a/libvast/test/printable.cpp
+++ b/libvast/test/printable.cpp
@@ -11,7 +11,13 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
+#define SUITE printable
+
+#include "vast/test/test.hpp"
+
 #include <sstream>
+
+#include <caf/optional.hpp>
 
 #include "vast/concept/printable/core.hpp"
 #include "vast/concept/printable/numeric.hpp"
@@ -22,9 +28,6 @@
 #include "vast/concept/printable/to.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/detail/escapers.hpp"
-
-#define SUITE printable
-#include "vast/test/test.hpp"
 
 using namespace std::string_literals;
 using namespace vast;
@@ -219,7 +222,7 @@ TEST(list) {
 }
 
 TEST(optional) {
-  optional<int> x;
+  caf::optional<int> x;
   auto p = -printers::integral<int>;
   std::string str;
   CHECK(p(str, x));

--- a/libvast/vast/concept/parseable/core/action.hpp
+++ b/libvast/vast/concept/parseable/core/action.hpp
@@ -37,24 +37,24 @@ public:
     // nop
   }
 
-  template <class Iterator, class Attribute, class A = Action>
+  template <class Iterator, class Attribute>
   bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
-    if constexpr (detail::action_traits<A>::no_args_returns_void) {
+    if constexpr (detail::action_traits<Action>::no_args_returns_non_void) {
+      if (!parser_(f, l, a))
+        return false;
+      a = action_();
+    } else if constexpr (detail::action_traits<Action>::no_args_returns_void) {
       if (!parser_(f, l, a))
         return false;
       action_();
-    } else if constexpr (detail::action_traits<A>::one_arg_returns_void) {
-      if (!parser_(f, l, a))
-        return false;
-      action_(a);
-    } else if constexpr (detail::action_traits<A>::no_args_returns_non_void) {
+    } else if constexpr (detail::action_traits<Action>::one_arg_returns_void) {
       inner_attribute x;
       if (!parser_(f, l, x))
         return false;
-      a = action_();
+      action_(std::move(x));
     } else {
       // One argument, non-void return type.
-      static_assert(detail::action_traits<A>::one_arg_returns_non_void);
+      static_assert(detail::action_traits<Action>::one_arg_returns_non_void);
       action_arg_type x;
       if (!parser_(f, l, x))
         return false;
@@ -69,4 +69,3 @@ private:
 };
 
 } // namespace vast
-

--- a/libvast/vast/concept/parseable/core/choice.hpp
+++ b/libvast/vast/concept/parseable/core/choice.hpp
@@ -48,17 +48,17 @@ public:
   // LHS = T && RHS = U            =>  variant<T, U>
   using attribute =
     std::conditional_t<
-      std::is_same<lhs_attribute, unused_type>{}
-        && std::is_same<rhs_attribute, unused_type>{},
+      std::is_same_v<lhs_attribute, unused_type>
+        && std::is_same_v<rhs_attribute, unused_type>,
       unused_type,
       std::conditional_t<
-        std::is_same<lhs_attribute, unused_type>{},
+        std::is_same_v<lhs_attribute, unused_type>,
         rhs_attribute,
         std::conditional_t<
-          std::is_same<rhs_attribute, unused_type>{},
+          std::is_same_v<rhs_attribute, unused_type>,
           lhs_attribute,
           std::conditional_t<
-            std::is_same<lhs_attribute, rhs_attribute>{},
+            std::is_same_v<lhs_attribute, rhs_attribute>,
             lhs_attribute,
             detail::flattened_variant<lhs_attribute, rhs_attribute>
           >

--- a/libvast/vast/concept/parseable/core/sequence.hpp
+++ b/libvast/vast/concept/parseable/core/sequence.hpp
@@ -49,19 +49,19 @@ public:
   // LHS = T && RHS = U            =>  std:tuple<T, U>
   using attribute =
     std::conditional_t<
-      std::is_same<lhs_attribute, unused_type>{}
-        && std::is_same<rhs_attribute, unused_type>{},
+      std::is_same_v<lhs_attribute, unused_type>
+        && std::is_same_v<rhs_attribute, unused_type>,
       unused_type,
       std::conditional_t<
-        std::is_same<lhs_attribute, unused_type>{},
+        std::is_same_v<lhs_attribute, unused_type>,
         rhs_attribute,
         std::conditional_t<
-          std::is_same<rhs_attribute, unused_type>{},
+          std::is_same_v<rhs_attribute, unused_type>,
           lhs_attribute,
-          typename detail::attr_fold<
+          detail::attr_fold_t<
             decltype(std::tuple_cat(detail::tuple_wrap<lhs_attribute>{},
                                     detail::tuple_wrap<rhs_attribute>{}))
-          >::type
+          >
         >
       >
     >;

--- a/libvast/vast/concept/parseable/detail/container.hpp
+++ b/libvast/vast/concept/parseable/detail/container.hpp
@@ -25,7 +25,7 @@ namespace detail {
 template <class Elem>
 struct container {
   using vector_type = std::vector<Elem>;
-  using attribute = typename attr_fold<vector_type>::type;
+  using attribute = attr_fold_t<vector_type>;
 
   template <class T>
   struct lazy_value_type {

--- a/libvast/vast/concept/printable/core/kleene.hpp
+++ b/libvast/vast/concept/printable/core/kleene.hpp
@@ -24,8 +24,7 @@ template <class Printer>
 class kleene_printer : public printer<kleene_printer<Printer>> {
 public:
   using inner_attribute = typename Printer::attribute;
-  using attribute =
-    typename detail::attr_fold<std::vector<inner_attribute>>::type;
+  using attribute = detail::attr_fold_t<std::vector<inner_attribute>>;
 
   explicit kleene_printer(Printer p) : printer_{std::move(p)} {
   }
@@ -47,4 +46,3 @@ private:
 };
 
 } // namespace vast
-

--- a/libvast/vast/concept/printable/core/list.hpp
+++ b/libvast/vast/concept/printable/core/list.hpp
@@ -25,10 +25,10 @@ class list_printer : public printer<list_printer<Lhs, Rhs>> {
 public:
   using lhs_attribute = typename Lhs::attribute;
   using rhs_attribute = typename Rhs::attribute;
-  using attribute =
-    typename detail::attr_fold<std::vector<lhs_attribute>>::type;
+  using attribute = detail::attr_fold_t<std::vector<lhs_attribute>>;
 
   list_printer(Lhs lhs, Rhs rhs) : lhs_{std::move(lhs)}, rhs_{std::move(rhs)} {
+    // nop
   }
 
   template <class Iterator, class Attribute>
@@ -51,4 +51,3 @@ private:
 };
 
 } // namespace vast
-

--- a/libvast/vast/concept/printable/core/optional.hpp
+++ b/libvast/vast/concept/printable/core/optional.hpp
@@ -13,23 +13,23 @@
 
 #pragma once
 
+#include <caf/optional.hpp>
+
 #include "vast/concept/printable/core/printer.hpp"
 #include "vast/concept/support/detail/attr_fold.hpp"
-#include "vast/optional.hpp"
 
 namespace vast {
 
 template <class Printer>
 class optional_printer : public printer<optional_printer<Printer>> {
 public:
-  using inner_attribute =
-    typename detail::attr_fold<typename Printer::attribute>::type;
+  using inner_attribute = detail::attr_fold_t<typename Printer::attribute>;
 
   using attribute =
     std::conditional_t<
-      std::is_same<inner_attribute, unused_type>{},
+      std::is_same_v<inner_attribute, unused_type>,
       unused_type,
-      optional<inner_attribute>
+      caf::optional<inner_attribute>
     >;
 
   explicit optional_printer(Printer p)
@@ -52,5 +52,3 @@ private:
 };
 
 } // namespace vast
-
-

--- a/libvast/vast/concept/printable/core/plus.hpp
+++ b/libvast/vast/concept/printable/core/plus.hpp
@@ -24,9 +24,7 @@ template <class Printer>
 class plus_printer : public printer<plus_printer<Printer>> {
 public:
   using inner_attribute = typename Printer::attribute;
-  using attribute =
-    typename detail::attr_fold<std::vector<inner_attribute>>::type;
-
+  using attribute = detail::attr_fold_t<std::vector<inner_attribute>>;
 
   explicit plus_printer(Printer p) : printer_{std::move(p)} {
   }
@@ -51,5 +49,3 @@ private:
 };
 
 } // namespace vast
-
-

--- a/libvast/vast/concept/printable/core/sequence.hpp
+++ b/libvast/vast/concept/printable/core/sequence.hpp
@@ -49,19 +49,19 @@ public:
   // LHS = T && RHS = U            =>  std:tuple<T, U>
   using attribute =
     std::conditional_t<
-      std::is_same<lhs_attribute, unused_type>{}
-        && std::is_same<rhs_attribute, unused_type>{},
+      std::is_same_v<lhs_attribute, unused_type>
+        && std::is_same_v<rhs_attribute, unused_type>,
       unused_type,
       std::conditional_t<
-        std::is_same<lhs_attribute, unused_type>{},
+        std::is_same_v<lhs_attribute, unused_type>,
         rhs_attribute,
         std::conditional_t<
-          std::is_same<rhs_attribute, unused_type>{},
+          std::is_same_v<rhs_attribute, unused_type>,
           lhs_attribute,
-          typename detail::attr_fold<
+          detail::attr_fold<
             decltype(std::tuple_cat(detail::tuple_wrap<lhs_attribute>{},
                                     detail::tuple_wrap<rhs_attribute>{}))
-          >::type
+          >
         >
       >
     >;
@@ -121,4 +121,3 @@ private:
 };
 
 } // namespace vast
-

--- a/libvast/vast/concept/support/detail/attr_fold.hpp
+++ b/libvast/vast/concept/support/detail/attr_fold.hpp
@@ -15,6 +15,7 @@
 
 #include <string>
 #include <vector>
+#include <tuple>
 #include <type_traits>
 
 namespace vast {
@@ -44,7 +45,8 @@ struct attr_fold<std::tuple<char, std::string>> : std::decay<std::string> {};
 template <>
 struct attr_fold<std::tuple<std::string, char>> : std::decay<std::string> {};
 
+template <class T>
+using attr_fold_t = typename attr_fold<T>::type;
+
 } // namespace detail
 } // namespace vast
-
-

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -29,8 +29,11 @@ namespace command {
 /// Path to persistent state.
 extern std::string_view directory;
 
-/// Locator for connecting to a remote node in "host:port" notation.
-extern std::string_view endpoint;
+/// Hostname or IP address of a remote node.
+extern std::string_view endpoint_host;
+
+/// TCP port address of a remote node.
+extern uint16_t endpoint_port;
 
 /// Server ID for the consensus module.
 extern std::string_view id;

--- a/libvast/vast/endpoint.hpp
+++ b/libvast/vast/endpoint.hpp
@@ -24,4 +24,3 @@ struct endpoint {
 };
 
 } // namespace vast
-

--- a/libvast/vast/endpoint.hpp
+++ b/libvast/vast/endpoint.hpp
@@ -15,8 +15,6 @@
 
 #include <string>
 
-#include <caf/optional.hpp>
-
 namespace vast {
 
 /// A transport-layer endpoint consisting of host and port.


### PR DESCRIPTION
The action parser did the wrong thing for action lambdas with a single arguemnt. The endpoint parser was overriding the defaults, even when the string to parse didn't contain relevant values.