### PR TITLE
Include last_replenish for status only after use

### DIFF
--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -110,7 +110,8 @@ caf::dictionary<caf::config_value> importer_state::status() const {
   result.emplace("in-flight-slices", in_flight_slices);
   result.emplace("max-table-slice-size", max_table_slice_size);
   result.emplace("blocks-per-replenish", blocks_per_replenish);
-  result.emplace("last-replenish", caf::deep_to_string(last_replenish));
+  if (last_replenish > steady_clock::time_point::min())
+    result.emplace("last-replenish", caf::deep_to_string(last_replenish));
   result.emplace("awaiting-ids", awaiting_ids);
   result.emplace("available-ids", available_ids());
   if (!id_generators.empty())


### PR DESCRIPTION
The IMPORTER initializes its last_replenish with a value of: `"last-replenish": "1677-09-21T01:06:12.-854"`.

That's not useful information, so we no longer add it to the status until we actually replenished at least once.