### PR TITLE
Fix double-free in PCAP writer

### DIFF
--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -317,7 +317,10 @@ writer::writer(std::string trace, size_t flush_interval)
 }
 
 writer::~writer() {
-  cleanup();
+  if (dumper_)
+    ::pcap_dump_close(dumper_);
+  if (pcap_)
+    ::pcap_close(pcap_);
 }
 
 expected<void> writer::write(const event& e) {
@@ -368,13 +371,6 @@ expected<void> writer::flush() {
   if (::pcap_dump_flush(dumper_) == -1)
     return make_error(ec::format_error, "failed to flush");
   return no_error;
-}
-
-void writer::cleanup() {
-  if (dumper_)
-    ::pcap_dump_close(dumper_);
-  if (pcap_)
-    ::pcap_close(pcap_);
 }
 
 const char* writer::name() const {

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -340,7 +340,7 @@ expected<void> writer::write(const event& e) {
   auto& payload = caf::get<std::string>(xs[5]);
   // Make PCAP header.
   ::pcap_pkthdr header;
-  auto ns = e.timestamp().time_since_epoch().count();
+  auto ns = caf::get<timestamp>(xs[0]).time_since_epoch().count();
   header.ts.tv_sec = ns / 1000000000;
 #ifdef PCAP_TSTAMP_PRECISION_NANO
   header.ts.tv_usec = ns % 1000000000;

--- a/libvast/vast/format/pcap.hpp
+++ b/libvast/vast/format/pcap.hpp
@@ -145,8 +145,6 @@ public:
 
   caf::expected<void> flush() override;
 
-  void cleanup() override;
-
   const char* name() const override;
 
 private:


### PR DESCRIPTION
- Fix timestamp in output packet
- Call `writer::cleanup()` only once