### PR TITLE
Relax instruction set requirements on target host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ endif ()
 if (NOT CMAKE_CXX_FLAGS)
   # Our default flags.
   set(EXTRA_FLAGS "${EXTRA_FLAGS} -std=c++17 -Wall -Wextra -pedantic")
-  set(PERFORMANCE_FLAGS "-march=native -mpopcnt")
+  set(PERFORMANCE_FLAGS "-msse3 -mssse3 -msse4.1 -msse4.2")
   # Increase maximum number of template instantiations, for all that
   # template-heavy code.
   set(EXTRA_FLAGS "${EXTRA_FLAGS} -ftemplate-depth=512")


### PR DESCRIPTION
I ran into `Illegal Instruction` woes when executing the fedora jenkins build on an osx-based docker host (LinuxKit). This will hopefully get rid of the problem. I enabled up to sse4.2 as a compromise, the chance of running on a box that does not support this is pretty low.