### PR TITLE
Support fractional timespans

### DIFF
--- a/libvast/src/system/spawn_exporter.cpp
+++ b/libvast/src/system/spawn_exporter.cpp
@@ -28,6 +28,7 @@
 namespace vast::system {
 
 maybe_actor spawn_exporter(node_actor* self, spawn_arguments& args) {
+  VAST_TRACE(VAST_ARG(args));
   // Parse given expression.
   VAST_UNBOX_VAR(expr, normalized_and_valided(args));
   // Parse query options.

--- a/libvast/test/time.cpp
+++ b/libvast/test/time.cpp
@@ -36,13 +36,6 @@ void check_timespan(const Input& str, T x) {
   CHECK_EQUAL(t, duration_cast<timespan>(x));
 }
 
-template <class Input, class T>
-void check_timestamp(const Input& str, T x) {
-  timestamp ts;
-  CHECK(parsers::timespan(str, ts));
-  CHECK_EQUAL(ts, duration_cast<timestamp>(x));
-}
-
 } // namespace <anonymous>
 
 TEST(positive durations) {
@@ -87,7 +80,6 @@ TEST(fractional durations) {
 TEST_DISABLED(compound durations) {
   check_timespan("3m42s10ms", 3min + 42s + 10ms);
 }
-
 
 TEST(ymdshms timestamp parser) {
   timestamp ts;

--- a/libvast/test/time.cpp
+++ b/libvast/test/time.cpp
@@ -45,7 +45,6 @@ TEST(positive durations) {
   check_timespan("42ns", 42ns);
   check_timespan("42ns", 42ns);
   MESSAGE("microseconds");
-  MESSAGE("nanoseconds");
   check_timespan("42 usecs", 42us);
   check_timespan("42usec", 42us);
   check_timespan("42us", 42us);

--- a/libvast/test/time.cpp
+++ b/libvast/test/time.cpp
@@ -24,56 +24,72 @@
 
 using namespace vast;
 using namespace std::chrono;
+using namespace std::chrono_literals;
 using namespace date;
 
-TEST(parseable) {
-  timespan sp;
+namespace {
+
+template <class Input, class T>
+void check_timespan(const Input& str, T x) {
+  timespan t;
+  CHECK(parsers::timespan(str, t));
+  CHECK_EQUAL(t, duration_cast<timespan>(x));
+}
+
+template <class Input, class T>
+void check_timestamp(const Input& str, T x) {
+  timestamp ts;
+  CHECK(parsers::timespan(str, ts));
+  CHECK_EQUAL(ts, duration_cast<timestamp>(x));
+}
+
+} // namespace <anonymous>
+
+TEST(positive durations) {
   MESSAGE("nanoseconds");
-  CHECK(parsers::timespan("42 nsecs", sp));
-  CHECK(sp == nanoseconds(42));
-  CHECK(parsers::timespan("43nsecs", sp));
-  CHECK(sp == nanoseconds(43));
-  CHECK(parsers::timespan("44ns", sp));
-  CHECK(sp == nanoseconds(44));
+  check_timespan("42 nsecs", 42ns);
+  check_timespan("42nsec", 42ns);
+  check_timespan("42ns", 42ns);
+  check_timespan("42ns", 42ns);
   MESSAGE("microseconds");
-  CHECK(parsers::timespan("42 usecs", sp));
-  CHECK(sp == microseconds(42));
-  CHECK(parsers::timespan("43usecs", sp));
-  CHECK(sp == microseconds(43));
-  CHECK(parsers::timespan("44us", sp));
-  CHECK(sp == microseconds(44));
+  MESSAGE("nanoseconds");
+  check_timespan("42 usecs", 42us);
+  check_timespan("42usec", 42us);
+  check_timespan("42us", 42us);
   MESSAGE("milliseconds");
-  CHECK(parsers::timespan("42 msecs", sp));
-  CHECK(sp == milliseconds(42));
-  CHECK(parsers::timespan("43msecs", sp));
-  CHECK(sp == milliseconds(43));
-  CHECK(parsers::timespan("44ms", sp));
-  CHECK(sp == milliseconds(44));
+  check_timespan("42 msecs", 42ms);
+  check_timespan("42msec", 42ms);
+  check_timespan("42ms", 42ms);
   MESSAGE("seconds");
-  CHECK(parsers::timespan("-42 secs", sp));
-  CHECK(sp == seconds(-42));
-  CHECK(parsers::timespan("-43secs", sp));
-  CHECK(sp == seconds(-43));
-  CHECK(parsers::timespan("-44s", sp));
-  CHECK(sp == seconds(-44));
+  check_timespan("42 secs", 42s);
+  check_timespan("42sec", 42s);
+  check_timespan("42s", 42s);
   MESSAGE("minutes");
-  CHECK(parsers::timespan("-42 mins", sp));
-  CHECK(sp == minutes(-42));
-  CHECK(parsers::timespan("-43min", sp));
-  CHECK(sp == minutes(-43));
-  CHECK(parsers::timespan("44m", sp));
-  CHECK(sp == minutes(44));
+  check_timespan("42 mins", 42min);
+  check_timespan("42min", 42min);
+  check_timespan("42m", 42min);
   MESSAGE("hours");
-  CHECK(parsers::timespan("42 hours", sp));
-  CHECK(sp == hours(42));
-  CHECK(parsers::timespan("-43hrs", sp));
-  CHECK(sp == hours(-43));
-  CHECK(parsers::timespan("44h", sp));
-  CHECK(sp == hours(44));
-// TODO
-// MESSAGE("compound");
-// CHECK(parsers::timespan("5m99s", sp));
-// CHECK(sp.count() == 399000000000ll);
+  check_timespan("42 hours", 42h);
+  check_timespan("42hour", 42h);
+  check_timespan("42h", 42h);
+}
+
+TEST(negative durations) {
+  check_timespan("-42ns", -42ns);
+  check_timespan("-42h", -42h);
+}
+
+TEST(fractional durations) {
+  check_timespan("3.54s", 3540ms);
+  check_timespan("-42.001ms", -42001us);
+}
+
+TEST_DISABLED(compound durations) {
+  check_timespan("3m42s10ms", 3min + 42s + 10ms);
+}
+
+
+TEST(ymdshms timestamp parser) {
   timestamp ts;
   MESSAGE("YYYY-MM-DD+HH:MM:SS.ssss");
   CHECK(parsers::timestamp("2012-08-12+23:55:04.001234", ts));
@@ -124,12 +140,18 @@ TEST(parseable) {
   CHECK(t.hours() == hours{0});
   CHECK(t.minutes() == minutes{0});
   CHECK(t.seconds() == seconds{0});
-  MESSAGE("UNIX epoch");
+}
+
+TEST(unix epoch timestamp parser) {
+  timestamp ts;
   CHECK(parsers::timestamp("@1444040673", ts));
-  CHECK(ts.time_since_epoch() == seconds{1444040673});
+  CHECK(ts.time_since_epoch() == 1444040673s);
   CHECK(parsers::timestamp("@1398933902.686337", ts));
   CHECK(ts.time_since_epoch() == double_seconds{1398933902.686337});
-  MESSAGE("now");
+}
+
+TEST(now timestamp parser) {
+  timestamp ts;
   CHECK(parsers::timestamp("now", ts));
   CHECK(ts > timestamp::clock::now() - minutes{1});
   CHECK(ts < timestamp::clock::now() + minutes{1});
@@ -137,11 +159,16 @@ TEST(parseable) {
   CHECK(ts < timestamp::clock::now());
   CHECK(parsers::timestamp("now + 1m", ts));
   CHECK(ts > timestamp::clock::now());
-  MESSAGE("ago");
+}
+
+TEST(ago timestamp parser) {
+  timestamp ts;
   CHECK(parsers::timestamp("10 days ago", ts));
   CHECK(ts < timestamp::clock::now());
-  MESSAGE("in");
+}
+
+TEST(in timestamp parser) {
+  timestamp ts;
   CHECK(parsers::timestamp("in 1 year", ts));
   CHECK(ts > timestamp::clock::now());
 }
-

--- a/libvast/vast/concept/parseable/vast/time.hpp
+++ b/libvast/vast/concept/parseable/vast/time.hpp
@@ -155,7 +155,7 @@ namespace parsers {
 auto const ymdhms = ymdhms_parser{};
 
 /// Parses a fractional seconds-timestamp as UNIX epoch.
-auto const epoch = real_opt_dot
+auto const unix_ts = real_opt_dot
   ->* [](double d) {
     using std::chrono::duration_cast;
     return timestamp{duration_cast<vast::timespan>(double_seconds{d})};
@@ -174,7 +174,7 @@ struct timestamp_parser : parser<timestamp_parser> {
     auto ws = ignore(*parsers::space);
     auto p
       = parsers::ymdhms
-      | '@' >> parsers::epoch
+      | '@' >> parsers::unix_ts
       | "now" >> ws >> ( '+' >> ws >> parsers::timespan ->* plus
                        | '-' >> ws >> parsers::timespan ->* minus )
       | "now"_p ->* []() { return timestamp::clock::now(); }

--- a/libvast/vast/concept/parseable/vast/time.hpp
+++ b/libvast/vast/concept/parseable/vast/time.hpp
@@ -74,13 +74,18 @@ struct duration_parser : parser<duration_parser<Rep, Period>> {
       | "year"_p  ->* [] { return cast(hours(24 * 365)); }
       | "y"_p     ->* [] { return cast(hours(24 * 365)); }
       ;
-    double scale;
-    auto multiply = [&](attribute dur) {
-      auto result = duration_cast<duration<double, Period>>(dur) * scale;
-      return cast(result);
-    };
-    auto p = real_opt_dot >> ignore(*space) >> unit ->* multiply;
-    return p(f, l, scale, x);
+    if constexpr (std::is_same_v<Attribute, unused_type>) {
+      auto p = ignore(real_opt_dot) >> ignore(*space) >> unit;
+      return p(f, l, unused);
+    } else {
+      double scale;
+      auto multiply = [&](attribute dur) {
+        auto result = duration_cast<duration<double, Period>>(dur) * scale;
+        return cast(result);
+      };
+      auto p = real_opt_dot >> ignore(*space) >> unit ->* multiply;
+      return p(f, l, scale, x);
+    }
   }
 };
 

--- a/libvast/vast/system/spawn_arguments.hpp
+++ b/libvast/vast/system/spawn_arguments.hpp
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "caf/fwd.hpp"
+#include "caf/meta/type_name.hpp"
 
 #include "vast/aliases.hpp"
 #include "vast/fwd.hpp"
@@ -47,6 +48,11 @@ struct spawn_arguments {
     return first == last;
   }
 };
+
+template <class Inspector>
+auto inspect(Inspector& f, spawn_arguments& x) {
+  return f(caf::meta::type_name("spawn_arguments"), x.dir, x.label, x.options);
+}
 
 /// Attempts to parse `[args.first, args.last)` as ::expression and returns a
 /// normalized and validated version of that expression on success.


### PR DESCRIPTION
Previously the data parser would not parse `2.5` as 2.5 seconds because it didn't accept fractional values. This is now fixed.