### PR TITLE
Fix Zeek ASCII output

### DIFF
--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -33,6 +33,10 @@
 namespace vast::format::zeek {
 namespace {
 
+// The type name prefix to preprend to zeek log names when transleting them
+// into VAST types.
+constexpr std::string_view type_name_prefix = "zeek::";
+
 // Creates a VAST type from an ASCII Zeek type in a log header.
 expected<type> parse_type(std::string_view zeek_type) {
   type t;
@@ -140,8 +144,8 @@ Stream& operator<<(Stream& out, const time_factory& t) {
 }
 
 void stream_header(const type& t, std::ostream& out) {
-  auto i = t.name().find("zeek::");
-  auto path = i == std::string::npos ? t.name() : t.name().substr(5);
+  VAST_ASSERT(detail::starts_with(t.name(), type_name_prefix));
+  auto path = t.name().substr(type_name_prefix.size());
   out << "#separator " << separator << '\n'
       << "#set_separator" << separator << set_separator << '\n'
       << "#empty_field" << separator << empty_field << '\n'
@@ -458,7 +462,7 @@ caf::error reader::parse_header() {
   }
   // Construct type.
   layout_ = std::move(record_fields);
-  layout_.name("zeek::" + path);
+  layout_.name(std::string{type_name_prefix} + path);
   VAST_DEBUG(this, "parsed zeek header:");
   VAST_DEBUG(this, "    #separator", separator_);
   VAST_DEBUG(this, "    #set_separator", set_separator_);

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -337,10 +337,10 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
       separator_.clear();
       if (auto err = parse_header())
         return err;
-    if (!reset_builder(layout_))
-      return make_error(ec::parse_error,
-                        "unable to create a bulider for parsed layout at",
-                        lines_->line_number());
+      if (!reset_builder(layout_))
+        return make_error(ec::parse_error,
+                          "unable to create a bulider for parsed layout at",
+                          lines_->line_number());
     } else if (detail::starts_with(line, "#")) {
       // Ignore comments.
       VAST_DEBUG(this, "ignores comment at line", lines_->line_number());

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -143,7 +143,7 @@ Stream& operator<<(Stream& out, const time_factory& t) {
   return out;
 }
 
-void stream_header(const type& t, std::ostream& out) {
+void print_header(const type& t, std::ostream& out) {
   VAST_ASSERT(detail::starts_with(t.name(), type_name_prefix));
   auto path = t.name().substr(type_name_prefix.size());
   out << "#separator " << separator << '\n'
@@ -526,7 +526,7 @@ expected<void> writer::write(const event& e) {
       auto sb = std::make_unique<detail::fdoutbuf>(1);
       auto out = std::make_unique<std::ostream>(sb.release());
       auto i = streams_.emplace("", std::move(out));
-      stream_header(e.type(), *i.first->second);
+      print_header(e.type(), *i.first->second);
     }
     os = streams_.begin()->second.get();
   } else {
@@ -546,7 +546,7 @@ expected<void> writer::write(const event& e) {
       }
       auto filename = dir_ / (e.type().name() + ".log");
       auto fos = std::make_unique<std::ofstream>(filename.str());
-      stream_header(e.type(), *fos);
+      print_header(e.type(), *fos);
       auto i = streams_.emplace(e.type().name(), std::move(fos));
       os = i.first->second.get();
     }

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -525,10 +525,13 @@ expected<void> writer::write(const event& e) {
       VAST_DEBUG(this, "creates a new stream for STDOUT");
       auto sb = std::make_unique<detail::fdoutbuf>(1);
       auto out = std::make_unique<std::ostream>(sb.release());
-      auto i = streams_.emplace("", std::move(out));
-      print_header(e.type(), *i.first->second);
+      streams_.emplace("", std::move(out));
     }
     os = streams_.begin()->second.get();
+    if (e.type() != previous_layout_) {
+      print_header(e.type(), *os);
+      previous_layout_ = e.type();
+    }
   } else {
     auto i = streams_.find(e.type().name());
     if (i != streams_.end()) {

--- a/libvast/vast/format/zeek.hpp
+++ b/libvast/vast/format/zeek.hpp
@@ -282,6 +282,7 @@ public:
 
 private:
   path dir_;
+  type previous_layout_;
   std::unordered_map<std::string, std::unique_ptr<std::ostream>> streams_;
 };
 


### PR DESCRIPTION
This PR fixes an invalid substring operation when stripping off the `zeek::` type name prefix. The renaming from Bro to Zeek relied on a hardcoded substring offset, but Zeek is one character longer.

Moreover, we can now print events of multiple types on standard output. Previously, the output was just broken because only the header of the first type got printed. Now, we re-print a new header whenever the type changes. It's not ideal, but it's at least correct. When issueing queries where multiple log types show up in the result set, one should use the directory-based output anyway, which writes each log type in a separate file.