### PR TITLE
Use exactly 6 fractional digits for Zeek floating point values

### DIFF
--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -182,7 +182,7 @@ struct streamer {
   }
 
   void operator()(const real_type&, real r) const {
-    auto p = real_printer<real, 6>{};
+    auto p = real_printer<real, 6, 6>{};
     auto out = std::ostreambuf_iterator<char>(out_);
     p.print(out, r);
   }
@@ -190,7 +190,7 @@ struct streamer {
   void operator()(const timestamp_type&, timestamp ts) const {
     double d;
     convert(ts.time_since_epoch(), d);
-    auto p = real_printer<real, 6>{};
+    auto p = real_printer<real, 6, 6>{};
     auto out = std::ostreambuf_iterator<char>(out_);
     p.print(out, d);
   }
@@ -198,7 +198,7 @@ struct streamer {
   void operator()(const timespan_type&, timespan span) const {
     double d;
     convert(span, d);
-    auto p = real_printer<real, 6>{};
+    auto p = real_printer<real, 6, 6>{};
     auto out = std::ostreambuf_iterator<char>(out_);
     p.print(out, d);
   }

--- a/libvast/test/printable.cpp
+++ b/libvast/test/printable.cpp
@@ -120,6 +120,11 @@ TEST(floating point) {
   str.clear();
   CHECK(real_printer<double, 6>{}(str, d));
   CHECK_EQUAL(str, "123456.00123");
+
+  d = 123456.123;
+  str.clear();
+  CHECK(real_printer<double, 6, 6>{}(str, d));
+  CHECK_EQUAL(str, "123456.123000");
 }
 
 // -- string ------------------------------------------------------------------

--- a/libvast/vast/concept/printable/detail/print_numeric.hpp
+++ b/libvast/vast/concept/printable/detail/print_numeric.hpp
@@ -19,26 +19,23 @@
 
 #include "vast/detail/coding.hpp"
 
-namespace vast {
-namespace detail {
+namespace vast::detail {
 
 template <class Iterator, class T>
-bool print_numeric(Iterator& out, T x) {
+size_t print_numeric(Iterator& out, T x) {
   static_assert(std::is_integral<T>{}, "T must be an integral type");
   if (x == 0) {
     *out++ = '0';
-    return true;
+    return 1;
   }
   char buf[std::numeric_limits<T>::digits10 + 1];
-  auto p = buf;
+  auto ptr = buf;
   while (x > 0) {
-    *p++ = byte_to_char(x % 10);
+    *ptr++ = byte_to_char(x % 10);
     x /= 10;
   }
-  out = std::reverse_copy(buf, p, out);
-  return true;
+  out = std::reverse_copy(buf, ptr, out);
+  return ptr - buf;
 }
 
-} // namespace detail
-} // namespace vast
-
+} // namespace vast::detail

--- a/libvast/vast/concept/printable/numeric/integral.hpp
+++ b/libvast/vast/concept/printable/numeric/integral.hpp
@@ -51,22 +51,15 @@ struct integral_printer : printer<integral_printer<T, Policy, MinDigits>> {
     }
   }
 
-  template <class Iterator, class U = T>
-  auto print(Iterator& out, U x) const
-  -> std::enable_if_t<std::is_unsigned<U>{}, bool> {
-    pad(out, x);
-    detail::print_numeric(out, x);
-    return true;
-  }
-
-  template <class Iterator, class U = T>
-  auto print(Iterator& out, U x) const
-  -> std::enable_if_t<std::is_signed<U>{}, bool> {
-    if (x < 0) {
-      *out++ = '-';
-      x = -x;
-    } else if (std::is_same_v<Policy, policy::force_sign>) {
-      *out++ = '+';
+  template <class Iterator, class U>
+  bool print(Iterator& out, U x) const {
+    if constexpr (std::is_signed_v<U>) {
+      if (x < 0) {
+        *out++ = '-';
+        x = -x;
+      } else if (std::is_same_v<Policy, policy::force_sign>) {
+        *out++ = '+';
+      }
     }
     pad(out, x);
     detail::print_numeric(out, x);
@@ -106,4 +99,3 @@ auto const u64 = integral_printer<uint64_t>{};
 
 } // namespace printers
 } // namespace vast
-

--- a/libvast/vast/concept/printable/numeric/integral.hpp
+++ b/libvast/vast/concept/printable/numeric/integral.hpp
@@ -55,7 +55,8 @@ struct integral_printer : printer<integral_printer<T, Policy, MinDigits>> {
   auto print(Iterator& out, U x) const
   -> std::enable_if_t<std::is_unsigned<U>{}, bool> {
     pad(out, x);
-    return detail::print_numeric(out, x);
+    detail::print_numeric(out, x);
+    return true;
   }
 
   template <class Iterator, class U = T>
@@ -68,7 +69,8 @@ struct integral_printer : printer<integral_printer<T, Policy, MinDigits>> {
       *out++ = '+';
     }
     pad(out, x);
-    return detail::print_numeric(out, x);
+    detail::print_numeric(out, x);
+    return true;
   }
 };
 

--- a/libvast/vast/concept/printable/numeric/real.hpp
+++ b/libvast/vast/concept/printable/numeric/real.hpp
@@ -23,8 +23,8 @@
 
 namespace vast {
 
-template <class T, int MaxDigits = 10>
-struct real_printer : printer<real_printer<T, MaxDigits>> {
+template <class T, int MaxDigits = 10, int MinDigits = 0>
+struct real_printer : printer<real_printer<T, MaxDigits, MinDigits>> {
   static_assert(std::is_floating_point<T>{}, "T must be a floating point type");
 
   using attribute = T;
@@ -38,19 +38,25 @@ struct real_printer : printer<real_printer<T, MaxDigits>> {
     }
     T left;
     uint64_t right = std::round(std::modf(x, &left) * std::pow(10, MaxDigits));
-    if (MaxDigits == 0)
-      return detail::print_numeric(out, static_cast<uint64_t>(std::round(x)));
-    if (!detail::print_numeric(out, static_cast<uint64_t>(left)))
-      return false;
+    if constexpr (MaxDigits == 0) {
+      detail::print_numeric(out, static_cast<uint64_t>(std::round(x)));
+      return true;
+    }
+    detail::print_numeric(out, static_cast<uint64_t>(left));
     *out++ = '.';
     // Add leading decimal zeros.
     auto magnitude = right == 0 ? MaxDigits : std::log10(right);
     for (auto i = 1.0; i < MaxDigits - magnitude; ++i)
       *out++ = '0';
-    // Avoid trailing zeros on the decimal digits.
+    // Chop off trailing zeros of the decimal digits.
     while (right > 0 && right % 10 == 0)
       right /= 10;
-    return detail::print_numeric(out, right);
+    if constexpr (MinDigits == 0)
+      detail::print_numeric(out, right);
+    else
+      for (auto i = detail::print_numeric(out, right); i < MinDigits; ++i)
+        *out++ = '0';
+    return true;
   }
 };
 
@@ -72,4 +78,3 @@ auto const real6 = real_printer<double, 6>{};
 
 } // namespace printers
 } // namespace vast
-


### PR DESCRIPTION
Previously the output did not include trailing zeros if the fractional digits were less than 6.