### PR TITLE
Add new help and version commands

### DIFF
--- a/doc/vast.1.md
+++ b/doc/vast.1.md
@@ -108,9 +108,6 @@ The following *options* are available:
 `-h`, `-?`, `--help`
   Display a help message and exit.
 
-`-v`, `--version`
-  Print VAST version and exit.
-
 When specifying an endpoint via `-e`, `vast` connects to that endpoint to
 obtain a **node** handle. An exception is the command `vast start`,
 which uses the endpoint specification to spawn a **node**.
@@ -127,6 +124,8 @@ COMMANDS
 
 This section describes each *command* and its *arguments*. The following
 commands exist:
+    *help*          displays a help message
+    *version*       displays the software version
     *start*         starts a node
     *stop*          stops a node
     *peer*          peers with another node
@@ -135,6 +134,22 @@ commands exist:
     *kill*          terminates a component
     *import*        imports data from STDIN or file
     *export*        exports query results to STDOUT or file
+
+### help
+
+Synopsis:
+
+  *help*
+
+Displays a help message and exits.
+
+### version
+
+Synopsis:
+
+  *version*
+
+Displays the software version and exits.
 
 ### start
 

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -88,6 +88,7 @@ set(libvast_sources
   src/system/dummy_consensus.cpp
   src/system/evaluator.cpp
   src/system/exporter.cpp
+  src/system/help_command.cpp
   src/system/importer.cpp
   src/system/index.cpp
   src/system/indexer.cpp

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -118,6 +118,7 @@ set(libvast_sources
   src/system/table_indexer.cpp
   src/system/task.cpp
   src/system/tracker.cpp
+  src/system/version_command.cpp
   src/table_slice.cpp
   src/table_slice_builder.cpp
   src/table_slice_builder_factory.cpp

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -129,6 +129,10 @@ caf::message run(const command& cmd, caf::actor_system& sys,
   return run(cmd, sys, options, args.begin(), args.end());
 }
 
+const command& root(const command& cmd) {
+  return cmd.parent == nullptr ? cmd : root(*cmd.parent);
+}
+
 std::string full_name(const command& cmd) {
   std::string result{cmd.name};
   for (auto ptr = cmd.parent; ptr != nullptr; ptr = ptr->parent) {

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -93,11 +93,6 @@ caf::message run(const command& cmd, caf::actor_system& sys,
     helptext(cmd, std::cerr);
     return caf::none;
   }
-  // Check for version option.
-  if (get_or<bool>(options, "version", false)) {
-    std::cerr << VAST_VERSION << std::endl;
-    return caf::none;
-  }
   // Invoke cmd.run if no subcommand was defined.
   if (!has_subcommand) {
     // Commands without a run implementation require subcommands.

--- a/libvast/src/system/default_application.cpp
+++ b/libvast/src/system/default_application.cpp
@@ -24,6 +24,7 @@
 #include "vast/system/application.hpp"
 #include "vast/system/configuration.hpp"
 #include "vast/system/generator_command.hpp"
+#include "vast/system/help_command.hpp"
 #include "vast/system/reader_command.hpp"
 #include "vast/system/remote_command.hpp"
 #include "vast/system/start_command.hpp"
@@ -46,6 +47,7 @@ default_application::default_application() {
   // Default options for commands.
   auto opts = [] { return command::opts(); };
   // Add standalone commands.
+  add(help_command, "help", "prints the help text", opts());
   add(start_command, "start", "starts a node", opts());
   add(remote_command, "stop", "stops a node", opts());
   add(remote_command, "spawn", "creates a new component", opts());

--- a/libvast/src/system/default_application.cpp
+++ b/libvast/src/system/default_application.cpp
@@ -28,6 +28,7 @@
 #include "vast/system/reader_command.hpp"
 #include "vast/system/remote_command.hpp"
 #include "vast/system/start_command.hpp"
+#include "vast/system/version_command.hpp"
 #include "vast/system/writer_command.hpp"
 
 #ifdef VAST_HAVE_PCAP
@@ -42,12 +43,12 @@ default_application::default_application() {
   root.options
     .add<std::string>("dir,d", "directory for persistent state")
     .add<std::string>("endpoint,e", "node endpoint")
-    .add<std::string>("id,i", "the unique ID of this node")
-    .add<bool>("version,v", "print version and exit");
+    .add<std::string>("id,i", "the unique ID of this node");
   // Default options for commands.
   auto opts = [] { return command::opts(); };
   // Add standalone commands.
   add(help_command, "help", "prints the help text", opts());
+  add(version_command, "version", "prints the software version", opts());
   add(start_command, "start", "starts a node", opts());
   add(remote_command, "stop", "stops a node", opts());
   add(remote_command, "spawn", "creates a new component", opts());

--- a/libvast/src/system/help_command.cpp
+++ b/libvast/src/system/help_command.cpp
@@ -1,0 +1,35 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/system/help_command.hpp"
+
+#include <string>
+#include <vector>
+
+#include <caf/config_value.hpp>
+#include <caf/message.hpp>
+#include <caf/settings.hpp>
+
+namespace vast::system {
+
+caf::message help_command(const command& cmd, caf::actor_system& sys,
+                          caf::settings& , command::argument_iterator,
+                          command::argument_iterator) {
+  // Simply dispatch to '<root> -h'.
+  caf::settings options;
+  std::vector<std::string> cli;
+  options.emplace("help", caf::config_value{true});
+  return run(root(cmd), sys, options, cli.begin(), cli.end());
+}
+
+} // namespace vast::system

--- a/libvast/src/system/version_command.cpp
+++ b/libvast/src/system/version_command.cpp
@@ -1,0 +1,31 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/system/version_command.hpp"
+
+#include <iostream>
+
+#include <caf/message.hpp>
+
+#include "vast/config.hpp"
+
+namespace vast::system {
+
+caf::message version_command(const command&, caf::actor_system&, caf::settings&,
+                             command::argument_iterator,
+                             command::argument_iterator) {
+  std::cout << VAST_VERSION << std::endl;
+  return caf::none;
+}
+
+} // namespace vast::system

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -95,6 +95,10 @@ caf::message run(const command& cmd, caf::actor_system& sys,
 caf::message run(const command& cmd, caf::actor_system& sys,
                  caf::settings& options, const std::vector<std::string>& args);
 
+/// Traverses the command hierarchy until finding the root.
+/// @returns the root command.
+const command& root(const command& cmd);
+
 /// Gets a subcommand from its full name.
 /// @param cmd The parent to search for *position.
 /// @param position The next subcommand to resolve.

--- a/libvast/vast/system/help_command.hpp
+++ b/libvast/vast/system/help_command.hpp
@@ -1,0 +1,28 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <caf/fwd.hpp>
+
+#include "vast/command.hpp"
+
+namespace vast::system {
+
+/// Generates help text for users.
+caf::message help_command(const command& cmd, caf::actor_system& sys,
+                          caf::settings& options,
+                          command::argument_iterator begin,
+                          command::argument_iterator end);
+
+} // namespace vast::system

--- a/libvast/vast/system/version_command.hpp
+++ b/libvast/vast/system/version_command.hpp
@@ -1,0 +1,28 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <caf/fwd.hpp>
+
+#include "vast/command.hpp"
+
+namespace vast::system {
+
+/// Displays the software version to the user.
+caf::message version_command(const command& cmd, caf::actor_system& sys,
+                             caf::settings& options,
+                             command::argument_iterator begin,
+                             command::argument_iterator end);
+
+} // namespace vast::system


### PR DESCRIPTION
Allow users to call `vast help` and replace `vast -v` with `vast version` to enable us to make better use of the `-v` option in the future (e.g. as `verbose` flag).