### PR TITLE
Fix bug in EXPORTER control flow

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -453,8 +453,9 @@ behavior index(stateful_actor<index_state>* self, const path& dir,
       }
       // Delegate to query supervisor (uses up this worker) and report
       // query ID + some stats to the client.
-      VAST_DEBUG(self, "schedules first", qm.size(), "partition(s) for query",
-                 iter->first);
+      VAST_DEBUG(self, "schedules", qm.size(), "more partition(s) for query",
+                 iter->first, "with", iter->second.partitions.size(),
+                 "remaining");
       self->send(st.next_worker(), iter->second.expr, std::move(qm), client);
       // Cleanup if we exhausted all candidates.
       if (iter->second.partitions.empty())

--- a/libvast/src/system/source_command.cpp
+++ b/libvast/src/system/source_command.cpp
@@ -111,9 +111,10 @@ caf::message source_command(const command& cmd, caf::actor_system& sys,
       // Assign accountant to source.
       VAST_DEBUG(&cmd, "assigns accountant from node", id, "to new source");
       auto er = reg.components[id].equal_range("accountant");
-      VAST_ASSERT(er.first != er.second);
-      auto accountant = er.first->second.actor;
-      self->send(src, actor_cast<accountant_type>(accountant));
+      if (er.first != er.second) {
+        auto accountant = er.first->second.actor;
+        self->send(src, actor_cast<accountant_type>(accountant));
+      }
       // Assign IMPORTER to SOURCE and start streaming.
       er = reg.components[id].equal_range("importer");
       if (er.first == er.second) {


### PR DESCRIPTION
The various paths through the two `done` handlers in the EXPORTER can lead to corrupt query status. This set of changes fixes a bug that can lead to too few results by enforcing a dependency between done messages from the ARCHIVE and done messages from QUERY_SUPERVISOR actors.