### PR TITLE
Add scaffold for using test logs in unit tests without parsing them over and over again

### DIFF
--- a/libvast_test/CMakeLists.txt
+++ b/libvast_test/CMakeLists.txt
@@ -48,9 +48,31 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/vast/test/data.hpp"
         DESTINATION include/vast/test
 )
 
+## utility for converting artifacts to source files via gen-vast-slices
+
+set(generated_sources)
+
+macro(log_to_slices format name)
+  set(target_dir "${CMAKE_CURRENT_BINARY_DIR}/src/artifacts/logs/${format}")
+  set(logfile "${CMAKE_CURRENT_SOURCE_DIR}/artifacts/logs/${format}/${name}.log")
+  set(cppfile "${target_dir}/${name}.cpp")
+  list(APPEND generated_sources "${cppfile}")
+  set(cmd "${EXECUTABLE_OUTPUT_PATH}/gen-vast-slices")
+  set(nn_arg "--namespace-name=artifacts::logs::${format}")
+  set(vn_arg "--variable-name=${name}_buf")
+  file(MAKE_DIRECTORY "${target_dir}")
+  add_custom_command(
+    OUTPUT "${cppfile}"
+    COMMAND ${cmd} -i ${logfile} -o ${cppfile} -f ${format} ${nn_arg} ${vn_arg}
+    DEPENDS gen-vast-slices "${logfile}")
+endmacro()
+
+log_to_slices("zeek" "conn")
+
 ## test library definition
 
 add_library(libvast_test
+  "${generated_sources}"
   src/actor_system.cpp
   src/dummy_index.cpp
   src/events.cpp

--- a/libvast_test/src/events.cpp
+++ b/libvast_test/src/events.cpp
@@ -307,9 +307,6 @@ events::events() {
   SANITY_CHECK(bgpdump_txt, bgpdump_txt_slices);
   // SANITY_CHECK(random, const_random_slices);
   // Read the full Zeek conn.log.
-  // TODO: port remaining slices to new deserialization API and replace
-  //       this hard-coded starting offset
-  id offset = 100000;
   caf::binary_deserializer src{nullptr, artifacts::logs::zeek::conn_buf,
                                artifacts::logs::zeek::conn_buf_size};
   if (auto err = src(zeek_full_conn_log_slices))
@@ -317,6 +314,9 @@ events::events() {
   VAST_ASSERT(std::all_of(zeek_full_conn_log_slices.begin(),
                           zeek_full_conn_log_slices.end() - 1,
                           [](auto& slice) { return slice->rows() == 100; }));
+  // TODO: port remaining slices to new deserialization API and replace
+  //       this hard-coded starting offset
+  id offset = 100000;
   for (auto& ptr : zeek_full_conn_log_slices) {
     ptr.unshared().offset(offset);
     offset += ptr->rows();

--- a/libvast_test/vast/test/fixtures/events.hpp
+++ b/libvast_test/vast/test/fixtures/events.hpp
@@ -47,6 +47,8 @@ struct events {
   static std::vector<table_slice_ptr> bgpdump_txt_slices;
   // static std::vector<table_slice_ptr> random_slices;
 
+  static std::vector<table_slice_ptr> zeek_full_conn_log_slices;
+
   /// 10000 ascending integer values, starting at 0.
   static std::vector<event> ascending_integers;
   static std::vector<table_slice_ptr> ascending_integers_slices;
@@ -63,7 +65,13 @@ struct events {
   }
 
   std::vector<table_slice_ptr> copy(std::vector<table_slice_ptr> xs);
+
+  auto take_n(const std::vector<table_slice_ptr>& xs, size_t n) {
+    VAST_ASSERT(n <= xs.size());
+    auto first = xs.begin();
+    auto last = first + n;
+    return std::vector<table_slice_ptr>{first, last};
+  }
 };
 
 } // namespace fixtures
-

--- a/libvast_test/vast/test/fixtures/events.hpp
+++ b/libvast_test/vast/test/fixtures/events.hpp
@@ -66,7 +66,7 @@ struct events {
 
   std::vector<table_slice_ptr> copy(std::vector<table_slice_ptr> xs);
 
-  auto take_n(const std::vector<table_slice_ptr>& xs, size_t n) {
+  auto take(const std::vector<table_slice_ptr>& xs, size_t n) {
     VAST_ASSERT(n <= xs.size());
     auto first = xs.begin();
     auto last = first + n;

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(dscat)
+add_subdirectory(gen-vast-slices)
 if (BROKER_FOUND)
   add_subdirectory(zeek-to-vast)
 endif ()

--- a/tools/gen-vast-slices/CMakeLists.txt
+++ b/tools/gen-vast-slices/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(gen-vast-slices gen-vast-slices.cpp)
+target_link_libraries(gen-vast-slices libvast)
+install(TARGETS gen-vast-slices DESTINATION bin)

--- a/tools/gen-vast-slices/README.md
+++ b/tools/gen-vast-slices/README.md
@@ -1,11 +1,12 @@
 # gen-vast-slices
 
 The **gen-vast-slices** tool parses supported log formats from STDIN into table
-slices and prints them in serialized form to STDOUT.
+slices, serializes them with a `caf::binary_serializer`, and prints the
+serialized data to STDOUT.
 
-Our primary use case is to create a `.cpp` with an array that contains the
-serialized form of a table slice vector. Unit tests than can quickly
-deserialize the vector instead of parsing files from the file system.
+Our primary use case is to create a `.cpp` file with an array that contains the
+serialized form of a table slice vector. Unit tests then can quickly
+deserialize the vector instead of performing filesystem I/O.
 
 ## Usage
 

--- a/tools/gen-vast-slices/README.md
+++ b/tools/gen-vast-slices/README.md
@@ -1,0 +1,20 @@
+# gen-vast-slices
+
+The **gen-vast-slices** tool parses supported log formats from STDIN into table
+slices and prints them in serialized form to STDOUT.
+
+Our primary use case is to create a `.cpp` with an array that contains the
+serialized form of a table slice vector. Unit tests than can quickly
+deserialize the vector instead of parsing files from the file system.
+
+## Usage
+
+The tool reads from STDIN and writes to STDOUT. When generating C++ source code
+(the default mode), it's best to pipe the output through `clang-format`. Also,
+explicitly defining namespace and variable names for the generated C++ source
+code is good practice:
+
+    gen-vast-slices --namespace-name="artifacts::logs::zeek" \
+                    --variable-name="small_con_buf" /
+                    < libvast_test/artifacts/logs/zeek/small_conn.log \
+                    | clang-format

--- a/tools/gen-vast-slices/README.md
+++ b/tools/gen-vast-slices/README.md
@@ -9,12 +9,15 @@ deserialize the vector instead of parsing files from the file system.
 
 ## Usage
 
-The tool reads from STDIN and writes to STDOUT. When generating C++ source code
-(the default mode), it's best to pipe the output through `clang-format`. Also,
-explicitly defining namespace and variable names for the generated C++ source
-code is good practice:
+We use this tool primarily for automatic code generation via CMake.
+
+By default, the tool reads from STDIN and writes to STDOUT. When generating C++
+source code (the default mode), it's best to pipe the output through
+`clang-format` when generating code under the Git source tree. Also, explicitly
+defining namespace and variable names for the generated C++ source code is good
+practice:
 
     gen-vast-slices --namespace-name="artifacts::logs::zeek" \
-                    --variable-name="small_con_buf" /
+                    --variable-name="small_con_buf" \
                     < libvast_test/artifacts/logs/zeek/small_conn.log \
                     | clang-format

--- a/tools/gen-vast-slices/gen-vast-slices.cpp
+++ b/tools/gen-vast-slices/gen-vast-slices.cpp
@@ -1,0 +1,166 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include <cstddef>
+#include <iostream>
+#include <string>
+
+#include <caf/actor_system.hpp>
+#include <caf/actor_system_config.hpp>
+#include <caf/binary_serializer.hpp>
+#include <caf/exec_main.hpp>
+#include <caf/scoped_actor.hpp>
+
+#include "vast/defaults.hpp"
+#include "vast/detail/make_io_stream.hpp"
+#include "vast/error.hpp"
+#include "vast/factory.hpp"
+#include "vast/format/zeek.hpp"
+#include "vast/system/configuration.hpp"
+#include "vast/system/source.hpp"
+#include "vast/table_slice.hpp"
+#include "vast/table_slice_builder.hpp"
+
+using std::cerr;
+using std::cout;
+using std::endl;
+
+using vast::table_slice_ptr;
+
+using namespace caf;
+
+namespace {
+
+constexpr const char* vast_header
+  = R"(/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+)";
+
+using slices_vector = std::vector<vast::table_slice_ptr>;
+
+using read_function = slices_vector (*)(actor_system&);
+
+using print_function = void (*)(actor_system&, const slices_vector&);
+
+// Our custom configuration with extra command line options for this tool.
+class config : public vast::system::configuration {
+public:
+  config() {
+    opt_group{custom_options_, "global"}
+      .add<std::string>("input-format,f", "input log format, defaults to zeek")
+      .add<std::string>("variable-name",
+                        "optional name for generated C++ variables")
+      .add<std::string>("namespace-name",
+                        "optional namespace for generated C++ code")
+      .add<std::string>("output,o", "output format, defaults to 'c++'")
+      .add<atom_value>("table-slice-type,t",
+                       "implementation type for the generated slices")
+      .add<size_t>("table-slice-size,s",
+                   "maximum size of the generated slices");
+  }
+
+  using actor_system_config::parse;
+};
+
+void print_cpp(actor_system& sys, const slices_vector& slices) {
+  std::vector<char> buf;
+  binary_serializer sink{sys, buf};
+  sink(slices);
+  auto nn = get_or(sys.config(), "namespace-name", "log");
+  auto vn = get_or(sys.config(), "variable-name", "buf");
+  std::cout << vast_header << endl
+            << "#include <cstddef>" << endl
+            << endl
+            << "namespace " << nn << " {" << endl
+            << endl
+            << "char " << vn << "[] = {" << endl;
+  for (auto c : buf)
+    std::cout << static_cast<int>(c) << "," << endl;
+  std::cout << "};" << endl
+            << endl
+            << "size_t " << vn << "_size = sizeof(" << vn << ");" << endl
+            << endl
+            << "} // namespace " << nn << endl;
+}
+
+slices_vector read_zeek(actor_system& sys) {
+  slices_vector result;
+  using reader_type = vast::format::zeek::reader;
+  auto slice_size = get_or(sys.config(), "table-slice-size",
+                           vast::defaults::system::table_slice_size);
+  auto slice_type = get_or(sys.config(), "table-slice-type",
+                           vast::defaults::system::table_slice_type);
+  auto in = vast::detail::make_input_stream("-", false);
+  auto push_slice = [&](table_slice_ptr x) {
+    result.emplace_back(std::move(x));
+  };
+  reader_type reader{slice_type, std::move(*in)};
+  auto [err, produced] = reader.read(std::numeric_limits<size_t>::max(),
+                                     slice_size, push_slice);
+  if (err != vast::ec::end_of_input)
+    std::cerr << "*** error: " << sys.render(err) << std::endl;
+  VAST_INFO("reader", "produced", produced, "events");
+  return result;
+}
+
+void caf_main(actor_system& sys, const config& cfg) {
+  // Print funtions setup.
+  std::unordered_map<std::string, print_function> printers{
+    {"c++", print_cpp},
+  };
+  // Source factories setup.
+  std::unordered_map<std::string, read_function> readers{
+    {"zeek", read_zeek},
+  };
+  // Utility functions.
+  auto dump_keys = [&](const auto& xs) {
+    for (auto& kvp : xs)
+      cerr << "- " << kvp.first << endl;
+  };
+  // Verify printer setup.
+  print_function print = nullptr;
+  if (auto i = printers.find(get_or(cfg, "output", "c++"));
+      i == printers.end()) {
+    std::cerr << "invalid printer; supported output formats:" << endl;
+    dump_keys(printers);
+    return;
+  } else {
+    print = i->second;
+  }
+  // Verify input format setup.
+  read_function read = nullptr;
+  auto input_format = get_or(cfg, "input-format", "zeek");
+  if (auto i = readers.find(input_format); i == readers.end()) {
+    cerr << "invalid input format; supported formats:" << endl;
+    dump_keys(readers);
+    return;
+  } else {
+    read = i->second;
+  }
+  // Dispatch to function pair.
+  print(sys, read(sys));
+}
+
+} // namespace
+
+CAF_MAIN()


### PR DESCRIPTION
The new tool `gen-vast-slices` allows us to convert our log artifacts into table slices *once* while compiling `libvast_test`. The unit test than simply deserialize the slices instead of parsing them over and over again.