### PR TITLE
Implement actor-based FSM for query processing

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -95,6 +95,7 @@ set(libvast_sources
   src/system/node.cpp
   src/system/partition.cpp
   src/system/profiler.cpp
+  src/system/query_processor.cpp
   src/system/query_supervisor.cpp
   src/system/raft.cpp
   src/system/remote_command.cpp
@@ -272,6 +273,7 @@ set(tests
   test/system/key_value_store.cpp
   test/system/partition.cpp
   test/system/queries.cpp
+  test/system/query_processor.cpp
   test/system/query_supervisor.cpp
   test/system/replicated_store.cpp
   test/system/sink.cpp

--- a/libvast/src/system/query_processor.cpp
+++ b/libvast/src/system/query_processor.cpp
@@ -1,0 +1,111 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/system/query_processor.hpp"
+
+#include <caf/event_based_actor.hpp>
+#include <caf/skip.hpp>
+#include <caf/stateful_actor.hpp>
+
+#include "vast/expression.hpp"
+#include "vast/ids.hpp"
+#include "vast/logger.hpp"
+#include "vast/system/atoms.hpp"
+
+namespace vast::system {
+
+// -- constructors, destructors, and assignment operators ----------------------
+
+query_processor::query_processor(caf::event_based_actor* self)
+  : state_(idle), self_(self) {
+  // We might receive hits before the query ID arrives. Since we don't want to
+  // deal with races manually, we skip messages that arrive out of order until
+  // transitioning into the corresponding state.
+  self->set_default_handler(caf::skip);
+  behaviors_[idle].assign(
+    // Our default init state simply waits for a query to execute.
+    [=](expression& expr, const caf::actor& index) {
+      start(std::move(expr), index);
+    });
+  behaviors_[await_query_id].assign(
+    // Received from the INDEX after sending the query when leaving `idle`.
+    [=](const uuid& query_id, uint32_t total, uint32_t scheduled) {
+      query_id_ = query_id;
+      partitions_.received = 0;
+      partitions_.scheduled = scheduled;
+      partitions_.total = total;
+      transition_to(collect_hits);
+    });
+  behaviors_[collect_hits].assign(
+    // Received from EVALUATOR actors while generating query hits.
+    [=](const ids& hits) {
+      process_hits(hits);
+      // No transtion. We will receive a 'done' message after getting all hits.
+    },
+    [=](done_atom) {
+      partitions_.received += partitions_.scheduled;
+      process_end_of_hits();
+    });
+}
+
+query_processor::~query_processor() {
+  // nop
+}
+
+// -- convenience functions ----------------------------------------------------
+
+void query_processor::start(expression expr, caf::actor index) {
+  index_ = std::move(index);
+  self_->send(index_, std::move(expr));
+  transition_to(await_query_id);
+}
+
+void query_processor::request_more_hits(uint32_t n) {
+  VAST_DEBUG(self_, "asks the INDEX for more hits by scheduling", n,
+             "additional partitions");
+  VAST_ASSERT(n > 0);
+  VAST_ASSERT(partitions_.received + n <= partitions_.total);
+  partitions_.scheduled = n;
+  self_->send(index_, query_id_, n);
+}
+
+// -- state management ---------------------------------------------------------
+
+void query_processor::transition_to(state_name x) {
+  VAST_DEBUG(self_, "transitions from state", state_, "to state", x);
+  self_->become(behaviors_[x]);
+  state_ = x;
+}
+
+// -- implementation hooks -----------------------------------------------------
+
+void query_processor::process_hits(const ids&) {
+  // nop
+}
+
+void query_processor::process_end_of_hits() {
+  transition_to(idle);
+}
+
+// -- related functions --------------------------------------------------------
+
+std::string to_string(query_processor::state_name x) {
+  static constexpr const char* tbl[] = {
+    "idle",
+    "await_query_id",
+    "collect_hits",
+  };
+  return tbl[static_cast<size_t>(x)];
+}
+
+} // namespace vast::system

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -1,0 +1,112 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#define SUITE query_processor
+
+#include "vast/system/query_processor.hpp"
+
+#include "vast/test/test.hpp"
+
+#include "vast/test/fixtures/actor_system.hpp"
+
+#include "vast/concept/parseable/to.hpp"
+#include "vast/concept/parseable/vast/expression.hpp"
+#include "vast/concept/parseable/vast/uuid.hpp"
+#include "vast/ids.hpp"
+#include "vast/system/atoms.hpp"
+
+using namespace vast;
+
+namespace {
+
+constexpr std::string_view uuid_str = "423b45a1-c217-4f99-ba43-9e3fc3285cd3";
+
+constexpr std::string_view query_str = "#time < 1 week ago";
+
+struct mock_index_state {
+  static inline constexpr const char* name = "mock-index";
+};
+
+caf::behavior mock_index(caf::stateful_actor<mock_index_state>* self) {
+  return {[=](expression&) {
+    auto query_id = unbox(to<uuid>(uuid_str));
+    auto hdl = caf::actor_cast<caf::actor>(self->current_sender());
+    self->send(hdl, query_id, uint32_t{3}, uint32_t(7));
+    self->send(hdl, make_ids({1, 2, 4}));
+    self->send(hdl, make_ids({3, 5}));
+    self->send(hdl, system::done_atom::value);
+  }};
+}
+
+class mock_processor : public system::query_processor {
+public:
+  using super = query_processor;
+
+  mock_processor(caf::event_based_actor* self) : super(self) {
+    // nop
+  }
+
+  void transition_to(state_name x) override {
+    log.emplace_back(to_string(state_) + " -> " + to_string(x));
+    super::transition_to(x);
+  }
+
+  void process_hits(const ids& xs) override {
+    hits |= xs;
+  }
+
+  std::vector<std::string> log;
+  ids hits;
+};
+
+struct fixture : fixtures::deterministic_actor_system {
+  fixture() : query_id(unbox(to<uuid>(uuid_str))) {
+    index = sys.spawn(mock_index);
+    aut = sys.spawn([=](caf::stateful_actor<mock_processor>* self) {
+      return self->state.behavior();
+    });
+    sched.run();
+  }
+
+  mock_processor& mock_ref() {
+    return deref<caf::stateful_actor<mock_processor>>(aut).state;
+  }
+
+  uuid query_id;
+  caf::actor index;
+  caf::actor aut;
+};
+
+} // namespace
+
+FIXTURE_SCOPE(query_processor_tests, fixture)
+
+TEST(state transitions) {
+  std::vector<std::string> expected_log{
+    "idle -> await_query_id",
+    "await_query_id -> collect_hits",
+    "collect_hits -> idle",
+  };
+  self->send(aut, unbox(to<expression>(query_str)), index);
+  expect((expression, caf::actor), from(self).to(aut));
+  expect((expression), from(aut).to(index));
+  expect((uuid, uint32_t, uint32_t), from(index).to(aut));
+  expect((ids), from(index).to(aut));
+  expect((ids), from(index).to(aut));
+  expect((system::done_atom), from(index).to(aut));
+  CHECK_EQUAL(mock_ref().log, expected_log);
+  CHECK_EQUAL(mock_ref().hits, make_ids({{1, 6}}));
+  CHECK_EQUAL(mock_ref().state(), system::query_processor::idle);
+}
+
+FIXTURE_SCOPE_END()

--- a/libvast/vast/system/query_processor.hpp
+++ b/libvast/vast/system/query_processor.hpp
@@ -1,0 +1,163 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include <caf/behavior.hpp>
+#include <caf/fwd.hpp>
+
+#include "vast/fwd.hpp"
+#include "vast/uuid.hpp"
+
+namespace vast::system {
+
+/// A query processor takes a query and collects hits from the INDEX.
+/// Implementation hooks allow subtypes to configure how many hits are
+/// requested and how hits are processed. The query processor implements the
+/// following state machine:
+///
+/// ```
+///                    +----------------+
+///                    |                |
+///               +--->+      idle      |
+///               |    |                |
+///               |    +-------+--------+
+///               |            |
+///               |            | (run)
+///               |            v
+///               |    +-------+--------+
+///               |    |                |
+///               |    | await query id |
+///               |    |                |
+///               |    +-------+--------+
+///               |            |
+///               |            | (query_id, scheduled, total)
+///               |            |
+///               |            |      +------+
+///               |            |      |      |
+///               |            v      v      | (ids)
+///               |    +-------+------+-+    |
+///               |    |                +----+
+///               |    |  collect hits  |
+///               |    |                +<---+
+///               |    +-------+--------+    |
+///               |            |             |
+///               |            | (done)      |
+///               |            v             |
+///               |       XXXXXXXXXXXX       |
+///               |      XX request  XX      |
+///               +----+XX    more    XX+----+
+///                no    XX   hits?  XX   yes
+///                       XXXXXXXXXXXX
+/// ```
+class query_processor {
+public:
+  // -- member types -----------------------------------------------------------
+
+  enum state_name {
+    idle,
+    await_query_id,
+    collect_hits,
+  };
+
+  static constexpr size_t num_states = 3;
+
+  // -- constants --------------------------------------------------------------
+
+  /// Human-readable actor name for logging output.
+  static constexpr const char* name = "query-processor";
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  /// @warning Calls `set_default_handler(caf::skip)`.
+  query_processor(caf::event_based_actor* self);
+
+  virtual ~query_processor();
+
+  // -- convenience functions --------------------------------------------------
+
+  /// Sends the query `expr` to `index` and transitions from `idle` to
+  /// `await_query_id`.
+  /// @pre `state() == idle`
+  void start(expression expr, caf::actor index);
+
+  /// @pre `state() == collect_hits`
+  /// @pre `n > 0`
+  /// @pre `partitions_.received + n <= partitions_.total`
+  void request_more_hits(uint32_t n);
+
+  // -- properties -------------------------------------------------------------
+
+  /// @returns the current state.
+  state_name state() {
+    return state_;
+  }
+
+  /// @returns the current behavior.
+  caf::behavior& behavior() {
+    return behaviors_[state_];
+  }
+
+  /// @returns the behavior for state `x`.
+  caf::behavior& behavior(state_name x) {
+    return behaviors_[x];
+  }
+
+protected:
+  // -- state management -------------------------------------------------------
+
+  virtual void transition_to(state_name x);
+
+  // -- implementation hooks ---------------------------------------------------
+
+  /// Processes incoming hits from the INDEX.
+  virtual void process_hits(const ids& hits);
+
+  /// Processes incoming done messages. The default implementation always
+  /// transitions to the idle state.
+  virtual void process_end_of_hits();
+
+  // -- member variables -------------------------------------------------------
+
+  /// Stores the name of the current state.
+  state_name state_;
+
+  /// Stores a behavior for each named state.
+  std::array<caf::behavior, num_states> behaviors_;
+
+  /// Points to the actor that runs this FSM.
+  caf::event_based_actor* self_;
+
+  /// Our query ID for collecting more hits.
+  uuid query_id_;
+
+  /// Our INDEX for querying and collecting more hits.
+  caf::actor index_;
+
+  /// Keeps track of how many partitions were processed.
+  struct {
+    uint32_t received;
+    uint32_t scheduled;
+    uint32_t total;
+  } partitions_;
+};
+
+// -- related functions --------------------------------------------------------
+
+std::string to_string(query_processor::state_name x);
+
+} // namespace vast::system


### PR DESCRIPTION
Adds a QUERY_PROCESSOR actor that implements an FSM and allows derived actors to extend the FSM via implementation hooks. For example, derived actors can override `transition_to` for adding entry/exit actions.

This is cherry-picked and squashed from https://github.com/vast-io/vast/pull/461. Further, two review comments were open there:

> There seems to be an invalid transition possible: after going through `collect hits` -> `request more hits` -> `no`, I end up in `idle`. But I would not go into `await query id` from there again, right?

The default handler message handlers in `idle` accept an `expression` with an actor handle to the INDEX to trigger transition to the next state. However, derived actors can replace the message handlers to whatever makes sense.

> >   /// @warning Calls `set_default_handler(caf::skip)`.
> Why is this a warning?

I documented this as a warning, because anything that messes with default handlers can cause serious trouble and should therefore be documented very, very prominently. A simple `@note` is too easily overlooked in my opinion.