### PR TITLE
Add hidden command for sending atoms to actors

### DIFF
--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -224,9 +224,11 @@ void subcommand_helptext(const command& cmd, std::ostream& out) {
   out << "subcommands:\n";
   auto fs = field_size(cmd.children);
   for (auto& child : cmd.children) {
-    out << "  ";
-    out.width(fs);
-    out << child->name << "  " << child->description << '\n';
+    if (child->visible) {
+      out << "  ";
+      out.width(fs);
+      out << child->name << "  " << child->description << '\n';
+    }
   }
 }
 
@@ -252,11 +254,12 @@ void nested_helptext(const command& cmd, std::ostream& out) {
 void helptext(const command& cmd, std::ostream& out) {
   // Make sure fields are filled left-to-right.
   out << std::left;
-  // Dispatch based on whether or nood cmd has children.
-  if (cmd.children.empty())
-    flat_helptext(cmd, out);
-  else
+  // Dispatch based on whether or not cmd has visible children.
+  auto visible = [](const auto& cmd) { return cmd->visible; };
+  if (std::any_of(cmd.children.begin(), cmd.children.end(), visible))
     nested_helptext(cmd, out);
+  else
+    flat_helptext(cmd, out);
 }
 
 std::string helptext(const command& cmd) {

--- a/libvast/src/system/default_application.cpp
+++ b/libvast/src/system/default_application.cpp
@@ -54,6 +54,9 @@ default_application::default_application() {
   add(remote_command, "peer", "peers with another node", opts());
   add(remote_command, "status", "shows various properties of a topology",
       opts());
+  auto send_cmd = add(remote_command, "send",
+                      "sends a message to a registered actor", opts());
+  send_cmd->visible = false;
   // Add "import" command and its children.
   import_ = add(nullptr, "import", "imports data from STDIN or file",
                 opts()

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -62,7 +62,7 @@ auto make_error_msg(ec code, std::string msg) {
   return caf::make_message(make_error(code, std::move(msg)));
 }
 
-// Stop the node and exit the process
+// Stop the node and exit the process.
 caf::message stop_command(const command&, caf::actor_system&, caf::settings&,
                           command::argument_iterator,
                           command::argument_iterator) {
@@ -70,6 +70,27 @@ caf::message stop_command(const command&, caf::actor_system&, caf::settings&,
   // an illegal instruction interrupt.
   caf::anon_send_exit(this_node, exit_reason::user_shutdown);
   return caf::none;
+}
+
+// Sends an atom to a registered actor. Blocks until the actor responds.
+caf::message send_command(const command&, caf::actor_system& sys,
+                          caf::settings&, command::argument_iterator first,
+                          command::argument_iterator last) {
+  // Expect exactly two arguments.
+  if (std::distance(first, last) != 2)
+    return make_error_msg(ec::syntax_error,
+                          "expected two arguments: receiver and message atom");
+  // Get destination actor from the registry.
+  auto dst = sys.registry().get(caf::atom_from_string(*first));
+  if (dst == nullptr)
+    return make_error_msg(ec::syntax_error,
+                          "registry contains no actor named " + *first);
+  // Dispatch to destination.
+  auto f = caf::make_function_view(caf::actor_cast<caf::actor>(dst));
+  if (auto res = f(caf::atom_from_string(*(first + 1))))
+    return std::move(*res);
+  else
+    return caf::make_message(std::move(res.error()));
 }
 
 // Tries to establish peering to another node.
@@ -348,6 +369,7 @@ void node_state::init(std::string init_name, path init_dir) {
           opts());
   cmd.add(stop_command, "stop", "stops the node", opts());
   cmd.add(kill_command, "kill", "terminates a component", opts());
+  cmd.add(send_command, "send", "sends atom to a registered actor", opts());
   cmd.add(peer_command, "peer", "peers with another node", opts());
   // Add spawn commands.
   auto sp = cmd.add(nullptr, "spawn", "creates a new component", opts());

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -57,6 +57,8 @@ public:
 
   children_list children;
 
+  bool visible = true;
+
   // -- factory functions ------------------------------------------------------
 
   /// Creates a config option set pre-initialized with a help option.


### PR DESCRIPTION
For some actors, we need a way to trigger it deterministically for testing. However, such a `send` command should not be visible to the user (i.e. omitted in helptext, manual, etc.) and reserved for internal use only.