### PR TITLE
Allow adding new components to the NODE

### DIFF
--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -134,12 +134,12 @@ const command& root(const command& cmd) {
 }
 
 std::string full_name(const command& cmd) {
-  if (cmd.parent == nullptr)
-    return "";
   std::string result{cmd.name};
-  for (auto ptr = cmd.parent; ptr->parent != nullptr; ptr = ptr->parent) {
-    result.insert(result.begin(), ' ');
-    result.insert(result.begin(), ptr->name.begin(), ptr->name.end());
+  for (auto ptr = cmd.parent; ptr != nullptr; ptr = ptr->parent) {
+    if (!ptr->name.empty()) {
+      result.insert(result.begin(), ' ');
+      result.insert(result.begin(), ptr->name.begin(), ptr->name.end());
+    }
   }
   return result;
 }

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -134,8 +134,10 @@ const command& root(const command& cmd) {
 }
 
 std::string full_name(const command& cmd) {
+  if (cmd.parent == nullptr)
+    return "";
   std::string result{cmd.name};
-  for (auto ptr = cmd.parent; ptr != nullptr; ptr = ptr->parent) {
+  for (auto ptr = cmd.parent; ptr->parent != nullptr; ptr = ptr->parent) {
     result.insert(result.begin(), ' ');
     result.insert(result.begin(), ptr->name.begin(), ptr->name.end());
   }

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -270,6 +270,7 @@ caf::message kill_command(const command&, caf::actor_system&, caf::settings&,
 template <maybe_actor (*Fun)(local_actor*, spawn_arguments&)>
 node_state::component_factory lift_component_factory() {
   return [](node_actor* self, spawn_arguments& args) {
+    // Delegate to lifted function.
     return Fun(self, args);
   };
 }

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -180,9 +180,7 @@ caf::expected<caf::actor> spawn_component(const command& cmd,
   VAST_ASSERT(cmd.parent != nullptr);
   using caf::atom_uint;
   auto self = this_node;
-  auto key = std::pair{caf::atom_from_string(cmd.name),
-                       caf::atom_from_string(cmd.parent->name)};
-  auto i = node_state::factories.find(key);
+  auto i = node_state::factories.find(full_name(cmd));
   if (i == node_state::factories.end())
     return make_error(ec::unspecified, "invalid spawn component");
   return i->second(self, args);
@@ -281,28 +279,27 @@ node_state::component_factory lift_component_factory() {
   return Fun;
 }
 
-#define ADD(parent, cmd, fun)                                                  \
-  result.emplace(std::pair{caf::atom(parent), caf::atom(cmd)},                 \
-                 lift_component_factory<fun>())
+#define ADD(cmd_full_name, fun)                                                \
+  result.emplace(cmd_full_name, lift_component_factory<fun>())
 
 auto make_factories() {
   node_state::named_component_factories result;
-  ADD("spawn", "accountant", spawn_accountant);
-  ADD("spawn", "archive", spawn_archive);
-  ADD("spawn", "exporter", spawn_exporter);
-  ADD("spawn", "importer", spawn_importer);
-  ADD("spawn", "index", spawn_index);
-  ADD("spawn", "consensus", spawn_consensus);
-  ADD("spawn", "profiler", spawn_profiler);
-  ADD("source", "pcap", spawn_pcap_source);
-  ADD("source", "zeek", spawn_zeek_source);
-  ADD("source", "mrt", spawn_mrt_source);
-  ADD("source", "bgpdump", spawn_bgpdump_source);
-  ADD("sink", "pcap", spawn_pcap_sink);
-  ADD("sink", "zeek", spawn_zeek_sink);
-  ADD("sink", "csv", spawn_csv_sink);
-  ADD("sink", "ascii", spawn_ascii_sink);
-  ADD("sink", "json", spawn_json_sink);
+  ADD("spawn accountant", spawn_accountant);
+  ADD("spawn archive", spawn_archive);
+  ADD("spawn exporter", spawn_exporter);
+  ADD("spawn importer", spawn_importer);
+  ADD("spawn index", spawn_index);
+  ADD("spawn consensus", spawn_consensus);
+  ADD("spawn profiler", spawn_profiler);
+  ADD("spawn source pcap", spawn_pcap_source);
+  ADD("spawn source zeek", spawn_zeek_source);
+  ADD("spawn source mrt", spawn_mrt_source);
+  ADD("spawn source bgpdump", spawn_bgpdump_source);
+  ADD("spawn sink pcap", spawn_pcap_sink);
+  ADD("spawn sink zeek", spawn_zeek_sink);
+  ADD("spawn sink csv", spawn_csv_sink);
+  ADD("spawn sink ascii", spawn_ascii_sink);
+  ADD("spawn sink json", spawn_json_sink);
   return result;
 }
 

--- a/libvast/vast/system/node.hpp
+++ b/libvast/vast/system/node.hpp
@@ -39,13 +39,8 @@ struct node_state {
   /// Spawns a component (actor) for the NODE with given spawn arguments.
   using component_factory = maybe_actor (*)(node_actor*, spawn_arguments&);
 
-  /// Identifies a command and its parent by name. The two names in conjunction
-  /// uniquely identify a component, e.g., by disambiguating "import pcap" from
-  /// "export pcap".
-  using atom_pair = std::pair<caf::atom_value, caf::atom_value>;
-
   /// Maps command names to component factories.
-  using named_component_factories = std::map<atom_pair, component_factory>;
+  using named_component_factories = std::map<std::string, component_factory>;
 
   // -- constructors, destructors, and assignment operators --------------------
 
@@ -64,7 +59,7 @@ struct node_state {
   tracker_type tracker;
 
   /// Stores how many components per label are active.
-  std::unordered_map<std::string, size_t> labels;
+  std::map<std::string, size_t> labels;
 
   /// Gives the actor a recognizable name in log files.
   std::string name = "node";


### PR DESCRIPTION
The NODE actor in VAST starts all components. However, we need a way to
add new components as extensions. This set of changes adds a static map
to the NODE actor's state that downstream projects can extend during
startup.