### PR TITLE
Allow query processors to block end-of-hits transition

### DIFF
--- a/libvast/vast/system/query_processor.hpp
+++ b/libvast/vast/system/query_processor.hpp
@@ -122,6 +122,12 @@ protected:
 
   virtual void transition_to(state_name x);
 
+  /// Blocks or unblocks the processor from handling the final 'done' message
+  /// from the INDEX.
+  void block_end_of_hits(bool value) {
+    block_end_of_hits_ = value;
+  }
+
   // -- implementation hooks ---------------------------------------------------
 
   /// Processes incoming hits from the INDEX.
@@ -154,6 +160,10 @@ protected:
     uint32_t scheduled;
     uint32_t total;
   } partitions_;
+
+  /// Allows derived classes to block the processor from handling the final
+  /// 'done' message from the INDEX until processing other messages first.
+  bool block_end_of_hits_;
 };
 
 // -- related functions --------------------------------------------------------


### PR DESCRIPTION
Actors such as the EXPORTER and the COUNTER need a way to tell the underlying FSM to not transition out of `collect_hits` when receiving `done` from the INDEX until processing other messages first (usually messages from the ARCHIVE).