### PR TITLE
Fix behavior of numeric parser for partial input

### DIFF
--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -35,6 +35,7 @@
 #include "vast/si_literals.hpp"
 
 using namespace std::string_literals;
+using namespace std::string_view_literals;
 using namespace vast;
 using namespace vast::parser_literals;
 
@@ -422,11 +423,9 @@ TEST(signed integral with digit constraints) {
   constexpr auto max = 4;
   constexpr auto min = 2;
   auto p = integral_parser<int, max, min>{};
+  int x;
   MESSAGE("not enough digits");
   CHECK(!p("1"));
-  MESSAGE("too many digits");
-  CHECK(!p("12345"));
-  int x;
   MESSAGE("within range");
   CHECK(p("12", x));
   CHECK_EQUAL(x, 12);
@@ -438,6 +437,14 @@ TEST(signed integral with digit constraints) {
   CHECK(!p("-1"));
   CHECK(p("-1234", x));
   CHECK_EQUAL(x, -1234);
+  MESSAGE("partial match");
+  auto str = "12345"sv;
+  auto f = str.begin();
+  auto l = str.end();
+  CHECK(p.parse(f, l, x));
+  REQUIRE(f + 1 == l);
+  CHECK_EQUAL(*f, '5');
+  CHECK_EQUAL(x, 1234);
 }
 
 TEST(real) {

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -437,7 +437,7 @@ TEST(signed integral with digit constraints) {
   CHECK(!p("-1"));
   CHECK(p("-1234", x));
   CHECK_EQUAL(x, -1234);
-  MESSAGE("partial match");
+  MESSAGE("partial match with additional digit");
   auto str = "12345"sv;
   auto f = str.begin();
   auto l = str.end();
@@ -445,6 +445,14 @@ TEST(signed integral with digit constraints) {
   REQUIRE(f + 1 == l);
   CHECK_EQUAL(*f, '5');
   CHECK_EQUAL(x, 1234);
+  MESSAGE("partial match with non-digits character");
+  str = "6789x"sv;
+  f = str.begin();
+  l = str.end();
+  CHECK(p.parse(f, l, x));
+  REQUIRE(f + 1 == l);
+  CHECK_EQUAL(*f, 'x');
+  CHECK_EQUAL(x, 6789);
 }
 
 TEST(real) {

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -446,13 +446,13 @@ TEST(signed integral with digit constraints) {
   CHECK_EQUAL(*f, '5');
   CHECK_EQUAL(x, 1234);
   MESSAGE("partial match with non-digits character");
-  str = "6789x"sv;
+  str = "678x"sv;
   f = str.begin();
   l = str.end();
   CHECK(p.parse(f, l, x));
   REQUIRE(f + 1 == l);
   CHECK_EQUAL(*f, 'x');
-  CHECK_EQUAL(x, 6789);
+  CHECK_EQUAL(x, 678);
 }
 
 TEST(real) {

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -397,61 +397,47 @@ TEST(bool) {
   CHECK(p0(str));
 }
 
-TEST(integral) {
-  MESSAGE("signed integers");
-  auto str = "-1024"s;
-  auto p0 = integral_parser<int>{};
-  int n;
-  auto f = str.begin();
-  auto l = str.end();
-  CHECK(p0(f, l, n));
-  CHECK(n == -1024);
-  CHECK(f == l);
-  f = str.begin() + 1;
-  n = 0;
-  CHECK(p0(f, l, n));
-  CHECK(n == 1024);
-  CHECK(f == l);
-  str[0] = '+';
-  f = str.begin();
-  n = 0;
-  CHECK(p0(f, l, n));
-  CHECK(n == 1024);
-  CHECK(f == l);
+TEST(signed integral) {
+  auto p = integral_parser<int>{};
+  int x;
+  CHECK(p("-1024", x));
+  CHECK_EQUAL(x, -1024);
+  CHECK(p("1024", x));
+  CHECK_EQUAL(x, 1024);
+  CHECK(p("12.34", x));
+  CHECK_EQUAL(x, 12);
+}
 
-  MESSAGE("unsigned integers");
-  auto p1 = integral_parser<unsigned>{};
-  unsigned u;
-  f = str.begin() + 1; // no sign
-  CHECK(p1(f, l, u));
-  CHECK(u == 1024);
-  CHECK(f == l);
-  f = str.begin() + 1;
-  u = 0;
-  CHECK(p1(f, l, u));
-  CHECK(n == 1024);
-  CHECK(f == l);
+TEST(unsigned integral) {
+  auto p = integral_parser<unsigned>{};
+  unsigned x;
+  CHECK(!p("-1024"));
+  CHECK(p("1024", x));
+  CHECK_EQUAL(x, 1024u);
+  CHECK(p("12.34", x));
+  CHECK_EQUAL(x, 12u);
+}
 
-  MESSAGE("digit constraints");
-  auto p2 = integral_parser<int, 4, 2>{};
-  n = 0;
-  str[0] = '-';
-  f = str.begin();
-  CHECK(p2(f, l, n));
-  CHECK(n == -1024);
-  CHECK(f == l);
-  // Not enough digits.
-  str = "-1";
-  f = str.begin();
-  l = str.end();
-  CHECK(!p2(f, l, n));
-  CHECK(f == str.begin());
-  // Too many digits.
-  str = "-123456";
-  f = str.begin();
-  l = str.end();
-  CHECK(!p2(f, l, unused));
-  CHECK(f == str.begin());
+TEST(signed integral with digit constraints) {
+  constexpr auto max = 4;
+  constexpr auto min = 2;
+  auto p = integral_parser<int, max, min>{};
+  MESSAGE("not enough digits");
+  CHECK(!p("1"));
+  MESSAGE("too many digits");
+  CHECK(!p("12345"));
+  int x;
+  MESSAGE("within range");
+  CHECK(p("12", x));
+  CHECK_EQUAL(x, 12);
+  CHECK(p("123", x));
+  CHECK_EQUAL(x, 123);
+  CHECK(p("1234", x));
+  CHECK_EQUAL(x, 1234);
+  MESSAGE("sign doesn't count as digit");
+  CHECK(!p("-1"));
+  CHECK(p("-1234", x));
+  CHECK_EQUAL(x, -1234);
 }
 
 TEST(real) {

--- a/libvast/vast/concept/parseable/numeric/integral.hpp
+++ b/libvast/vast/concept/parseable/numeric/integral.hpp
@@ -53,16 +53,12 @@ struct integral_parser
 
   template <class Iterator, class Attribute, class F>
   static auto accumulate(Iterator& f, const Iterator& l, Attribute& a, F acc) {
-    int digits = 0;
-    a = 0;
-    while (f != l && isdigit(*f)) {
-      if (++digits > MaxDigits)
-        return false;
-      acc(a, *f++ - '0');
-    }
-    if (digits < MinDigits)
+    if (f == l)
       return false;
-    return true;
+    int digits = 0;
+    for (a = 0; isdigit(*f) && f != l && digits < MaxDigits; ++f, ++digits)
+      acc(a, *f - '0');
+    return digits >= MinDigits;
   }
 
   template <class Iterator>


### PR DESCRIPTION
Previously, integral parsers with a maximum digit specification failed when the input contained further digits. This is no longer considered a failure: the parser returns successfully with whatever is has parsed until it reached its digit limit.