### PR TITLE
Fix suricata fileinfo schema

### DIFF
--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -175,7 +175,6 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     auto layout = selector_(*xs);
     if (!layout)
       continue;
-    VAST_INFO(this, "got layout", *layout);
     auto bptr = builder(*layout);
     if (bptr == nullptr)
       return make_error(ec::parse_error, "unable to get a builder");

--- a/libvast/vast/format/json/suricata.hpp
+++ b/libvast/vast/format/json/suricata.hpp
@@ -107,7 +107,7 @@ struct suricata {
                                {"state", string_type{}},
                                {"md5", string_type{}},
                                {"sha1", string_type{}},
-                               {"sha256", count_type{}},
+                               {"sha256", string_type{}},
                                {"stored", boolean_type{}},
                                {"file_id", count_type{}},
                                {"size", count_type{}},


### PR DESCRIPTION
This additionally removes an overly noisy logging statement.