### PR TITLE
Try timestamp before timespan in data parser

### DIFF
--- a/libvast/vast/concept/parseable/vast/data.hpp
+++ b/libvast/vast/concept/parseable/vast/data.hpp
@@ -48,8 +48,8 @@ private:
     auto x = ws >> p >> ws;
     auto kvp = x >> "->" >> x;
     // clang-format off
-    p = parsers::timespan
-      | parsers::timestamp
+    p = parsers::timestamp
+      | parsers::timespan
       | parsers::net
       | parsers::port
       | parsers::addr


### PR DESCRIPTION
This fixes cases where "*timespan* ago" would be parsed incorrectly.