### PR TITLE
Adjust default name of state directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🔄 The default directory name for persistent state changed from `vast` to
+  `vast.db`. This makes it possible to run `./vast` in the current directory
+  without having to specify a different state directory on the command line.
+
 - 🔄 Nested types are from now on accessed by the `.`-syntax. This means
   VAST now has a unified syntax to select nested types and fields.
   For example, what used to be `zeek::http` is now just `zeek.http`.

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -213,7 +213,7 @@ constexpr std::string_view endpoint = ":42000";
 constexpr std::string_view node_id = "node";
 
 /// Path to persistent state.
-constexpr std::string_view directory = "vast";
+constexpr std::string_view directory = "vast.db";
 
 /// The default table slice type.
 constexpr caf::atom_value table_slice_type = caf::atom("default");


### PR DESCRIPTION
By using a different name than the VAST executable `vast`, we can now run `./vast` in the same directory where a state directory exists as well.