### PR TITLE
Implement 2-pass parsing of command line

### DIFF
--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -104,14 +104,13 @@ caf::error parse(command::invocation& result, const command& cmd,
 }
 
 caf::expected<command::invocation> parse(const command& root,
-                                        command::argument_iterator first,
-                                        command::argument_iterator last) {
+                                         command::argument_iterator first,
+                                         command::argument_iterator last) {
   command::invocation result;
   if (auto err = parse(result, root, first, last))
     return err;
   return result;
 }
-
 
 caf::message run(command::invocation& invocation, caf::actor_system& sys) {
   auto& cmd = *invocation.target;
@@ -151,8 +150,7 @@ caf::message run(const command& cmd, caf::actor_system& sys,
 caf::message run(const command& cmd, caf::actor_system& sys,
                  caf::settings predefined_options,
                  const std::vector<std::string>& args) {
-  return run(cmd, sys, std::move(predefined_options), args.begin(),
-             args.end());
+  return run(cmd, sys, std::move(predefined_options), args.begin(), args.end());
 }
 
 const command& root(const command& cmd) {

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -447,7 +447,7 @@ caf::behavior node(node_actor* self, std::string id, path dir) {
       this_node = self;
       // Note: several commands make a response promise. In this case, they
       // return an empty message that has no effect when returning it.
-      return run(self->state.cmd, self->system(), options, cli);
+      return run(self->state.cmd, self->system(), std::move(options), cli);
     },
     [=](const std::vector<std::string>& cli) {
       VAST_DEBUG(self, "got command", cli);

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -75,6 +75,34 @@ public:
     caf::config_option_set xs_;
   };
 
+  /// Wraps invocation of a single command for separating the parsing of
+  /// program argument from running the command.
+  struct invocation {
+    // -- member variables -----------------------------------------------------
+
+    /// Stores user-defined program options.
+    caf::settings options;
+
+    /// Points to the scheduled command.
+    const command* target = nullptr;
+
+    /// Points to the first CLI argument.
+    argument_iterator first;
+
+    /// Points past-the-end of CLI arguments.
+    argument_iterator last;
+
+    // -- mutators -------------------------------------------------------------
+
+    /// Sets the members `target`, `first`, and `last`.
+    void assign(const command* cmd, argument_iterator first,
+                argument_iterator last) {
+      target = cmd;
+      this->first = first;
+      this->last = last;
+    }
+  };
+
   // -- member variables -------------------------------------------------------
 
   command* parent = nullptr;
@@ -115,6 +143,18 @@ public:
   }
 };
 
+/// Parses all program arguments without running the command.
+/// @returns an error for malformed input, `none` otherwise.
+/// @relates command
+caf::expected<command::invocation> parse(const command& root,
+                                        command::argument_iterator first,
+                                        command::argument_iterator last);
+
+/// Runs the command and blocks until execution completes.
+/// @returns a type-erased result or a wrapped `caf::error`.
+/// @relates command
+caf::message run(command::invocation& invocation, caf::actor_system& sys);
+
 /// Runs the command and blocks until execution completes.
 /// @returns a type-erased result or a wrapped `caf::error`.
 /// @relates command
@@ -132,14 +172,16 @@ caf::message run(const command& cmd, caf::actor_system& sys,
 /// @returns a type-erased result or a wrapped `caf::error`.
 /// @relates command
 caf::message run(const command& cmd, caf::actor_system& sys,
-                 caf::settings& options, command::argument_iterator first,
+                 caf::settings predefined_options,
+                 command::argument_iterator first,
                  command::argument_iterator last);
 
 /// Runs the command and blocks until execution completes.
 /// @returns a type-erased result or a wrapped `caf::error`.
 /// @relates command
 caf::message run(const command& cmd, caf::actor_system& sys,
-                 caf::settings& options, const std::vector<std::string>& args);
+                 caf::settings predefined_options,
+                 const std::vector<std::string>& args);
 
 /// Traverses the command hierarchy until finding the root.
 /// @returns the root command.

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -147,8 +147,8 @@ public:
 /// @returns an error for malformed input, `none` otherwise.
 /// @relates command
 caf::expected<command::invocation> parse(const command& root,
-                                        command::argument_iterator first,
-                                        command::argument_iterator last);
+                                         command::argument_iterator first,
+                                         command::argument_iterator last);
 
 /// Runs the command and blocks until execution completes.
 /// @returns a type-erased result or a wrapped `caf::error`.

--- a/libvast/vast/system/default_configuration.hpp
+++ b/libvast/vast/system/default_configuration.hpp
@@ -24,7 +24,7 @@ namespace vast::system {
 
 struct default_configuration : system::configuration {
   default_configuration(std::string application_name);
-  caf::expected<path> setup_log_file(const path& base_dir);
+  caf::error setup_log_file();
   caf::error merge_root_options(system::application& app);
   void merge_settings(const caf::settings& from, caf::settings& to);
 

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -64,7 +64,15 @@ int main(int argc, char** argv) {
     render_error(app, invocation.error(), std::cerr);
     return EXIT_FAILURE;
   }
+  if (get_or(invocation->options, "help", false)) {
+    helptext(*invocation->target, std::cerr);
+    return EXIT_SUCCESS;
+  }
   // Initialize actor system (and thereby CAF's logger).
+  if (auto err = cfg.setup_log_file()) {
+    std::cerr << "failed to setup log file: " << to_string(err) << std::endl;
+    return EXIT_FAILURE;
+  }
   caf::actor_system sys{cfg};
   // Dispatch to root command.
   auto result = run(*invocation, sys);


### PR DESCRIPTION
Also fixes the weird behavior that `vast help` creates a directory [ch4976].