### PR TITLE
Report iterator position with command invocation

### DIFF
--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -113,9 +113,9 @@ command::invocation parse(const command& root, command::argument_iterator first,
 }
 
 caf::message run(command::invocation& invocation, caf::actor_system& sys) {
-  auto& cmd = *invocation.target;
   if (!invocation)
     return caf::make_message(invocation.error);
+  auto& cmd = *invocation.target;
   if (get_or(invocation.options, "help", false)) {
     helptext(cmd, std::cerr);
     return caf::none;

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -63,7 +63,8 @@ caf::error parse(command::invocation& result, const command& cmd,
   bool has_subcommand;
   switch(state) {
     default:
-      return make_error(ec::unrecognized_option, full_name(cmd), *position);
+      return make_error(ec::unrecognized_option, full_name(cmd), *position,
+                        to_string(state));
     case caf::pec::success:
       has_subcommand = false;
       break;
@@ -103,17 +104,18 @@ caf::error parse(command::invocation& result, const command& cmd,
   return parse(result, **i, position + 1, last);
 }
 
-caf::expected<command::invocation> parse(const command& root,
-                                         command::argument_iterator first,
-                                         command::argument_iterator last) {
+command::invocation parse(const command& root, command::argument_iterator first,
+                          command::argument_iterator last) {
   command::invocation result;
   if (auto err = parse(result, root, first, last))
-    return err;
+    result.error = std::move(err);
   return result;
 }
 
 caf::message run(command::invocation& invocation, caf::actor_system& sys) {
   auto& cmd = *invocation.target;
+  if (!invocation)
+    return caf::make_message(invocation.error);
   if (get_or(invocation.options, "help", false)) {
     helptext(cmd, std::cerr);
     return caf::none;
@@ -125,10 +127,8 @@ caf::message run(command::invocation& invocation, caf::actor_system& sys) {
 caf::message run(const command& cmd, caf::actor_system& sys,
                  command::argument_iterator first,
                  command::argument_iterator last) {
-  if (auto invocation = parse(cmd, first, last))
-    return run(*invocation, sys);
-  else
-    return caf::make_message(std::move(invocation.error()));
+  auto invocation = parse(cmd, first, last);
+  return run(invocation, sys);
 }
 
 caf::message run(const command& cmd, caf::actor_system& sys,

--- a/libvast/test/command.cpp
+++ b/libvast/test/command.cpp
@@ -56,10 +56,9 @@ struct fixture {
     options.clear();
     std::vector<std::string> xs;
     caf::split(xs, str, ' ', caf::token_compress_on);
-    if (auto res = parse(root, xs.begin(), xs.end()))
-      invocation = std::move(*res);
-    else
-      return std::move(res.error());
+    invocation = parse(root, xs.begin(), xs.end());
+    if (invocation.error)
+      return std::move(invocation.error);
     auto result = run(invocation, sys);
     if (result.empty())
       return caf::none;

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -92,6 +92,11 @@ public:
     /// Points past-the-end of CLI arguments.
     argument_iterator last;
 
+    /// Stores any error that occurred while parsing the CLI. When this error
+    /// is not default-constructed, `first` points to the CLI position where
+    /// the error occurred.
+    caf::error error;
+
     // -- mutators -------------------------------------------------------------
 
     /// Sets the members `target`, `first`, and `last`.
@@ -100,6 +105,20 @@ public:
       target = cmd;
       this->first = first;
       this->last = last;
+    }
+
+    // -- mutators -------------------------------------------------------------
+
+    /// @returns `true` when it is safe to call `run` on this object, `false`
+    /// otherwise.
+    explicit operator bool() const {
+      return !error;
+    }
+
+    /// @returns `true` when `error` is not default-constructed, `false`
+    /// otherwise.
+    bool operator!() const {
+      return static_cast<bool>(error);
     }
   };
 
@@ -146,9 +165,8 @@ public:
 /// Parses all program arguments without running the command.
 /// @returns an error for malformed input, `none` otherwise.
 /// @relates command
-caf::expected<command::invocation> parse(const command& root,
-                                         command::argument_iterator first,
-                                         command::argument_iterator last);
+command::invocation parse(const command& root, command::argument_iterator first,
+                          command::argument_iterator last);
 
 /// Runs the command and blocks until execution completes.
 /// @returns a type-erased result or a wrapped `caf::error`.

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -61,11 +61,11 @@ int main(int argc, char** argv) {
   auto invocation = parse(app.root, cfg.command_line.begin(),
                           cfg.command_line.end());
   if (!invocation) {
-    render_error(app, invocation.error(), std::cerr);
+    render_error(app, invocation.error, std::cerr);
     return EXIT_FAILURE;
   }
-  if (get_or(invocation->options, "help", false)) {
-    helptext(*invocation->target, std::cerr);
+  if (get_or(invocation.options, "help", false)) {
+    helptext(*invocation.target, std::cerr);
     return EXIT_SUCCESS;
   }
   // Initialize actor system (and thereby CAF's logger).
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
   }
   caf::actor_system sys{cfg};
   // Dispatch to root command.
-  auto result = run(*invocation, sys);
+  auto result = run(invocation, sys);
   if (result.match_elements<caf::error>()) {
     render_error(app, result.get_as<caf::error>(0), std::cerr);
     return EXIT_FAILURE;


### PR DESCRIPTION
In case of parsing of command fails, we still need the original iterator position to figure out *where* things went wrong. This set of changes puts the error state into the `invocation` for this purpose.