### PR TITLE
Allow writers to consume batches of events

### DIFF
--- a/libvast/src/format/writer.cpp
+++ b/libvast/src/format/writer.cpp
@@ -13,10 +13,19 @@
 
 #include "vast/format/writer.hpp"
 
+#include "vast/event.hpp"
+
 namespace vast::format {
 
 writer::~writer() {
   // nop
+}
+
+caf::error writer::write(const std::vector<event>& xs) {
+  for (auto& x : xs)
+    if (auto res = write(x); !res)
+      return res.error();
+  return caf::none;
 }
 
 caf::expected<void> writer::flush() {

--- a/libvast/test/system/sink.cpp
+++ b/libvast/test/system/sink.cpp
@@ -28,7 +28,7 @@ FIXTURE_SCOPE(sink_tests, fixtures::actor_system_and_events)
 TEST(zeek sink) {
   MESSAGE("constructing a sink");
   format::zeek::writer writer{directory};
-  auto snk = self->spawn(sink<format::zeek::writer>, std::move(writer), 0u);
+  auto snk = self->spawn(sink<format::zeek::writer>, std::move(writer), 20u);
   MESSAGE("sending events");
   self->send(snk, zeek_conn_log);
   MESSAGE("shutting down");

--- a/libvast/vast/format/pcap.hpp
+++ b/libvast/vast/format/pcap.hpp
@@ -141,6 +141,8 @@ public:
 
   ~writer();
 
+  using format::writer::write;
+
   caf::expected<void> write(const event& e) override;
 
   caf::expected<void> flush() override;

--- a/libvast/vast/format/printer_writer.hpp
+++ b/libvast/vast/format/printer_writer.hpp
@@ -37,6 +37,8 @@ public:
     : out_{std::move(out)} {
   }
 
+  using format::writer::write;
+
   expected<void> write(const event& e) override {
     auto i = std::ostreambuf_iterator<char>(*out_);
     if (!printer_.print(i, e))

--- a/libvast/vast/format/writer.hpp
+++ b/libvast/vast/format/writer.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <caf/expected.hpp>
 
 #include "vast/fwd.hpp"
@@ -28,6 +30,11 @@ public:
   /// @param x The event to write.
   /// @returns `caf::none` on success.
   virtual caf::expected<void> write(const event& x)  = 0;
+
+  /// Processes a batch of events.
+  /// @param xs The events to write.
+  /// @returns `caf::none` on success.
+  virtual caf::error write(const std::vector<event>& xs);
 
   /// Called periodically to flush state.
   /// @returns `caf::none` on success.

--- a/libvast/vast/format/zeek.hpp
+++ b/libvast/vast/format/zeek.hpp
@@ -277,6 +277,8 @@ public:
   /// @param dir The path where to write the log file(s) to.
   writer(path dir);
 
+  using format::writer::write;
+
   expected<void> write(const event& e) override;
 
   expected<void> flush() override;

--- a/libvast/vast/system/sink.hpp
+++ b/libvast/vast/system/sink.hpp
@@ -72,6 +72,9 @@ caf::behavior sink(caf::stateful_actor<sink_state<Writer>>* self,
   if (max_events > 0) {
     VAST_DEBUG(self, "caps event export at", max_events, "events");
     st.max_events = max_events;
+  } else {
+    // Interpret 0 as infinite.
+    st.max_events = std::numeric_limits<uint64_t>::max();
   }
   self->set_exit_handler(
     [=](const caf::exit_msg& msg) {

--- a/libvast/vast/system/sink.hpp
+++ b/libvast/vast/system/sink.hpp
@@ -80,26 +80,35 @@ caf::behavior sink(caf::stateful_actor<sink_state<Writer>>* self,
     }
   );
   return {
-    [=](const std::vector<event>& xs) {
+    [=](std::vector<event>& xs) {
       VAST_DEBUG(self, "got:", xs.size(), "events from",
                  self->current_sender());
       auto& st = self->state;
+      auto reached_max_events = [&] {
+        VAST_INFO(self, "reached max_events:", st.max_events, "events");
+        st.writer.flush();
+        st.send_report();
+        self->quit();
+      };
+      // Drop excess elements.
+      auto remaining = st.max_events - st.processed;
+      if (remaining == 0)
+        return reached_max_events();
+      if (xs.size() > remaining)
+        xs.resize(remaining);
+      // Handle events.
       auto t = timer::start(st.measurement);
-      for (auto& x : xs) {
-        auto r = st.writer.write(x);
-        if (!r) {
-          VAST_ERROR(self, self->system().render(r.error()));
-          self->quit(r.error());
-          return;
-        }
-        if (++st.processed == st.max_events) {
-          VAST_INFO(self, "reached max_events:", st.max_events, "events");
-          st.send_report();
-          self->quit();
-          return;
-        }
+      if (auto err = st.writer.write(xs)) {
+        VAST_ERROR(self, self->system().render(err));
+        self->quit(std::move(err));
+        return;
       }
       t.stop(xs.size());
+      // Stop when reaching configured limit.
+      st.processed += xs.size();
+      if (st.processed >= st.max_events)
+        return reached_max_events();
+      // Force flush if necessary.
       auto now = steady_clock::now();
       if (now - st.last_flush > st.flush_interval) {
         st.writer.flush();

--- a/tools/zeek-to-vast/zeek-to-vast.cpp
+++ b/tools/zeek-to-vast/zeek-to-vast.cpp
@@ -208,6 +208,8 @@ public:
     VAST_INFO_ANON("query", query_id_, "had", num_results_, "result(s)");
   }
 
+  using vast::format::writer::write;
+
   caf::expected<void> write(const vast::event& x) override {
     ++num_results_;
     if (show_progress_)


### PR DESCRIPTION
This tweak adds a new virtual function to `writer` that allows subtypes to get the entire batch at once. It makes no difference to VAST at the moment, but I'm going to need the new member function for tackling `Arrow` export (since I need to see the entire batch all at once to create an Arrow table slice [record batch] from it).