### PR TITLE
Add write overload to the writer for table slices

### DIFF
--- a/libvast/src/format/writer.cpp
+++ b/libvast/src/format/writer.cpp
@@ -14,6 +14,8 @@
 #include "vast/format/writer.hpp"
 
 #include "vast/event.hpp"
+#include "vast/table_slice.hpp"
+#include "vast/to_events.hpp"
 
 namespace vast::format {
 
@@ -26,6 +28,10 @@ caf::error writer::write(const std::vector<event>& xs) {
     if (auto res = write(x); !res)
       return res.error();
   return caf::none;
+}
+
+caf::error writer::write(const table_slice& x) {
+  return write(to_events(x));
 }
 
 caf::expected<void> writer::flush() {

--- a/libvast/vast/format/writer.hpp
+++ b/libvast/vast/format/writer.hpp
@@ -28,12 +28,18 @@ public:
 
   /// Processes an event.
   /// @param x The event to write.
-  /// @returns `caf::none` on success.
+  /// @returns `caf::unit` on success.
+  /// @note Legacy API! This exists only for backwards compatibility at the
+  ///       moment and is going to get removed when all implementations of this
+  ///       interface switched to the `table_slice` API.
   virtual caf::expected<void> write(const event& x)  = 0;
 
   /// Processes a batch of events.
   /// @param xs The events to write.
   /// @returns `caf::none` on success.
+  /// @note Legacy API! This exists only for backwards compatibility at the
+  ///       moment and is going to get removed when all implementations of this
+  ///       interface switched to the `table_slice` API.
   virtual caf::error write(const std::vector<event>& xs);
 
   /// Processes a single batch of events.

--- a/libvast/vast/format/writer.hpp
+++ b/libvast/vast/format/writer.hpp
@@ -36,6 +36,11 @@ public:
   /// @returns `caf::none` on success.
   virtual caf::error write(const std::vector<event>& xs);
 
+  /// Processes a single batch of events.
+  /// @param x The events to write wrapped in a table slice.
+  /// @returns `caf::none` on success.
+  virtual caf::error write(const table_slice& x);
+
   /// Called periodically to flush state.
   /// @returns `caf::none` on success.
   /// The default implementation does nothing.


### PR DESCRIPTION
This refactoring simply allows us to port the EXPORTER to table slices
while independently updating writer implementations.