### PR TITLE
Implement an evaluate function for table slices

### DIFF
--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -25,6 +25,7 @@
 #include "vast/die.hpp"
 #include "vast/event.hpp"
 #include "vast/expression_visitors.hpp"
+#include "vast/ids.hpp"
 #include "vast/logger.hpp"
 #include "vast/system/atoms.hpp"
 #include "vast/table_slice.hpp"
@@ -603,6 +604,14 @@ bool table_slice_row_evaluator::operator()(const data_extractor& e,
 
 bool evaluate_at(const table_slice& slice, size_t row, const expression& expr) {
   return caf::visit(table_slice_row_evaluator{slice, row}, expr);
+}
+
+ids evaluate(const table_slice& slice, const expression& expr) {
+  ids result;
+  result.append(false, slice.offset());
+  for (size_t row = 0; row != slice.rows(); ++row)
+    result.append_bit(evaluate_at(slice, row, expr));
+  return result;
 }
 
 matcher::matcher(const type& t) : type_{t} {

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -578,6 +578,8 @@ bool table_slice_row_evaluator::operator()(const attribute_extractor& e,
   if (e.attr == system::type_atom::value)
     return evaluate(slice_.layout().name(), op_, d);
   // Find the column with attribute 'time'.
+  if (e.attr != system::time_atom::value)
+    return false;
   auto pred = [](auto& x) {
     return caf::holds_alternative<timestamp_type>(x.type)
            && has_attribute(x.type, "time");

--- a/libvast/test/expression_evaluation.cpp
+++ b/libvast/test/expression_evaluation.cpp
@@ -175,6 +175,8 @@ TEST(evaluation - table slice rows) {
   CHECK(evaluate_at(*slice, 1, tailored(":addr != 192.168.1.102")));
   CHECK(evaluate_at(*slice, 1, tailored("orig_h in 192.168.1.0/24")));
   CHECK(evaluate_at(*slice, 1, tailored("!(orig_h in 192.168.2.0/24)")));
+  CHECK(evaluate_at(*slice, 1,
+                    tailored("orig_h in {192.168.1.102, 192.168.1.103}")));
 }
 
 TEST(evaluation - table slice) {

--- a/libvast/test/expression_evaluation.cpp
+++ b/libvast/test/expression_evaluation.cpp
@@ -168,6 +168,7 @@ TEST(evaluation - table slice rows) {
     return unbox(caf::visit(type_resolver{layout}, ast));
   };
   // Run some checks on various rows.
+  CHECK(evaluate_at(*slice, 0, tailored("#time < 2009-12-18+00:00:00")));
   CHECK(evaluate_at(*slice, 0, tailored("orig_h == 192.168.1.102")));
   CHECK(evaluate_at(*slice, 0, tailored(":addr == 192.168.1.102")));
   CHECK(evaluate_at(*slice, 1, tailored("orig_h != 192.168.1.102")));

--- a/libvast/test/expression_evaluation.cpp
+++ b/libvast/test/expression_evaluation.cpp
@@ -29,7 +29,7 @@ using namespace vast;
 
 namespace {
 
-struct fixture {
+struct fixture : fixtures::events {
   fixture() {
     foo = record_type{
       {"s1", string_type{}},
@@ -158,10 +158,8 @@ TEST(evaluation - schema) {
 }
 
 TEST(evaluation - table slice rows) {
-  // Calling the fixture ctor makes sure the slices are available.
-  fixtures::events dummy;
   // Get the first Zeek conn log slice and provide some utility.
-  auto& slice = fixtures::events::zeek_conn_log_slices[0];
+  auto& slice = zeek_conn_log_slices[0];
   auto layout = slice->layout();
   auto tailored = [&](std::string_view expr) {
     auto ast = unbox(to<expression>(expr));
@@ -180,10 +178,8 @@ TEST(evaluation - table slice rows) {
 }
 
 TEST(evaluation - table slice) {
-  // Calling the fixture ctor makes sure the slices are available.
-  fixtures::events dummy;
   // Get the first Zeek conn log slice and provide some utility.
-  auto slice = fixtures::events::zeek_conn_log_slices[0];
+  auto slice = zeek_conn_log_slices[0];
   slice.unshared().offset(0);
   REQUIRE_EQUAL(slice->rows(), 8u);
   auto layout = slice->layout();

--- a/libvast/vast/expression_visitors.hpp
+++ b/libvast/vast/expression_visitors.hpp
@@ -165,6 +165,41 @@ struct event_evaluator {
   relational_operator op_;
 };
 
+/// Evaluates a single row of a table slice over a [resolved](@ref
+/// type_extractor) expression.
+struct table_slice_row_evaluator {
+  table_slice_row_evaluator(const table_slice& slice, size_t row);
+
+  bool operator()(caf::none_t);
+  bool operator()(const conjunction& c);
+  bool operator()(const disjunction& d);
+  bool operator()(const negation& n);
+  bool operator()(const predicate& p);
+  bool operator()(const attribute_extractor& e, const data& d);
+  bool operator()(const key_extractor&, const data&);
+  bool operator()(const type_extractor&, const data&);
+  bool operator()(const data_extractor& e, const data& d);
+
+  template <class T>
+  bool operator()(const data& d, const T& x) {
+    return (*this)(x, d);
+  }
+
+  template <class T, class U>
+  bool operator()(const T&, const U&) {
+    return false;
+  }
+
+  const table_slice& slice_;
+  size_t row_;
+  relational_operator op_;
+};
+
+/// Evaluates a single row of a table slice over a [resolved](@ref
+/// type_extractor) expression.
+/// @relates table_slice_row_evaluator
+bool evaluate_at(const table_slice& slice, size_t row, const expression& expr);
+
 /// Checks whether a [resolved](@ref type_extractor) expression matches a given
 /// type. That is, this visitor tests whether an expression consists of a
 /// viable set of predicates for a type. For conjunctions, all operands must

--- a/libvast/vast/expression_visitors.hpp
+++ b/libvast/vast/expression_visitors.hpp
@@ -197,12 +197,19 @@ struct table_slice_row_evaluator {
 
 /// Evaluates a single row of a table slice over a [resolved](@ref
 /// type_extractor) expression.
+/// @param slice The table slice for evaluation.
+/// @param row Selects a single row in `slice`.
+/// @param expr A resolved expression for evaluating the selected row.
+/// @returns `true` if the row matches the expression, `false` otherwise.
 /// @relates table_slice_row_evaluator
+/// @pre `row < slice.rows()`
 bool evaluate_at(const table_slice& slice, size_t row, const expression& expr);
 
 /// Evaluates an entire table slice over a [resolved](@ref type_extractor)
 /// expression.
-/// @relates table_slice_evaluator
+/// @param slice The table slice for evaluation.
+/// @param expr A resolved expression for evaluating all rows in `slice`.
+/// @returns a bitmap containing all IDs of matching rows.
 ids evaluate(const table_slice& slice, const expression& expr);
 
 /// Checks whether a [resolved](@ref type_extractor) expression matches a given

--- a/libvast/vast/expression_visitors.hpp
+++ b/libvast/vast/expression_visitors.hpp
@@ -200,6 +200,11 @@ struct table_slice_row_evaluator {
 /// @relates table_slice_row_evaluator
 bool evaluate_at(const table_slice& slice, size_t row, const expression& expr);
 
+/// Evaluates an entire table slice over a [resolved](@ref type_extractor)
+/// expression.
+/// @relates table_slice_evaluator
+ids evaluate(const table_slice& slice, const expression& expr);
+
 /// Checks whether a [resolved](@ref type_extractor) expression matches a given
 /// type. That is, this visitor tests whether an expression consists of a
 /// viable set of predicates for a type. For conjunctions, all operands must

--- a/libvast/vast/view.hpp
+++ b/libvast/vast/view.hpp
@@ -450,4 +450,14 @@ data materialize(data_view xs);
 /// @returns `true` if *t* is a valid type for *x*.
 bool type_check(const type& t, const data_view& x);
 
+/// Evaluates a data predicate.
+/// @param lhs The LHS of the predicate.
+/// @param op The relational operator.
+/// @param rhs The RHS of the predicate.
+/// @note This function unfortunately needs to use the `_view` suffix because
+///       it otherwise produces ambiguous function calls with the `evaluate`
+///       function in `data.hpp`.
+bool evaluate_view(const data_view& lhs, relational_operator op,
+                   const data_view& rhs);
+
 } // namespace vast


### PR DESCRIPTION
Currently, the EXPORTER uses an `event_evaluator` for performing the candidate check. If we wish to switch to a table-slice based API then we first need this new function for checking candidates in table slices.