### PR TITLE
Port SINK to the table slice API

### DIFF
--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -189,6 +189,17 @@ table_slice* intrusive_cow_ptr_unshare(table_slice*& ptr) {
   return caf::default_intrusive_cow_ptr_unshare(ptr);
 }
 
+table_slice_ptr truncate(const table_slice_ptr& slice, size_t num_rows) {
+  VAST_ASSERT(slice != nullptr);
+  VAST_ASSERT(num_rows > 0);
+  if (slice->rows() <= num_rows)
+    return slice;
+  auto selection = make_ids({{slice->offset(), slice->offset() + num_rows}});
+  auto xs = select(slice, selection);
+  VAST_ASSERT(xs.size() == 1);
+  return std::move(xs.back());
+}
+
 bool operator==(const table_slice& x, const table_slice& y) {
   if (&x == &y)
     return true;

--- a/libvast/src/to_events.cpp
+++ b/libvast/src/to_events.cpp
@@ -57,11 +57,11 @@ event to_event(const table_slice& slice, id eid, type event_layout,
 void to_events(std::vector<event>& storage, const table_slice& slice,
                table_slice::size_type first_row,
                table_slice::size_type num_rows) {
-  if (num_rows == table_slice::npos)
-    num_rows = slice.rows();
+  VAST_ASSERT(first_row < slice.rows());
+  auto last_row = first_row + std::min(num_rows, slice.rows() - first_row);
   // Figure out whether there's a column that could be the event timestamp.
   auto timestamp_column = find_time_column(slice.layout());
-  for (auto i = first_row; i < first_row + num_rows; ++i)
+  for (auto i = first_row; i < last_row; ++i)
     storage.emplace_back(to_event(slice, slice.offset() + i, slice.layout(),
                                   timestamp_column));
 }

--- a/libvast/test/system/sink.cpp
+++ b/libvast/test/system/sink.cpp
@@ -30,7 +30,8 @@ TEST(zeek sink) {
   format::zeek::writer writer{directory};
   auto snk = self->spawn(sink<format::zeek::writer>, std::move(writer), 20u);
   MESSAGE("sending events");
-  self->send(snk, zeek_conn_log);
+  for (auto& slice : zeek_conn_log_slices)
+    self->send(snk, slice);
   MESSAGE("shutting down");
   self->send_exit(snk, caf::exit_reason::user_shutdown);
   self->wait_for(snk);

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -178,4 +178,25 @@ TEST(select suffix) {
   CHECK_EQUAL(to_events(*xs[0]), to_events(*sut, 50, 50));
 }
 
+TEST(truncate) {
+  auto sut = zeek_conn_log_slices.front();
+  REQUIRE_EQUAL(sut->rows(), 8u);
+  sut.unshared().offset(100);
+  auto truncated_events = [&](size_t num_rows) {
+    auto sub_slice = truncate(sut, num_rows);
+    if (sub_slice->rows() != num_rows)
+      FAIL("expected " << num_rows << " rows, got " << sub_slice->rows());
+    return to_events(*sub_slice);
+  };
+  auto sub_slice = truncate(sut, 8);
+  CHECK_EQUAL(*sub_slice, *sut);
+  CHECK_EQUAL(truncated_events(7), to_events(*sut, 0, 7));
+  CHECK_EQUAL(truncated_events(6), to_events(*sut, 0, 6));
+  CHECK_EQUAL(truncated_events(5), to_events(*sut, 0, 5));
+  CHECK_EQUAL(truncated_events(4), to_events(*sut, 0, 4));
+  CHECK_EQUAL(truncated_events(3), to_events(*sut, 0, 3));
+  CHECK_EQUAL(truncated_events(2), to_events(*sut, 0, 2));
+  CHECK_EQUAL(truncated_events(1), to_events(*sut, 0, 1));
+}
+
 FIXTURE_SCOPE_END()

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -19,7 +19,6 @@
 #include <unordered_map>
 
 #include "vast/aliases.hpp"
-#include "vast/event.hpp"
 #include "vast/expression.hpp"
 #include "vast/ids.hpp"
 #include "vast/query_options.hpp"

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -32,22 +32,52 @@
 namespace vast::system {
 
 struct exporter_state {
+  /// -- constants -------------------------------------------------------------
+
+  static inline const char* name = "exporter";
+
+  // -- properties -------------------------------------------------------------
+
   caf::settings status();
 
+  // -- member variables -------------------------------------------------------
+
+  /// Stores a handle to the ARCHIVE for fetching candidates.
   archive_type archive;
+
+  /// Stores a handle to the INDEX for querying results.
   caf::actor index;
+
+  /// Stores a handle to the SINK that processes results.
   caf::actor sink;
+
+  /// Stores a handle to the ACCOUNTANT that collects various statistics.
   accountant_type accountant;
+
+  /// Stores hits from the INDEX.
   ids hits;
+
+  /// Caches tailored candidate checkers.
   std::unordered_map<type, expression> checkers;
-  std::deque<event> candidates;
-  std::vector<event> results;
+
+  /// Caches results for the SINK.
+  std::vector<table_slice_ptr> results;
+
+  /// Stores the time point for when this actor got started via 'run'.
   std::chrono::steady_clock::time_point start;
+
+  /// Stores various meta information about the progress we made on the query.
   query_status query;
+
+  /// Stores flags for the query for distinguishing historic and continuous
+  /// queries.
   query_options options;
+
+  /// Stores the query ID we receive from the INDEX.
   uuid id;
+
+  /// Stores the user-defined export query.
   expression expr;
-  static inline const char* name = "exporter";
 };
 
 /// The EXPORTER receives index hits, looks up the corresponding events in the

--- a/libvast/vast/system/query_status.hpp
+++ b/libvast/vast/system/query_status.hpp
@@ -31,8 +31,9 @@ struct query_status {
   size_t lookups_issued = 0;   ///< Number of lookups sent to the ARCHIVE.
   size_t lookups_complete = 0; ///< Number of lookups returned by the ARCHIVE.
   uint64_t processed = 0;      ///< Processed candidates from ARCHIVE.
-  uint64_t shipped = 0;        ///< Shipped results to sink.
+  uint64_t shipped = 0;        ///< Shipped results to the SINK.
   uint64_t requested = 0;      ///< User-requested pending results to extract.
+  uint64_t cached = 0;         ///< Currently available results for the SINK.
 };
 
 template <class Inspector>

--- a/libvast/vast/system/sink.hpp
+++ b/libvast/vast/system/sink.hpp
@@ -25,7 +25,6 @@
 
 #include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/vast/uuid.hpp"
-#include "vast/event.hpp"
 #include "vast/format/writer.hpp"
 #include "vast/system/accountant.hpp"
 #include "vast/system/atoms.hpp"

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -172,6 +172,17 @@ std::vector<table_slice_ptr> select(const table_slice_ptr& xs,
 /// @pre `num_rows > 0`
 table_slice_ptr truncate(const table_slice_ptr& slice, size_t num_rows);
 
+/// Splits a table slice into two slices such that the first slice contains the
+/// rows `[0, partition_point)` and the second slice contains the rows
+/// `[partition_point, n)`, where `n = slice->rows()`.
+/// @param slice The input table slice.
+/// @param partition_point The index of the first row for the second slice.
+/// @returns two new table slices if `0 < partition_point < slice->rows()`,
+///          otherwise returns `slice` and a `nullptr`.
+/// @pre `slice != nullptr`
+std::pair<table_slice_ptr, table_slice_ptr> split(const table_slice_ptr& slice,
+                                                  size_t partition_point);
+
 /// @relates table_slice
 bool operator==(const table_slice& x, const table_slice& y);
 

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -163,6 +163,15 @@ void select(std::vector<table_slice_ptr>& result, const table_slice_ptr& xs,
 std::vector<table_slice_ptr> select(const table_slice_ptr& xs,
                                     const ids& selection);
 
+/// Selects the first `num_rows` rows of `slice`.
+/// @param slice The input table slice.
+/// @param num_rows The number of rows to keep.
+/// @returns `slice` if `slice->rows() <= num_rows`, otherwise creates a new
+///          table slice of the first `num_rows` rows from `slice`.
+/// @pre `slice != nullptr`
+/// @pre `num_rows > 0`
+table_slice_ptr truncate(const table_slice_ptr& slice, size_t num_rows);
+
 /// @relates table_slice
 bool operator==(const table_slice& x, const table_slice& y);
 


### PR DESCRIPTION
This set of changes allows the EXPORTER to send table slices to the SINK and drops the conversion to `vector<event>`.

The two new free functions `split` and `truncate` that operate on table slices could be implemented more efficiently as virtual member functions, but I think we should not convolute the `table_slice` interface more than necessary. Those functions are only needed if a table slice exceeds the number of requested events, so they are probably not in a critical path. Should either one of these functions show up in a profile while benchmarking VAST then we can still move those functions into the `table_slice` interface and implement them efficiently for each table slice type.