### PR TITLE
Implement generic Community ID computation API

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -22,6 +22,7 @@ set(libvast_sources
   src/command.cpp
   src/compression.cpp
   src/concept/hashable/crc.cpp
+  src/concept/hashable/sha1.cpp
   src/concept/hashable/xxhash.cpp
   src/data.cpp
   src/default_table_slice.cpp

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -31,6 +31,7 @@ set(libvast_sources
   src/detail/add_error_categories.cpp
   src/detail/add_message_types.cpp
   src/detail/adjust_resource_consumption.cpp
+  src/detail/base64.cpp
   src/detail/compressedbuf.cpp
   src/detail/fdinbuf.cpp
   src/detail/fdistream.cpp
@@ -227,6 +228,7 @@ set(tests
   test/compressedbuf.cpp
   test/data.cpp
   test/detail/algorithms.cpp
+  test/detail/base64.cpp
   test/detail/column_iterator.cpp
   test/detail/flat_lru_cache.cpp
   test/detail/operators.cpp

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -65,6 +65,7 @@ set(libvast_sources
   src/format/writer.cpp
   src/format/zeek.cpp
   src/http.cpp
+  src/icmp.cpp
   src/ids.cpp
   src/json.cpp
   src/meta_index.cpp

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -225,6 +225,7 @@ set(tests
   test/coder.cpp
   test/column_index.cpp
   test/command.cpp
+  test/community_id.cpp
   test/compressedbuf.cpp
   test/data.cpp
   test/detail/algorithms.cpp

--- a/libvast/src/concept/hashable/sha1.cpp
+++ b/libvast/src/concept/hashable/sha1.cpp
@@ -1,0 +1,163 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+// Most of the actual implementation in this file comes from a 3rd party and
+// has been adapted to fit into the VAST code base. Details about the original
+// file:
+//
+// - Repository: https://github.com/kerukuro/digestpp
+// - Commit:     92dc9b33a63da76b088ac2471fbb350177d04c2f
+// - Path:       algorithm/detail/sha1_provider.hpp
+// - Author:     kerukuro
+// - License:    Public Domain
+
+#include "vast/concept/hashable/sha1.hpp"
+
+#include <cstring>
+
+#include "vast/detail/byte_swap.hpp"
+
+namespace vast {
+namespace {
+
+// Rotate 32-bit unsigned integer to the left.
+uint32_t rotate_left(uint32_t x, unsigned n) {
+  return (x << n) | (x >> (32 - n));
+}
+
+// Accumulate data and call the transformation function for full blocks.
+template <class T, class F>
+void absorb_bytes(const unsigned char* data, size_t len, size_t bs,
+                  size_t bschk, unsigned char* m, size_t& pos, T& total,
+                  F transform) {
+  if (pos && pos + len >= bschk) {
+    std::memcpy(m + pos, data, bs - pos);
+    transform(m, 1);
+    len -= bs - pos;
+    data += bs - pos;
+    total += bs * 8;
+    pos = 0;
+  }
+  if (len >= bschk) {
+    size_t blocks = (len + bs - bschk) / bs;
+    size_t bytes = blocks * bs;
+    transform(data, blocks);
+    len -= bytes;
+    data += bytes;
+    total += (bytes) *8;
+  }
+  std::memcpy(m + pos, data, len);
+  pos += len;
+}
+
+// -- SHA1 constants and functions --------------------------------------------
+
+std::array<uint32_t, 4> K = {0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xca62c1d6};
+
+uint32_t choice(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & y) ^ (~x & z);
+}
+
+uint32_t parity(uint32_t x, uint32_t y, uint32_t z) {
+  return x ^ y ^ z;
+}
+
+uint32_t majority(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & y) ^ (x & z) ^ (y & z);
+}
+
+} // namespace
+
+sha1::sha1() noexcept {
+  H_[0] = 0x67452301;
+  H_[1] = 0xefcdab89;
+  H_[2] = 0x98badcfe;
+  H_[3] = 0x10325476;
+  H_[4] = 0xc3d2e1f0;
+}
+
+void sha1::operator()(const void* xs, size_t n) noexcept {
+  auto f = [this](const unsigned char* data, size_t len) {
+    transform(data, len);
+  };
+  auto ptr = reinterpret_cast<const unsigned char*>(xs);
+  absorb_bytes(ptr, n, 64, 64, m_.data(), pos_, total_, f);
+}
+
+sha1::operator sha1::result_type() noexcept {
+  finalize();
+  return H_;
+}
+
+void sha1::finalize() {
+  total_ += pos_ * 8;
+  m_[pos_++] = 0x80;
+  if (pos_ > 56) {
+    if (pos_ != 64)
+      std::memset(&m_[pos_], 0, 64 - pos_);
+    transform(&m_[0], 1);
+    pos_ = 0;
+  }
+  std::memset(&m_[0] + pos_, 0, 56 - pos_);
+  uint64_t mlen = detail::byte_swap(total_);
+  std::memcpy(&m_[0] + (64 - 8), &mlen, 64 / 8);
+  transform(&m_[0], 1);
+  for (int i = 0; i < 5; i++)
+    H_[i] = detail::byte_swap(H_[i]);
+}
+
+void sha1::transform(const unsigned char* data, size_t num_blks) {
+  for (uint64_t blk = 0; blk < num_blks; blk++) {
+    uint32_t m[16];
+    auto xs = reinterpret_cast<const uint32_t*>(data);
+    for (uint32_t i = 0; i < 64 / 4; i++)
+      m[i] = detail::byte_swap(xs[blk * 16 + i]);
+    uint32_t w[80];
+    for (int t = 0; t <= 15; t++)
+      w[t] = m[t];
+    for (int t = 16; t <= 79; t++)
+      w[t] = rotate_left(w[t - 3] ^ w[t - 8] ^ w[t - 14] ^ w[t - 16], 1);
+    auto a = H_[0];
+    auto b = H_[1];
+    auto c = H_[2];
+    auto d = H_[3];
+    auto e = H_[4];
+    auto k = K[0];
+    auto f = choice;
+    for (int t = 0; t <= 79; t++) {
+      auto T = rotate_left(a, 5) + f(b, c, d) + e + k + w[t];
+      e = d;
+      d = c;
+      c = rotate_left(b, 30);
+      b = a;
+      a = T;
+      if (t == 19) {
+        f = parity;
+        k = K[1];
+      } else if (t == 39) {
+        f = majority;
+        k = K[2];
+      } else if (t == 59) {
+        f = parity;
+        k = K[3];
+      }
+    }
+    H_[0] += a;
+    H_[1] += b;
+    H_[2] += c;
+    H_[3] += d;
+    H_[4] += e;
+  }
+}
+
+} // namespace vast

--- a/libvast/src/detail/base64.cpp
+++ b/libvast/src/detail/base64.cpp
@@ -1,0 +1,105 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+// Most of the actual implementation in this file comes from a 3rd party and
+// has been adapted to fit into the VAST code base. Details about the original
+// file:
+//
+// - Repository: https://github.com/boostorg/beast
+// - Commit:     8848ced9ab1526053393b82a65449e651ae87cd2
+// - Path:       beast/include/boost/beast/core/detail/base64.ipp
+// - Author:     Vinnie Falco <vinnie.falco@gmail.com>
+// - License:    Boost Software License, Version 1.0
+
+#include "vast/detail/base64.hpp"
+
+namespace vast::detail::base64 {
+
+size_t encode(void* dst, const void* src, size_t len) {
+  auto out = static_cast<char*>(dst);
+  auto in = static_cast<char const*>(src);
+  for (auto n = len / 3; n--;) {
+    *out++ = alphabet[(in[0] & 0xfc) >> 2];
+    *out++ = alphabet[((in[0] & 0x03) << 4) + ((in[1] & 0xf0) >> 4)];
+    *out++ = alphabet[((in[2] & 0xc0) >> 6) + ((in[1] & 0x0f) << 2)];
+    *out++ = alphabet[in[2] & 0x3f];
+    in += 3;
+  }
+  switch (len % 3) {
+    case 2:
+      *out++ = alphabet[(in[0] & 0xfc) >> 2];
+      *out++ = alphabet[((in[0] & 0x03) << 4) + ((in[1] & 0xf0) >> 4)];
+      *out++ = alphabet[(in[1] & 0x0f) << 2];
+      *out++ = '=';
+      break;
+    case 1:
+      *out++ = alphabet[(in[0] & 0xfc) >> 2];
+      *out++ = alphabet[((in[0] & 0x03) << 4)];
+      *out++ = '=';
+      *out++ = '=';
+      break;
+    case 0:
+      break;
+  }
+  return out - static_cast<char*>(dst);
+}
+
+std::string encode(std::string_view str) {
+  std::string result;
+  result.resize(encoded_size(str.size()));
+  auto n = encode(result.data(), str.data(), str.size());
+  result.resize(n);
+  return result;
+}
+
+std::pair<size_t, size_t> decode(void* dst, char const* src, size_t len) {
+  auto out = static_cast<char*>(dst);
+  auto in = reinterpret_cast<unsigned char const*>(src);
+  unsigned char c3[3], c4[4];
+  int i = 0;
+  int j = 0;
+  while (len-- && *in != '=') {
+    auto const v = inverse[*in];
+    if (v == -1)
+      break;
+    ++in;
+    c4[i] = v;
+    if (++i == 4) {
+      c3[0] = (c4[0] << 2) + ((c4[1] & 0x30) >> 4);
+      c3[1] = ((c4[1] & 0xf) << 4) + ((c4[2] & 0x3c) >> 2);
+      c3[2] = ((c4[2] & 0x3) << 6) + c4[3];
+      for (i = 0; i < 3; i++)
+        *out++ = c3[i];
+      i = 0;
+    }
+  }
+  if (i) {
+    c3[0] = (c4[0] << 2) + ((c4[1] & 0x30) >> 4);
+    c3[1] = ((c4[1] & 0xf) << 4) + ((c4[2] & 0x3c) >> 2);
+    c3[2] = ((c4[2] & 0x3) << 6) + c4[3];
+    for (j = 0; j < i - 1; j++)
+      *out++ = c3[j];
+  }
+  return {out - static_cast<char*>(dst),
+          in - reinterpret_cast<unsigned char const*>(src)};
+}
+
+std::string decode(std::string_view str) {
+  std::string result;
+  result.resize(decoded_size(str.size()));
+  auto [written, read] = decode(result.data(), str.data(), str.size());
+  result.resize(written);
+  return result;
+}
+
+} // namespace vast::detail::base64

--- a/libvast/src/icmp.cpp
+++ b/libvast/src/icmp.cpp
@@ -1,0 +1,80 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/icmp.hpp"
+
+#include <cstdint>
+
+#include <caf/optional.hpp>
+
+namespace vast {
+
+caf::optional<icmp_type> dual(icmp_type x) {
+  switch (x) {
+    default:
+      return caf::none;
+    case icmp_type::echo:
+      return icmp_type::echo_reply;
+    case icmp_type::echo_reply:
+      return icmp_type::echo;
+    case icmp_type::tstamp:
+      return icmp_type::tstamp_reply;
+    case icmp_type::tstamp_reply:
+      return icmp_type::tstamp;
+    case icmp_type::info:
+      return icmp_type::info_reply;
+    case icmp_type::info_reply:
+      return icmp_type::info;
+    case icmp_type::rtr_solicit:
+      return icmp_type::rtr_advert;
+    case icmp_type::rtr_advert:
+      return icmp_type::rtr_solicit;
+    case icmp_type::mask:
+      return icmp_type::mask_reply;
+    case icmp_type::mask_reply:
+      return icmp_type::mask;
+  }
+}
+
+caf::optional<icmp6_type> dual(icmp6_type x) {
+  switch (x) {
+    default:
+      return caf::none;
+    case icmp6_type::echo_request:
+      return icmp6_type::echo_reply;
+    case icmp6_type::echo_reply:
+      return icmp6_type::echo_request;
+    case icmp6_type::mld_listener_query:
+      return icmp6_type::mld_listener_report;
+    case icmp6_type::mld_listener_report:
+      return icmp6_type::mld_listener_query;
+    case icmp6_type::nd_router_solicit:
+      return icmp6_type::nd_router_advert;
+    case icmp6_type::nd_router_advert:
+      return icmp6_type::nd_router_solicit;
+    case icmp6_type::nd_neighbor_solicit:
+      return icmp6_type::nd_neighbor_advert;
+    case icmp6_type::nd_neighbor_advert:
+      return icmp6_type::nd_neighbor_solicit;
+    case icmp6_type::wru_request:
+      return icmp6_type::wru_reply;
+    case icmp6_type::wru_reply:
+      return icmp6_type::wru_request;
+    case icmp6_type::haad_request:
+      return icmp6_type::haad_reply;
+    case icmp6_type::haad_reply:
+      return icmp6_type::haad_request;
+  }
+}
+
+} // namespace vast

--- a/libvast/src/port.cpp
+++ b/libvast/src/port.cpp
@@ -20,6 +20,10 @@
 
 namespace vast {
 
+port::port() {
+  type(unknown);
+}
+
 port::port(number_type n, port_type t) {
   number(n);
   type(t);
@@ -38,6 +42,7 @@ void port::number(number_type n) {
 }
 
 void port::type(port_type t) {
+  data_ &= 0xFFFFFF00;
   data_ |= static_cast<std::underlying_type_t<port_type>>(t);
 }
 

--- a/libvast/src/value_index.cpp
+++ b/libvast/src/value_index.cpp
@@ -400,7 +400,7 @@ subnet_index::lookup_impl(relational_operator op, data_view d) const {
 port_index::port_index(vast::type t)
   : value_index{std::move(t)},
     num_{base::uniform(10, 5)}, // [0, 2^16)
-    proto_{4}                   // unknown, tcp, udp, icmp
+    proto_{256}                 // 8-bit proto/next-header field
 {
   // nop
 }

--- a/libvast/test/community_id.cpp
+++ b/libvast/test/community_id.cpp
@@ -28,9 +28,7 @@ namespace {
   flow make_##protocol##_flow(std::string_view orig_h, uint16_t orig_p,        \
                               std::string_view resp_h, uint16_t resp_p) {      \
     constexpr auto proto = port::port_type::protocol;                          \
-    auto x = make_flow<proto>(orig_h, orig_p, resp_h, resp_p);                 \
-    REQUIRE(x);                                                                \
-    return *x;                                                                 \
+    return unbox(make_flow<proto>(orig_h, orig_p, resp_h, resp_p));            \
   }
 
 FLOW_FACTORY(icmp)

--- a/libvast/test/community_id.cpp
+++ b/libvast/test/community_id.cpp
@@ -24,28 +24,21 @@ using namespace community_id;
 
 namespace {
 
-flow_tuple make_flow(protocol proto, std::string_view orig_h, uint16_t orig_p,
-                     std::string_view resp_h, uint16_t resp_p) {
-  auto make_addr = [](auto x) { return unbox(to<address>(x)); };
-  auto make_port = [](protocol x, auto number) {
-    switch (x) {
-      default:
-        return port{number, port::unknown};
-      case protocol::icmp:
-        return port{number, port::icmp};
-      case protocol::tcp:
-        return port{number, port::tcp};
-      case protocol::udp:
-        return port{number, port::tcp};
-      case protocol::icmp6:
-        return port{number, port::icmp};
-      case protocol::sctp:
-        return port{number, port::unknown}; // TODO
-    }
-  };
-  return {proto, make_addr(orig_h), make_port(proto, orig_p), make_addr(resp_h),
-          make_port(proto, resp_p)};
-}
+#define FLOW_FACTORY(protocol)                                                 \
+  flow make_##protocol##_flow(std::string_view orig_h, uint16_t orig_p,        \
+                              std::string_view resp_h, uint16_t resp_p) {      \
+    constexpr auto proto = port::port_type::protocol;                          \
+    auto x = make_flow<proto>(orig_h, orig_p, resp_h, resp_p);                 \
+    REQUIRE(x);                                                                \
+    return *x;                                                                 \
+  }
+
+FLOW_FACTORY(icmp)
+FLOW_FACTORY(tcp)
+FLOW_FACTORY(udp)
+FLOW_FACTORY(icmp6)
+
+#undef FLOW_FACTORY
 
 } // namespace
 
@@ -57,7 +50,7 @@ flow_tuple make_flow(protocol proto, std::string_view orig_h, uint16_t orig_p,
 //     flow = FlowTuple(PROTO_UDP, "192.168.1.102", "192.168.1.1", 68, 67)
 
 TEST(UDP IPv4) {
-  auto x = make_flow(protocol::udp, "192.168.1.102", 68, "192.168.1.1", 67);
+  auto x = make_udp_flow("192.168.1.102", 68, "192.168.1.1", 67);
   auto hex = compute<policy::ascii>(x);
   auto b64 = compute<policy::base64>(x);
   CHECK_EQUAL(hex, "1:69665f2c8aae6250b1286b89eb67d01a5805cc02");
@@ -65,16 +58,15 @@ TEST(UDP IPv4) {
 }
 
 TEST(UDP IPv6) {
-  auto x = make_flow(protocol::udp, "fe80::2c23:b96c:78d:e116", 58544,
-                     "ff02::c", 3702);
+  auto x = make_udp_flow("fe80::2c23:b96c:78d:e116", 58544, "ff02::c", 3702);
   auto hex = compute<policy::ascii>(x);
   auto b64 = compute<policy::base64>(x);
-  CHECK_EQUAL(hex, "1:a6a666566d134acee99f99c74d6c83cf295ad6a3");
-  CHECK_EQUAL(b64, "1:pqZmVm0TSs7pn5nHTWyDzyla1qM=");
+  CHECK_EQUAL(hex, "1:662f40748c18bd99d8bee39b4cf806582052611b");
+  CHECK_EQUAL(b64, "1:Zi9AdIwYvZnYvuObTPgGWCBSYRs=");
 }
 
 TEST(TCP IPv4) {
-  auto x = make_flow(protocol::tcp, "192.168.1.102", 1180, "68.216.79.113", 37);
+  auto x = make_tcp_flow("192.168.1.102", 1180, "68.216.79.113", 37);
   auto hex = compute<policy::ascii>(x);
   auto b64 = compute<policy::base64>(x);
   CHECK_EQUAL(hex, "1:f4bfed67579b1f395687307fa49c92f405495b2f");
@@ -82,10 +74,41 @@ TEST(TCP IPv4) {
 }
 
 TEST(TCP IPv6) {
-  auto x = make_flow(protocol::tcp, "fe80::219:e3ff:fee7:5d23", 5353,
-                     "ff02::fb", 53);
+  auto x = make_tcp_flow("fe80::219:e3ff:fee7:5d23", 5353, "ff02::fb", 53);
   auto hex = compute<policy::ascii>(x);
   auto b64 = compute<policy::base64>(x);
   CHECK_EQUAL(hex, "1:03aaaffe2842910257a2fdf52f863395cb8a4769");
   CHECK_EQUAL(b64, "1:A6qv/ihCkQJXov31L4YzlcuKR2k=");
+}
+
+TEST(ICMPv4) {
+  auto x = make_icmp_flow("1.2.3.4", 0, "5.6.7.8", 8);
+  auto hex = compute<policy::ascii>(x);
+  auto b64 = compute<policy::base64>(x);
+  CHECK_EQUAL(hex, "1:d6f36bf9c570edbcd9fad1ac8761fbbe807069a6");
+  CHECK_EQUAL(b64, "1:1vNr+cVw7bzZ+tGsh2H7voBwaaY=");
+}
+
+TEST(ICMPv4 oneway) {
+  auto x = make_icmp_flow("192.168.0.89", 128, "192.168.0.1", 129);
+  auto hex = compute<policy::ascii>(x);
+  auto b64 = compute<policy::base64>(x);
+  CHECK_EQUAL(hex, "1:86459c1ce1ea4c65aaffe7f01c48a6e5efa0d5f1");
+  CHECK_EQUAL(b64, "1:hkWcHOHqTGWq/+fwHEim5e+g1fE=");
+}
+
+TEST(ICMPv6) {
+  auto x = make_icmp6_flow("fe80::200:86ff:fe05:80da", 135, "fe80::260", 136);
+  auto hex = compute<policy::ascii>(x);
+  auto b64 = compute<policy::base64>(x);
+  CHECK_EQUAL(hex, "1:ffb2d8321708804a883ac02fe6c76655499b3ff5");
+  CHECK_EQUAL(b64, "1:/7LYMhcIgEqIOsAv5sdmVUmbP/U=");
+}
+
+TEST(ICMPv6 oneway) {
+  auto x = make_icmp6_flow("fe80::dead", 42, "fe80::beef", 84);
+  auto hex = compute<policy::ascii>(x);
+  auto b64 = compute<policy::base64>(x);
+  CHECK_EQUAL(hex, "1:118a3bbf175529a3d55dca55c4364ec47f1c4152");
+  CHECK_EQUAL(b64, "1:EYo7vxdVKaPVXcpVxDZOxH8cQVI=");
 }

--- a/libvast/test/community_id.cpp
+++ b/libvast/test/community_id.cpp
@@ -1,0 +1,91 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#define SUITE community_id
+
+#include "vast/test/test.hpp"
+
+#include "vast/community_id.hpp"
+#include "vast/concept/parseable/to.hpp"
+#include "vast/concept/parseable/vast/address.hpp"
+
+using namespace vast;
+using namespace community_id;
+
+namespace {
+
+flow_tuple make_flow(protocol proto, std::string_view orig_h, uint16_t orig_p,
+                     std::string_view resp_h, uint16_t resp_p) {
+  auto make_addr = [](auto x) { return unbox(to<address>(x)); };
+  auto make_port = [](protocol x, auto number) {
+    switch (x) {
+      default:
+        return port{number, port::unknown};
+      case protocol::icmp:
+        return port{number, port::icmp};
+      case protocol::tcp:
+        return port{number, port::tcp};
+      case protocol::udp:
+        return port{number, port::tcp};
+      case protocol::icmp6:
+        return port{number, port::icmp};
+      case protocol::sctp:
+        return port{number, port::unknown}; // TODO
+    }
+  };
+  return {proto, make_addr(orig_h), make_port(proto, orig_p), make_addr(resp_h),
+          make_port(proto, resp_p)};
+}
+
+} // namespace
+
+// Ground truth established with Christian Kreibich's Python module, e.g.:
+//
+//     from communityid import *
+//     commid = CommunityID(seed=0, use_base64=False)
+//     commid.calc(flow)
+//     flow = FlowTuple(PROTO_UDP, "192.168.1.102", "192.168.1.1", 68, 67)
+
+TEST(UDP IPv4) {
+  auto x = make_flow(protocol::udp, "192.168.1.102", 68, "192.168.1.1", 67);
+  auto hex = compute<policy::ascii>(x);
+  auto b64 = compute<policy::base64>(x);
+  CHECK_EQUAL(hex, "1:69665f2c8aae6250b1286b89eb67d01a5805cc02");
+  CHECK_EQUAL(b64, "1:aWZfLIquYlCxKGuJ62fQGlgFzAI=");
+}
+
+TEST(UDP IPv6) {
+  auto x = make_flow(protocol::udp, "fe80::2c23:b96c:78d:e116", 58544,
+                     "ff02::c", 3702);
+  auto hex = compute<policy::ascii>(x);
+  auto b64 = compute<policy::base64>(x);
+  CHECK_EQUAL(hex, "1:a6a666566d134acee99f99c74d6c83cf295ad6a3");
+  CHECK_EQUAL(b64, "1:pqZmVm0TSs7pn5nHTWyDzyla1qM=");
+}
+
+TEST(TCP IPv4) {
+  auto x = make_flow(protocol::tcp, "192.168.1.102", 1180, "68.216.79.113", 37);
+  auto hex = compute<policy::ascii>(x);
+  auto b64 = compute<policy::base64>(x);
+  CHECK_EQUAL(hex, "1:f4bfed67579b1f395687307fa49c92f405495b2f");
+  CHECK_EQUAL(b64, "1:9L/tZ1ebHzlWhzB/pJyS9AVJWy8=");
+}
+
+TEST(TCP IPv6) {
+  auto x = make_flow(protocol::tcp, "fe80::219:e3ff:fee7:5d23", 5353,
+                     "ff02::fb", 53);
+  auto hex = compute<policy::ascii>(x);
+  auto b64 = compute<policy::base64>(x);
+  CHECK_EQUAL(hex, "1:03aaaffe2842910257a2fdf52f863395cb8a4769");
+  CHECK_EQUAL(b64, "1:A6qv/ihCkQJXov31L4YzlcuKR2k=");
+}

--- a/libvast/test/detail/base64.cpp
+++ b/libvast/test/detail/base64.cpp
@@ -1,0 +1,38 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#define SUITE base64
+
+#include "vast/test/test.hpp"
+
+#include "vast/detail/base64.hpp"
+
+using namespace std::string_view_literals;
+using namespace vast::detail;
+
+// Ground truth:
+//
+//   printf "The quick brown fox jumps over the lazy dog" | base64
+//   VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==
+
+TEST(encode) {
+  auto dec = "The quick brown fox jumps over the lazy dog"sv;
+  auto enc = "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw=="sv;
+  CHECK_EQUAL(base64::encode(dec), enc);
+}
+
+TEST(decode) {
+  auto enc = "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw=="sv;
+  auto dec = "The quick brown fox jumps over the lazy dog"sv;
+  CHECK_EQUAL(base64::decode(enc), dec);
+}

--- a/libvast/test/hash.cpp
+++ b/libvast/test/hash.cpp
@@ -17,11 +17,13 @@
 #include "vast/concept/hashable/sha1.hpp"
 #include "vast/concept/hashable/uhash.hpp"
 #include "vast/concept/hashable/xxhash.hpp"
+#include "vast/detail/coding.hpp"
 
 #define SUITE hash
 #include "vast/test/test.hpp"
 
 using namespace vast;
+using vast::detail::hexify;
 
 namespace {
 
@@ -33,16 +35,6 @@ struct foo {
 template <class Inspector>
 auto inspect(Inspector& f, foo& x) {
   return f(x.a, x.b);
-}
-
-template <class T, size_t N>
-std::string hexify(const std::array<T, N>& xs) {
-  std::stringstream ss;
-  ss << std::setfill('0') << std::hex;
-  auto ptr = reinterpret_cast<const uint8_t*>(xs.data());
-  for (auto i = 0u; i < N * sizeof(T); ++i)
-    ss << std::setw(2) << static_cast<int>(ptr[i]);
-  return ss.str();
 }
 
 } // namespace
@@ -115,7 +107,8 @@ TEST(sha1) {
   // one-shot
   std::array<char, 2> fortytwo = {'4', '2'};
   auto digest = uhash<sha1>{}(fortytwo);
-  CHECK_EQUAL(hexify(digest), "92cfceb39d57d914ed8b14d0e37643de0797ae56");
+  auto bytes = make_const_byte_span(digest);
+  CHECK_EQUAL(hexify(bytes), "92cfceb39d57d914ed8b14d0e37643de0797ae56");
   // incremental
   sha1 sha;
   sha("foo", 3);
@@ -123,5 +116,5 @@ TEST(sha1) {
   sha("baz", 3);
   sha("42", 2);
   digest = static_cast<sha1::result_type>(sha);
-  CHECK_EQUAL(hexify(digest), "4cbfb91f23be76f0836c3007c1b3c8d8c2eacdd1");
+  CHECK_EQUAL(hexify(bytes), "4cbfb91f23be76f0836c3007c1b3c8d8c2eacdd1");
 }

--- a/libvast/test/port.cpp
+++ b/libvast/test/port.cpp
@@ -41,39 +41,25 @@ TEST(ports) {
 }
 
 TEST(printable) {
-  auto p = port{53, port::udp};
-  CHECK_EQUAL(to_string(p), "53/udp");
+  CHECK_EQUAL(to_string(port{42, port::unknown}), "42/?");
+  CHECK_EQUAL(to_string(port{53, port::udp}), "53/udp");
+  CHECK_EQUAL(to_string(port{80, port::tcp}), "80/tcp");
+  CHECK_EQUAL(to_string(port{7, port::icmp}), "7/icmp");
+  CHECK_EQUAL(to_string(port{7, port::icmp6}), "7/icmp6");
 }
 
 TEST(parseable) {
-  auto& p = parsers::port;
-  MESSAGE("tcp");
-  auto str = "22/tcp"s;
-  auto f = str.begin();
-  auto l = str.end();
-  port prt;
-  CHECK(p(f, l, prt));
-  CHECK(f == l);
-  CHECK_EQUAL(prt, port(22, port::tcp));
-  MESSAGE("udp");
-  str = "53/udp"s;
-  f = str.begin();
-  l = str.end();
-  CHECK(p(f, l, prt));
-  CHECK(f == l);
-  CHECK_EQUAL(prt, port(53, port::udp));
-  MESSAGE("icmp");
-  str = "7/icmp"s;
-  f = str.begin();
-  l = str.end();
-  CHECK(p(f, l, prt));
-  CHECK(f == l);
-  CHECK_EQUAL(prt, port(7, port::icmp));
-  MESSAGE("unknown");
-  str = "42/?"s;
-  f = str.begin();
-  l = str.end();
-  CHECK(p(f, l, prt));
-  CHECK(f == l);
-  CHECK_EQUAL(prt, port(42, port::unknown));
+  port x;
+  CHECK(parsers::port("42/?"s, x));
+  CHECK(x == port{42, port::unknown});
+  CHECK(parsers::port("7/icmp"s, x));
+  CHECK(x == port{7, port::icmp});
+  CHECK(parsers::port("22/tcp"s, x));
+  CHECK(x == port{22, port::tcp});
+  CHECK(parsers::port("53/udp"s, x));
+  CHECK(x == port{53, port::udp});
+  CHECK(parsers::port("7/icmp6"s, x));
+  CHECK(x == port{7, port::icmp6});
+  CHECK(parsers::port("80/sctp"s, x));
+  CHECK(x == port{80, port::sctp});
 }

--- a/libvast/vast/address.hpp
+++ b/libvast/vast/address.hpp
@@ -138,5 +138,14 @@ private:
   std::array<uint8_t, 16> bytes_;
 };
 
-} // namespace vast
+/// @relates address
+template <class Hasher>
+void hash_append(Hasher& h, const address& x) {
+  auto bytes = x.data().data();
+  if (x.is_v4())
+    h(bytes + 12, 4);
+  else
+    h(bytes, 16);
+}
 
+} // namespace vast

--- a/libvast/vast/community_id.hpp
+++ b/libvast/vast/community_id.hpp
@@ -1,0 +1,157 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include "vast/address.hpp"
+#include "vast/concept/hashable/hash_append.hpp"
+#include "vast/concept/hashable/sha1.hpp"
+#include "vast/detail/base64.hpp"
+#include "vast/detail/byte_swap.hpp"
+#include "vast/detail/coding.hpp"
+#include "vast/port.hpp"
+
+namespace vast {
+namespace policy {
+
+/// Tag type to select Base64 encoding.
+struct base64 {};
+
+/// Tag type to select plain hex ASCII encoding.
+struct ascii {};
+
+} // namespace policy
+
+/// The [Community ID](https://github.com/corelight/community-id-spec) flow
+/// hashing algorithm.
+namespace community_id {
+
+/// The Community ID version.
+constexpr char version = '1';
+
+/// The byte values for transport-layer protocols.
+/// @relates flow_tuple
+enum class protocol : uint8_t {
+  icmp = 1,
+  tcp = 6,
+  udp = 17,
+  icmp6 = 58,
+  sctp = 132,
+};
+
+/// A connection 5-tuple.
+struct flow_tuple {
+  protocol proto;
+  address src_addr;
+  port src_port;
+  address dst_addr;
+  port dst_port;
+};
+
+/// Determines whether the flow is ordered, i.e., has a directionality-agnostic
+/// component-wise total ordering.
+/// @param x The tuple to inspect.
+/// @returns `true` if the flow is ordered.
+/// @relates flow_tuple
+inline bool is_ordered(const flow_tuple& x) noexcept {
+  return x.src_addr < x.dst_addr
+         || (x.src_addr == x.dst_addr && x.src_port < x.dst_port);
+}
+
+/// @relates flow_tuple
+template <class Hasher>
+void hash_append(Hasher& hasher, const flow_tuple& x) {
+  constexpr auto padding = uint8_t{0};
+  auto src_port = detail::to_network_order(x.src_port.number());
+  auto dst_port = detail::to_network_order(x.dst_port.number());
+  if (is_ordered(x)) {
+    hash_append(hasher, x.src_addr);
+    hash_append(hasher, x.dst_addr);
+    hash_append(hasher, x.proto);
+    hash_append(hasher, padding);
+    hash_append(hasher, src_port);
+    hash_append(hasher, dst_port);
+  } else {
+    hash_append(hasher, x.dst_addr);
+    hash_append(hasher, x.src_addr);
+    hash_append(hasher, x.proto);
+    hash_append(hasher, padding);
+    hash_append(hasher, dst_port);
+    hash_append(hasher, src_port);
+  }
+}
+
+/// Computes the length of the version prefix.
+/// @see max_length
+inline constexpr size_t version_prefix_length() {
+  constexpr size_t version_number = 1;
+  constexpr size_t version_separator = 1;
+  return version_number + version_separator;
+}
+
+/// Computes the maximum length of the Community ID string.
+/// @returns An upper bound in bytes.
+/// @see version_prefix_length
+template <class Policy>
+constexpr size_t max_length() {
+  constexpr auto hex_size = (160 / 8) * 2; // 160-bit SHA-1 digest as hex.
+  auto prefix = version_prefix_length();
+  if constexpr (std::is_same_v<Policy, policy::base64>)
+    return prefix + detail::base64::encoded_size(hex_size);
+  else if constexpr (std::is_same_v<Policy, policy::ascii>)
+    return prefix + hex_size;
+  return 0;
+}
+
+/// Calculates the Community ID for a given flow.
+/// @tparam Policy The rendering policy to select Base64 or ASCII.
+/// @param flow The flow tuple.
+/// @param seed An optional seed to the SHA-1 hash.
+/// @returns A string representation of the Community ID for *flow*.
+template <class Policy>
+std::string compute(const flow_tuple& flow, uint16_t seed = 0) {
+  std::string result;
+  // Perform exactly one allocator round-trip.
+  result.reserve(max_length<Policy>());
+  // The version prefix is always present.
+  result += version;
+  result += ':';
+  // Compute a SHA-1 hash over the flow tuple.
+  sha1 hasher;
+  hash_append(hasher, detail::to_network_order(seed));
+  hash_append(hasher, flow);
+  auto digest = static_cast<sha1::result_type>(hasher);
+  // Convert the binary digest to plain hex ASCII or to Base64.
+  constexpr auto element_size = sizeof(sha1::result_type::value_type);
+  constexpr auto num_bytes = element_size * digest.size();
+  auto ptr = reinterpret_cast<const uint8_t*>(digest.data());
+  if constexpr (std::is_same_v<Policy, policy::base64>) {
+    result.resize(max_length<Policy>());
+    auto offset = version_prefix_length();
+    auto n = detail::base64::encode(result.data() + offset, ptr, num_bytes);
+    result.resize(offset + n);
+  } else {
+    for (size_t i = 0; i < num_bytes; ++i) {
+      auto [hi, lo] = detail::byte_to_hex<policy::lowercase>(ptr[i]);
+      result += hi;
+      result += lo;
+    }
+  }
+  return result;
+}
+
+} // namespace community_id
+} // namespace vast

--- a/libvast/vast/community_id.hpp
+++ b/libvast/vast/community_id.hpp
@@ -146,7 +146,7 @@ caf::optional<flow> make_flow(std::string_view orig_h, uint16_t orig_p,
 
 /// Computes the length of the version prefix.
 /// @see max_length
-inline constexpr size_t version_prefix_length() {
+constexpr size_t version_prefix_length() {
   constexpr size_t version_number = 1;
   constexpr size_t version_separator = 1;
   return version_number + version_separator;

--- a/libvast/vast/concept/hashable/sha1.hpp
+++ b/libvast/vast/concept/hashable/sha1.hpp
@@ -1,0 +1,54 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include "vast/detail/endian.hpp"
+
+namespace vast {
+
+/// The [SHA-1](https://en.wikipedia.org/wiki/SHA-1) hash algorithm.
+/// This implementation comes from https://github.com/kerukuro/digestpp.
+class sha1 {
+public:
+  using result_type = std::array<uint32_t, 5>;
+
+  static constexpr detail::endianness endian = detail::host_endian;
+
+  sha1() noexcept;
+
+  void operator()(const void* xs, size_t n) noexcept;
+
+  operator result_type() noexcept;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, sha1& x) {
+    return f(x.H_, x.m_, x.pos_, x.total_);
+  }
+
+private:
+  void finalize();
+
+  void transform(const unsigned char* data, size_t num_blks);
+
+  std::array<uint32_t, 5> H_;
+  std::array<unsigned char, 64> m_;
+  size_t pos_ = 0;
+  uint64_t total_ = 0;
+};
+
+} // namespace vast

--- a/libvast/vast/concept/parseable/vast/port.hpp
+++ b/libvast/vast/concept/parseable/vast/port.hpp
@@ -26,7 +26,16 @@ struct port_type_parser : parser<port_type_parser> {
   bool parse(Iterator& f, const Iterator& l, unused_type) const {
     using namespace parsers;
     using namespace parser_literals;
-    auto p = ("?"_p | "tcp" | "udp" | "icmp");
+    // clang-format off
+    auto p
+      = ( "?"_p
+        | "icmp6"
+        | "icmp"
+        | "tcp"
+        | "udp"
+        | "sctp"
+        );
+    // clang-format on
     return p(f, l, unused);
   }
 
@@ -37,11 +46,12 @@ struct port_type_parser : parser<port_type_parser> {
     // clang-format off
     auto p
       = ( "?"_p ->* [] { return port::unknown; }
-         | "tcp"_p ->* [] { return port::tcp; }
-         | "udp"_p ->* [] { return port::udp; }
-         | "icmp"_p ->* [] { return port::icmp; }
-         )
-      ;
+        | "icmp6"_p ->* [] { return port::icmp6; }
+        | "icmp"_p ->* [] { return port::icmp; }
+        | "tcp"_p ->* [] { return port::tcp; }
+        | "udp"_p ->* [] { return port::udp; }
+        | "sctp"_p ->* [] { return port::sctp; }
+        );
     // clang-format on
     return p(f, l, x);
   }
@@ -73,7 +83,7 @@ struct port_parser : parser<port_parser> {
       port::port_type t;
       if (!p(f, l, n, t))
         return false;
-      x = {n, t};
+      x = port{n, t};
       return true;
     }
   }

--- a/libvast/vast/concept/printable/vast/port.hpp
+++ b/libvast/vast/concept/printable/vast/port.hpp
@@ -32,12 +32,16 @@ struct port_printer : vast::printer<port_printer> {
     switch (p.type()) {
       default:
         return chr<'?'>(out);
+      case port::icmp:
+        return str(out, "icmp");
       case port::tcp:
         return str(out, "tcp");
       case port::udp:
         return str(out, "udp");
-      case port::icmp:
-        return str(out, "icmp");
+      case port::icmp6:
+        return str(out, "icmp6");
+      case port::sctp:
+        return str(out, "sctp");
     }
   }
 };
@@ -48,4 +52,3 @@ struct printer_registry<port> {
 };
 
 } // namespace vast
-

--- a/libvast/vast/detail/base64.hpp
+++ b/libvast/vast/detail/base64.hpp
@@ -1,0 +1,85 @@
+
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+/// [Base64](https://en.wikipedia.org/wiki/Base64) coding.
+namespace vast::detail::base64 {
+
+constexpr char alphabet[] = "ABCDEFGHIJKLMNOP"
+                            "QRSTUVWXYZabcdef"
+                            "ghijklmnopqrstuv"
+                            "wxyz0123456789+/";
+
+constexpr char inverse[] = {
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, //   0-15
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, //  16-31
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63, //  32-47
+  52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1, //  48-63
+  -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, //  64-79
+  15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, //  80-95
+  -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, //  96-111
+  41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1, // 112-127
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 128-143
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 144-159
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 160-175
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 176-191
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 192-207
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 208-223
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 224-239
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1  // 240-255
+};
+
+/// @see decoded_size
+inline constexpr size_t encoded_size(size_t n) {
+  return 4 * ((n + 2) / 3);
+}
+
+/// @see encoded_size
+inline constexpr size_t decoded_size(size_t n) {
+  return n / 4 * 3;
+}
+
+// Base64-encodes a sequence of bytes.
+// @param dst The destination buffer.
+// @param src The beginning of the bytes to encode.
+// @param len The nubmer of bytes to encode starting at *src*.
+// @returns The number of bytes written to *out* without NUL-termination.
+// @requires The destination buffers has at least `encoded_size(len)` bytes.
+// @see encoded_size
+size_t encode(void* dst, const void* src, size_t len);
+
+/// Base64-encodes a string.
+/// @param str The string to encode.
+/// @returns The Base64-encoded version of *str*.
+std::string encode(std::string_view str);
+
+// Decodes a Base64-encoded string into a sequence of bytes.
+// @param dst The destination buffer.
+// @param src The beginning of the bytes to decode.
+// @param len The nubmer of bytes to decode starting at *src*.
+// @returns The number of bytes written to *out* and read from *src*.
+// @requires The destination buffers has at least `decoded_size(len)` bytes.
+// @see decoded_size
+std::pair<size_t, size_t> decode(void* dst, char const* src, size_t len);
+
+/// Decodes a Base64-encoded string.
+/// @param str The string to decode.
+/// @returns The decoded bytes of *str*.
+std::string decode(std::string_view str);
+
+} // namespace vast::detail::base64

--- a/libvast/vast/detail/coding.hpp
+++ b/libvast/vast/detail/coding.hpp
@@ -29,11 +29,9 @@ namespace vast::detail {
 /// @param b The byte to convert.
 /// @returns The ASCII representation of *b*.
 /// @relates byte_to_hex hex_to_byte
-template <
-  class T,
-  class = std::enable_if_t<std::is_integral_v<T>>
->
-char byte_to_char(T b) {
+template <class T>
+constexpr char byte_to_char(T b) {
+  static_assert(std::is_integral_v<T>);
   return b < 10 ? '0' + b : 'a' + b - 10;
 }
 
@@ -66,11 +64,9 @@ constexpr std::pair<char, char> byte_to_hex(T x) {
 /// @param hex The hex character.
 /// @returns The byte value of *hex* or 0 if *hex* is not a valid hex char.
 /// @relates byte_to_hex byte_to_char
-template <
-  class T,
-  class = std::enable_if_t<std::is_integral_v<T>>
->
-char hex_to_byte(T hex) {
+template <class T>
+constexpr char hex_to_byte(T hex) {
+  static_assert(std::is_integral_v<T>);
   if (hex >= '0' && hex <= '9')
     return hex - '0';
   if (hex >= 'A' && hex <= 'F')
@@ -84,11 +80,9 @@ char hex_to_byte(T hex) {
 /// @param hi The high hex nibble.
 /// @param lo The low hex nibble.
 /// @relates byte_to_hex byte_to_char
-template <
-  class T,
-  class = std::enable_if_t<std::is_integral_v<T>>
->
-char hex_to_byte(T hi, T lo) {
+template <class T>
+constexpr char hex_to_byte(T hi, T lo) {
+  static_assert(std::is_integral_v<T>);
   auto byte = hex_to_byte(hi) << 4;
   byte |= hex_to_byte(lo);
   return byte;

--- a/libvast/vast/detail/coding.hpp
+++ b/libvast/vast/detail/coding.hpp
@@ -16,6 +16,8 @@
 #include <limits>
 #include <type_traits>
 
+#include "vast/detail/type_traits.hpp"
+
 namespace vast::policy {
 
 struct uppercase {};
@@ -57,7 +59,7 @@ constexpr std::pair<char, char> byte_to_hex(T x) {
   else if constexpr (std::is_same_v<Policy, policy::lowercase>)
     return byte_to_hex(x, "0123456789abcdef");
   else
-    return {0, 0};
+    static_assert(always_false_v<Policy>, "unsupported policy");
 }
 
 /// Converts a single hex character into its byte value.

--- a/libvast/vast/detail/coding.hpp
+++ b/libvast/vast/detail/coding.hpp
@@ -85,9 +85,7 @@ constexpr char hex_to_byte(T hex) {
 template <class T>
 constexpr char hex_to_byte(T hi, T lo) {
   static_assert(std::is_integral_v<T>);
-  auto byte = hex_to_byte(hi) << 4;
-  byte |= hex_to_byte(lo);
-  return byte;
+  return (hex_to_byte(hi) << 4) | hex_to_byte(lo);
 }
 
 } // namespace vast::detail

--- a/libvast/vast/format/mrt.hpp
+++ b/libvast/vast/format/mrt.hpp
@@ -287,7 +287,6 @@ struct attributes_parser : parser<attributes_parser<TypeCode14Policy>> {
       // can use the combinator style to chain the parser together, as opposed
       // to dispatching manually.
       auto t = f;
-      // clang-format off
       switch (type_code) {
         case 1: {
           auto p = parsers::byte ->* [](uint8_t x) {

--- a/libvast/vast/format/mrt.hpp
+++ b/libvast/vast/format/mrt.hpp
@@ -265,6 +265,7 @@ struct attributes_parser : parser<attributes_parser<TypeCode14Policy>> {
 
   template <class Iterator>
   bool parse(Iterator& f, const Iterator& l, attributes& x) const {
+    // clang-format off
     using namespace parsers;
     for (auto i = 0; i < length; ) {
       // Meta data.
@@ -272,9 +273,9 @@ struct attributes_parser : parser<attributes_parser<TypeCode14Policy>> {
       uint8_t type_code;
       uint16_t attr_length;
       auto is_extended_length = [&] { return (flags & 0b0001'0000) >> 4 == 1; };
-      auto u8to16 = byte ->* [](uint8_t x) { return uint16_t{x}; };
+      auto u8to16 = parsers::byte ->* [](uint8_t x) { return uint16_t{x}; };
       auto len = b16be.when(is_extended_length) | u8to16;
-      auto meta = byte >> byte >> len;
+      auto meta = parsers::byte >> parsers::byte >> len;
       auto before = f;
       if (!meta(f, l, flags, type_code, attr_length))
         return false;
@@ -286,6 +287,7 @@ struct attributes_parser : parser<attributes_parser<TypeCode14Policy>> {
       // can use the combinator style to chain the parser together, as opposed
       // to dispatching manually.
       auto t = f;
+      // clang-format off
       switch (type_code) {
         case 1: {
           auto p = parsers::byte ->* [](uint8_t x) {
@@ -313,7 +315,7 @@ struct attributes_parser : parser<attributes_parser<TypeCode14Policy>> {
           auto as16 = b16be ->* [](uint16_t x) { return uint32_t{x}; };
           auto as32 = b32be;
           auto as = as32.when([&] { return as4; }) | as16;
-          auto p = byte >> byte >> rep(as, path_segment_length);
+          auto p = parsers::byte >> parsers::byte >> rep(as, path_segment_length);
           if (!p(t, l, path_segment_type, path_segment_length, x.as_path))
             return false;
           break;
@@ -367,7 +369,7 @@ struct attributes_parser : parser<attributes_parser<TypeCode14Policy>> {
             // to reflect only the length of the Next Hop Address Length and
             // Next Hop Address fields.
             uint8_t next_hop_network_address_length = 0;
-            if (!byte(t, l, next_hop_network_address_length))
+            if (!parsers::byte(t, l, next_hop_network_address_length))
               return false;
             auto mp_next_hop
               = detail::make_ip_v4_v6_parser([&] { return afi4; });
@@ -384,7 +386,7 @@ struct attributes_parser : parser<attributes_parser<TypeCode14Policy>> {
               auto offset = addr_family_id == 1 ? 4 : 16;
               t += next_hop_addr_len - offset + 1;
             });
-            auto p = b16be >> byte >> byte >> mp_next_hop;
+            auto p = b16be >> parsers::byte >> parsers::byte >> mp_next_hop;
             if (!p(t, l, addr_family_id, subsequent_addr_family_id,
                    next_hop_addr_len, x.next_hop))
               return false;
@@ -404,7 +406,7 @@ struct attributes_parser : parser<attributes_parser<TypeCode14Policy>> {
         case 15: {
           uint16_t addr_family_id = 0;
           uint8_t subsequent_addr_family_id = 0;
-          auto p = b16be >> byte;
+          auto p = b16be >> parsers::byte;
           if (!p(t, l, addr_family_id, subsequent_addr_family_id))
             return false;
           auto family = addr_family_id == 1 ? address::ipv4 : address::ipv6;
@@ -427,6 +429,7 @@ struct attributes_parser : parser<attributes_parser<TypeCode14Policy>> {
       f += attr_length;
     }
     return true;
+    // clang-format on
   }
 
   const uint16_t& length;
@@ -440,9 +443,11 @@ struct message_header_parser : parser<message_header_parser> {
 
   template <class Iterator>
   bool parse(Iterator& f, const Iterator& l, message_header& x) const {
+    // clang-format off
     using namespace parsers;
-    auto p = bytes<16> >> b16be >> byte;
+    auto p = bytes<16> >> b16be >> parsers::byte;
     return p(f, l, x.marker, x.length, x.type);
+    // clang-format on
   }
 };
 
@@ -457,7 +462,7 @@ struct open_parser : parser<open_parser> {
       f += std::min(static_cast<size_t>(l - f),
                     static_cast<size_t>(x.opt_parm_len));
     };
-    auto p = (byte >> b16be >> b16be >> b32be >> byte) ->* skip;
+    auto p = (parsers::byte >> b16be >> b16be >> b32be >> parsers::byte)->*skip;
     return p(f, l, x.version, x.my_autonomous_system, x.hold_time,
              x.bgp_identifier, x.opt_parm_len);
   }
@@ -503,10 +508,12 @@ struct notification_parser : parser<notification_parser> {
 
   template <class Iterator>
   bool parse(Iterator& f, const Iterator& l, notification& x) const {
+    // clang-format off
     using namespace parsers;
     auto skip = [&] { f += (l - f); };
-    auto p = (byte >> byte) ->* skip;
+    auto p = (parsers::byte >> parsers::byte) ->* skip;
     return p(f, l, x.error_code, x.error_subcode);
+    // clang-format on
   }
 };
 
@@ -940,7 +947,7 @@ struct peer_entry_parser : parser<peer_entry_parser> {
     auto to_u32 = [](uint16_t u) { return uint32_t{u}; };
     auto peer_as
       = (b16be ->* to_u32).when([&] { return (x.peer_type & 2) == 0; }) | b32be;
-    auto p = byte >> b32be >> ip_addr >> peer_as;
+    auto p = parsers::byte >> b32be >> ip_addr >> peer_as;
     return p(f, l, x.peer_type, x.peer_bgp_id, x.peer_ip_address, x.peer_as);
   }
 };

--- a/libvast/vast/icmp.hpp
+++ b/libvast/vast/icmp.hpp
@@ -1,0 +1,120 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+#include <caf/optional.hpp>
+
+namespace vast {
+
+/// ICMP message type.
+/// @see icmp6_type
+enum class icmp_type : uint8_t {
+  echo_reply = 0,
+  echo = 8,
+  rtr_advert = 9,
+  rtr_solicit = 10,
+  tstamp = 13,
+  tstamp_reply = 14,
+  info = 15,
+  info_reply = 16,
+  mask = 17,
+  mask_reply = 18,
+};
+
+/// ICMP6 message type.
+/// @see icmp_type
+enum class icmp6_type : uint8_t {
+  echo_request = 128,
+  echo_reply = 129,
+  mld_listener_query = 130,
+  mld_listener_report = 131,
+  nd_router_solicit = 133,
+  nd_router_advert = 134,
+  nd_neighbor_solicit = 135,
+  nd_neighbor_advert = 136,
+  wru_request = 139,
+  wru_reply = 140,
+  haad_request = 144,
+  haad_reply = 145,
+};
+
+/// Computes the dual to a given ICMP type.
+/// @param x The ICMP type.
+/// @returns For a request type, the response type - and vice versa.
+/// @relates icmp_type
+inline caf::optional<icmp_type> dual(icmp_type x) {
+  switch (x) {
+    default:
+      return caf::none;
+    case icmp_type::echo:
+      return icmp_type::echo_reply;
+    case icmp_type::echo_reply:
+      return icmp_type::echo;
+    case icmp_type::tstamp:
+      return icmp_type::tstamp_reply;
+    case icmp_type::tstamp_reply:
+      return icmp_type::tstamp;
+    case icmp_type::info:
+      return icmp_type::info_reply;
+    case icmp_type::info_reply:
+      return icmp_type::info;
+    case icmp_type::rtr_solicit:
+      return icmp_type::rtr_advert;
+    case icmp_type::rtr_advert:
+      return icmp_type::rtr_solicit;
+    case icmp_type::mask:
+      return icmp_type::mask_reply;
+    case icmp_type::mask_reply:
+      return icmp_type::mask;
+  }
+}
+
+/// Computes the dual to a given ICMP6 type.
+/// @param x The ICMP6 type.
+/// @returns For a request type, the response type - and vice versa.
+/// @relates icmp6_type
+inline caf::optional<icmp6_type> dual(icmp6_type x) {
+  switch (x) {
+    default:
+      return caf::none;
+    case icmp6_type::echo_request:
+      return icmp6_type::echo_reply;
+    case icmp6_type::echo_reply:
+      return icmp6_type::echo_request;
+    case icmp6_type::mld_listener_query:
+      return icmp6_type::mld_listener_report;
+    case icmp6_type::mld_listener_report:
+      return icmp6_type::mld_listener_query;
+    case icmp6_type::nd_router_solicit:
+      return icmp6_type::nd_router_advert;
+    case icmp6_type::nd_router_advert:
+      return icmp6_type::nd_router_solicit;
+    case icmp6_type::nd_neighbor_solicit:
+      return icmp6_type::nd_neighbor_advert;
+    case icmp6_type::nd_neighbor_advert:
+      return icmp6_type::nd_neighbor_solicit;
+    case icmp6_type::wru_request:
+      return icmp6_type::wru_reply;
+    case icmp6_type::wru_reply:
+      return icmp6_type::wru_request;
+    case icmp6_type::haad_request:
+      return icmp6_type::haad_reply;
+    case icmp6_type::haad_reply:
+      return icmp6_type::haad_request;
+  }
+}
+
+} // namespace vast

--- a/libvast/vast/icmp.hpp
+++ b/libvast/vast/icmp.hpp
@@ -15,7 +15,7 @@
 
 #include <cstdint>
 
-#include <caf/optional.hpp>
+#include <caf/fwd.hpp>
 
 namespace vast {
 
@@ -55,66 +55,12 @@ enum class icmp6_type : uint8_t {
 /// @param x The ICMP type.
 /// @returns For a request type, the response type - and vice versa.
 /// @relates icmp_type
-inline caf::optional<icmp_type> dual(icmp_type x) {
-  switch (x) {
-    default:
-      return caf::none;
-    case icmp_type::echo:
-      return icmp_type::echo_reply;
-    case icmp_type::echo_reply:
-      return icmp_type::echo;
-    case icmp_type::tstamp:
-      return icmp_type::tstamp_reply;
-    case icmp_type::tstamp_reply:
-      return icmp_type::tstamp;
-    case icmp_type::info:
-      return icmp_type::info_reply;
-    case icmp_type::info_reply:
-      return icmp_type::info;
-    case icmp_type::rtr_solicit:
-      return icmp_type::rtr_advert;
-    case icmp_type::rtr_advert:
-      return icmp_type::rtr_solicit;
-    case icmp_type::mask:
-      return icmp_type::mask_reply;
-    case icmp_type::mask_reply:
-      return icmp_type::mask;
-  }
-}
+caf::optional<icmp_type> dual(icmp_type x);
 
 /// Computes the dual to a given ICMP6 type.
 /// @param x The ICMP6 type.
 /// @returns For a request type, the response type - and vice versa.
 /// @relates icmp6_type
-inline caf::optional<icmp6_type> dual(icmp6_type x) {
-  switch (x) {
-    default:
-      return caf::none;
-    case icmp6_type::echo_request:
-      return icmp6_type::echo_reply;
-    case icmp6_type::echo_reply:
-      return icmp6_type::echo_request;
-    case icmp6_type::mld_listener_query:
-      return icmp6_type::mld_listener_report;
-    case icmp6_type::mld_listener_report:
-      return icmp6_type::mld_listener_query;
-    case icmp6_type::nd_router_solicit:
-      return icmp6_type::nd_router_advert;
-    case icmp6_type::nd_router_advert:
-      return icmp6_type::nd_router_solicit;
-    case icmp6_type::nd_neighbor_solicit:
-      return icmp6_type::nd_neighbor_advert;
-    case icmp6_type::nd_neighbor_advert:
-      return icmp6_type::nd_neighbor_solicit;
-    case icmp6_type::wru_request:
-      return icmp6_type::wru_reply;
-    case icmp6_type::wru_reply:
-      return icmp6_type::wru_request;
-    case icmp6_type::haad_request:
-      return icmp6_type::haad_reply;
-    case icmp6_type::haad_reply:
-      return icmp6_type::haad_request;
-  }
-}
+caf::optional<icmp6_type> dual(icmp6_type x);
 
 } // namespace vast

--- a/libvast/vast/port.hpp
+++ b/libvast/vast/port.hpp
@@ -28,14 +28,16 @@ public:
 
   /// The transport layer type.
   enum port_type : uint8_t {
-    unknown = 0,
-    tcp,
-    udp,
-    icmp
+    icmp = 1,
+    tcp = 6,
+    udp = 17,
+    icmp6 = 58,
+    sctp = 132,
+    unknown = 255,
   };
 
   /// Constructs the empty port, i.e., `0/unknown`.
-  port() = default;
+  port();
 
   /// Constructs a port.
   /// @param n The port number.
@@ -73,4 +75,3 @@ private:
 bool convert(const port& p, json& j);
 
 } // namespace vast
-

--- a/libvast/vast/span.hpp
+++ b/libvast/vast/span.hpp
@@ -629,9 +629,10 @@ auto make_byte_span(T* data, Size size) {
     byte
   >;
   auto ptr = reinterpret_cast<byte_type*>(data);
+  auto size_in_bytes = size * sizeof(T);
   using span_type = span<byte_type>;
   using index_type = typename span_type::index_type;
-  return span_type{ptr, detail::narrow_cast<index_type>(size)};
+  return span_type{ptr, detail::narrow_cast<index_type>(size_in_bytes)};
 }
 
 /// @relates make_byte_span


### PR DESCRIPTION
This PR adds a the [Community ID](https://github.com/corelight/community-id-spec) to PCAP packet data.