### PR TITLE
Rename #time to #timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🔄 Log files generally have some notion of timestamp for recorded events. To
+  make the query language more intuitive, the syntax for querying time points
+  thus changed from `#time` to `#timestamp`. For example,
+  `#time > 2019-07-02+12:00:00` now reads `#timestamp > 2019-07-02+12:00:00`.
+
 - 🎁 Configuring how much status information gets printed to STDERR previously
   required obscure config settings. From now on, users can simply use
   `--verbosity=<level>`, where `<level>` is one of `quiet`, `error`, `warn`,

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -129,7 +129,7 @@ set(libvast_sources
   src/table_slice_builder_factory.cpp
   src/table_slice_factory.cpp
   src/time.cpp
-  src/timestamp_synopsis.cpp
+  src/time_synopsis.cpp
   src/to_events.cpp
   src/type.cpp
   src/uuid.cpp

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -71,8 +71,8 @@ struct adder {
   }
 
   template <class T>
-  void operator()(timespan& x, const T& y) {
-    if constexpr (std::is_same_v<T, timespan>) {
+  void operator()(duration& x, const T& y) {
+    if constexpr (std::is_same_v<T, duration>) {
       x += y;
     } else if constexpr (detail::is_any_v<T, vector, set>) {
       lift(x, y);
@@ -80,8 +80,8 @@ struct adder {
   }
 
   template <class T>
-  void operator()(timestamp& x, const T& y) {
-    if constexpr (std::is_same_v<T, timespan>) {
+  void operator()(time& x, const T& y) {
+    if constexpr (std::is_same_v<T, duration>) {
       x += y;
     } else if constexpr (detail::is_any_v<T, vector, set>) {
       lift(x, y);

--- a/libvast/src/event.cpp
+++ b/libvast/src/event.cpp
@@ -38,11 +38,11 @@ id event::id() const {
   return id_;
 }
 
-void event::timestamp(vast::timestamp ts) {
+void event::timestamp(time ts) {
   timestamp_ = ts;
 }
 
-vast::timestamp event::timestamp() const {
+time event::timestamp() const {
   return timestamp_;
 }
 

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -254,8 +254,8 @@ expected<void> validator::operator()(const attribute_extractor& ex,
     return make_error(ec::syntax_error,
                       "type attribute extractor requires string operand",
                       ex.attr, op_, d);
-  else if (ex.attr == system::time_atom::value
-           && !caf::holds_alternative<timestamp>(d))
+  else if (ex.attr == system::timestamp_atom::value
+           && !caf::holds_alternative<time>(d))
     return make_error(ec::syntax_error,
                       "time attribute extractor requires timestamp operand",
                       ex.attr, op_, d);
@@ -512,7 +512,7 @@ bool event_evaluator::operator()(const attribute_extractor& e, const data& d) {
   // with the corresponding function object.
   if (e.attr == system::type_atom::value)
     return evaluate(event_.type().name(), op_, d);
-  if (e.attr == system::time_atom::value)
+  if (e.attr == system::timestamp_atom::value)
     return evaluate(event_.timestamp(), op_, d);
   return false;
 }
@@ -577,10 +577,10 @@ bool table_slice_row_evaluator::operator()(const attribute_extractor& e,
   // with the corresponding function object.
   if (e.attr == system::type_atom::value)
     return evaluate(slice_.layout().name(), op_, d);
-  if (e.attr == system::time_atom::value) {
+  if (e.attr == system::timestamp_atom::value) {
     auto pred = [](auto& x) {
-      return caf::holds_alternative<timestamp_type>(x.type)
-             && has_attribute(x.type, "time");
+      return caf::holds_alternative<time_type>(x.type)
+             && has_attribute(x.type, "timestamp");
     };
     auto& fs = slice_.layout().fields;
     auto i = std::find_if(fs.begin(), fs.end(), pred);
@@ -657,7 +657,7 @@ bool matcher::operator()(const attribute_extractor& e, const data& d) {
   if (e.attr == system::type_atom::value) {
     VAST_ASSERT(caf::holds_alternative<std::string>(d));
     return evaluate(d, op_, type_.name());
-  } else if (e.attr == system::time_atom::value) {
+  } else if (e.attr == system::timestamp_atom::value) {
     return true; // Every event has a timestamp.
   }
   return false;

--- a/libvast/src/format/bgpdump.cpp
+++ b/libvast/src/format/bgpdump.cpp
@@ -20,7 +20,7 @@ namespace bgpdump {
 bgpdump_parser::bgpdump_parser() {
   // Announce type.
   auto fields = std::vector<record_field>{
-    {"timestamp", timestamp_type{}.attributes({{"time"}})},
+    {"time", time_type{}.attributes({{"timestamp"}})},
     {"source_ip", address_type{}},
     {"source_as", count_type{}},
     {"prefix", subnet_type{}},
@@ -38,7 +38,7 @@ bgpdump_parser::bgpdump_parser() {
   // Route & withdraw type.
   route_type = record_type{std::move(fields)}.name("bgpdump.routing");
   auto withdraw_fields = std::vector<record_field>{
-    {"timestamp", timestamp_type{}.attributes({{"time"}})},
+    {"time", time_type{}.attributes({{"timestamp"}})},
     {"source_ip", address_type{}},
     {"source_as", count_type{}},
     {"prefix", subnet_type{}},
@@ -47,7 +47,7 @@ bgpdump_parser::bgpdump_parser() {
     "bgpdump.withdrawn");
   // State-change type.
   auto state_change_fields = std::vector<record_field>{
-    {"timestamp", timestamp_type{}.attributes({{"time"}})},
+    {"time", time_type{}.attributes({{"timestamp"}})},
     {"source_ip", address_type{}},
     {"source_as", count_type{}},
     {"old_state", string_type{}},

--- a/libvast/src/format/json.cpp
+++ b/libvast/src/format/json.cpp
@@ -60,15 +60,15 @@ struct convert {
     return port{detail::narrow_cast<port::number_type>(n)};
   }
 
-  expected<data> operator()(json::number s, const timestamp_type&) const {
+  expected<data> operator()(json::number s, const time_type&) const {
     auto secs = std::chrono::duration<json::number>(s);
-    auto since_epoch = std::chrono::duration_cast<timespan>(secs);
-    return timestamp{since_epoch};
+    auto since_epoch = std::chrono::duration_cast<duration>(secs);
+    return time{since_epoch};
   }
 
-  expected<data> operator()(json::number s, const timespan_type&) const {
+  expected<data> operator()(json::number s, const duration_type&) const {
     auto secs = std::chrono::duration<json::number>(s);
-    return std::chrono::duration_cast<timespan>(secs);
+    return std::chrono::duration_cast<duration>(secs);
   }
 
   expected<data> operator()(json::string s, const string_type&) const {

--- a/libvast/src/format/mrt.cpp
+++ b/libvast/src/format/mrt.cpp
@@ -12,8 +12,8 @@ namespace mrt {
 reader::factory::factory(reader& parent, uint32_t ts)
   : parent_(parent), produced_(0) {
   using namespace std::chrono;
-  auto since_epoch = duration<uint32_t>{ts};
-  timestamp_ = timestamp{duration_cast<timespan>(since_epoch)};
+  auto since_epoch = std::chrono::duration<uint32_t>{ts};
+  timestamp_ = time{duration_cast<duration>(since_epoch)};
 }
 
 caf::error reader::factory::operator()(caf::none_t) const {

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -30,7 +30,7 @@ namespace pcap {
 namespace {
 
 inline type make_packet_type() {
-  return record_type{{"timestamp", timestamp_type{}.attributes({{"time"}})},
+  return record_type{{"time", time_type{}.attributes({{"timestamp"}})},
                      {"src", address_type{}},
                      {"dst", address_type{}},
                      {"sport", port_type{}},
@@ -276,7 +276,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     // Extract timestamp.
     using namespace std::chrono;
     auto secs = seconds(header->ts.tv_sec);
-    auto ts = timestamp{duration_cast<timespan>(secs)};
+    auto ts = time{duration_cast<duration>(secs)};
 #ifdef PCAP_TSTAMP_PRECISION_NANO
     ts += nanoseconds(header->ts.tv_usec);
 #else
@@ -297,7 +297,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
                      ts.time_since_epoch().count(), '<',
                      last_timestamp_.time_since_epoch().count());
       }
-      if (last_timestamp_ != timestamp::min()) {
+      if (last_timestamp_ != time::min()) {
         auto delta = ts - last_timestamp_;
         std::this_thread::sleep_for(delta / pseudo_realtime_);
       }
@@ -342,7 +342,7 @@ expected<void> writer::write(const event& e) {
   auto& payload = caf::get<std::string>(xs[5]);
   // Make PCAP header.
   ::pcap_pkthdr header;
-  auto ns = caf::get<timestamp>(xs[0]).time_since_epoch().count();
+  auto ns = caf::get<time>(xs[0]).time_since_epoch().count();
   header.ts.tv_sec = ns / 1000000000;
 #ifdef PCAP_TSTAMP_PRECISION_NANO
   header.ts.tv_usec = ns % 1000000000;

--- a/libvast/src/format/test.cpp
+++ b/libvast/src/format/test.cpp
@@ -144,12 +144,12 @@ struct randomizer {
     x = static_cast<real>(sample());
   }
 
-  auto operator()(const timestamp_type&, timestamp& x) {
-    x += std::chrono::duration_cast<timespan>(double_seconds(sample()));
+  auto operator()(const time_type&, time& x) {
+    x += std::chrono::duration_cast<duration>(double_seconds(sample()));
   }
 
-  auto operator()(const timespan_type&, timespan& x) {
-    x += std::chrono::duration_cast<timespan>(double_seconds(sample()));
+  auto operator()(const duration_type&, duration& x) {
+    x += std::chrono::duration_cast<duration>(double_seconds(sample()));
   }
 
   void operator()(const bool_type&, bool& b) {

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -52,9 +52,9 @@ expected<type> parse_type(std::string_view zeek_type) {
   else if (zeek_type == "double")
     t = real_type{};
   else if (zeek_type == "time")
-    t = timestamp_type{};
+    t = time_type{};
   else if (zeek_type == "interval")
-    t = timespan_type{};
+    t = duration_type{};
   else if (zeek_type == "pattern")
     t = pattern_type{};
   else if (zeek_type == "addr")
@@ -102,11 +102,11 @@ struct zeek_type_printer {
     return "double";
   }
 
-  std::string operator()(const timestamp_type&) {
+  std::string operator()(const time_type&) {
     return "time";
   }
 
-  std::string operator()(const timespan_type&) {
+  std::string operator()(const duration_type&) {
     return "interval";
   }
 
@@ -192,7 +192,7 @@ struct streamer {
     p.print(out, r);
   }
 
-  void operator()(const timestamp_type&, timestamp ts) const {
+  void operator()(const time_type&, time ts) const {
     double d;
     convert(ts.time_since_epoch(), d);
     auto p = real_printer<real, 6, 6>{};
@@ -200,7 +200,7 @@ struct streamer {
     p.print(out, d);
   }
 
-  void operator()(const timespan_type&, timespan span) const {
+  void operator()(const duration_type&, duration span) const {
     double d;
     convert(span, d);
     auto p = real_printer<real, 6, 6>{};
@@ -523,7 +523,7 @@ caf::error reader::parse_header() {
   auto ts_pred = [&](auto& field) {
     if (field.name != "ts")
       return false;
-    if (!caf::holds_alternative<timestamp_type>(field.type)) {
+    if (!caf::holds_alternative<time_type>(field.type)) {
       VAST_WARNING(this, "encountered ts fields not of type timestamp");
       return false;
     }
@@ -533,7 +533,7 @@ caf::error reader::parse_header() {
   if (i != layout_.fields.end()) {
     VAST_DEBUG(this, "auto-detected field",
                std::distance(layout_.fields.begin(), i), "as event timestamp");
-    i->type.attributes({{"time"}});
+    i->type.attributes({{"timestamp"}});
   }
   // After having modified layout attributes, we no longer make changes to the
   // type and can now safely copy it.

--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -23,7 +23,7 @@
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/synopsis_factory.hpp"
-#include "vast/timestamp_synopsis.hpp"
+#include "vast/time_synopsis.hpp"
 
 #include "vast/detail/overload.hpp"
 

--- a/libvast/src/synopsis_factory.cpp
+++ b/libvast/src/synopsis_factory.cpp
@@ -14,13 +14,13 @@
 #include "vast/synopsis_factory.hpp"
 
 #include "vast/bool_synopsis.hpp"
-#include "vast/timestamp_synopsis.hpp"
+#include "vast/time_synopsis.hpp"
 
 namespace vast {
 
 void factory_traits<synopsis>::initialize() {
   factory<synopsis>::add<bool_type, bool_synopsis>();
-  factory<synopsis>::add<timestamp_type, timestamp_synopsis>();
+  factory<synopsis>::add<time_type, time_synopsis>();
 }
 
 } // namespace vast

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -125,8 +125,7 @@ void importer_state::send_report() {
   auto now = stopwatch::now();
   if (measurement_.events > 0) {
     using namespace std::string_literals;
-    auto elapsed = std::chrono::duration_cast<measurement::timespan>(
-      now - last_report);
+    auto elapsed = std::chrono::duration_cast<duration>(now - last_report);
     auto node_throughput = measurement{elapsed, measurement_.events};
     auto r = performance_report{
       {{"importer"s, measurement_}, {"node_throughput"s, node_throughput}}};

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -127,7 +127,7 @@ caf::actor fetch_indexer(table_indexer& tbl, const attribute_extractor& ex,
       return [=](const curried_predicate&) { return row_ids; };
     });
   }
-  if (ex.attr == system::time_atom::value) {
+  if (ex.attr == system::timestamp_atom::value) {
     if (!caf::holds_alternative<timestamp>(x)) {
       VAST_WARNING(tbl.state().self,
                    "expected a timestamp as time extractor attribute , got:",
@@ -136,8 +136,8 @@ caf::actor fetch_indexer(table_indexer& tbl, const attribute_extractor& ex,
     }
     // Find the column with attribute 'time'.
     auto pred = [](auto& x) {
-      return caf::holds_alternative<timestamp_type>(x.type)
-             && has_attribute(x.type, "time");
+      return caf::holds_alternative<time_type>(x.type)
+             && has_attribute(x.type, "timestamp");
     };
     auto& fs = layout.fields;
     auto i = std::find_if(fs.begin(), fs.end(), pred);

--- a/libvast/src/time.cpp
+++ b/libvast/src/time.cpp
@@ -18,12 +18,12 @@ namespace vast {
 
 using std::chrono::duration_cast;
 
-bool convert(timespan dur, double& d) {
+bool convert(duration dur, double& d) {
   d = duration_cast<double_seconds>(dur).count();
   return true;
 }
 
-bool convert(timespan dur, json& j) {
+bool convert(duration dur, json& j) {
   double time_since_epoch;
   if (!convert(dur, time_since_epoch))
     return false;
@@ -31,11 +31,11 @@ bool convert(timespan dur, json& j) {
   return true;
 }
 
-bool convert(timestamp ts, double& d) {
+bool convert(time ts, double& d) {
   return convert(ts.time_since_epoch(), d);
 }
 
-bool convert(timestamp ts, json& j) {
+bool convert(time ts, json& j) {
   return convert(ts.time_since_epoch(), j);
 }
 

--- a/libvast/src/time_synopsis.cpp
+++ b/libvast/src/time_synopsis.cpp
@@ -11,18 +11,21 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#pragma once
-
-#include "vast/min_max_synopsis.hpp"
-#include "vast/synopsis.hpp"
+#include "vast/time_synopsis.hpp"
 
 namespace vast {
 
-class timestamp_synopsis final : public min_max_synopsis<timestamp> {
-public:
-  timestamp_synopsis(vast::type x);
+time_synopsis::time_synopsis(vast::type x)
+  : min_max_synopsis<time>{std::move(x), time::max(),
+                                time::min()} {
+  // nop
+}
 
-  bool equals(const synopsis& other) const noexcept override;
-};
+bool time_synopsis::equals(const synopsis& other) const noexcept {
+  if (typeid(other) != typeid(time_synopsis))
+    return false;
+  auto& dref = static_cast<const time_synopsis&>(other);
+  return type() == dref.type() && min() == dref.min() && max() == dref.max();
+}
 
 } // namespace vast

--- a/libvast/src/time_synopsis.cpp
+++ b/libvast/src/time_synopsis.cpp
@@ -16,8 +16,7 @@
 namespace vast {
 
 time_synopsis::time_synopsis(vast::type x)
-  : min_max_synopsis<time>{std::move(x), time::max(),
-                                time::min()} {
+  : min_max_synopsis<time>{std::move(x), time::max(), time::min()} {
   // nop
 }
 

--- a/libvast/src/to_events.cpp
+++ b/libvast/src/to_events.cpp
@@ -28,7 +28,7 @@ namespace {
 
 optional<size_t> find_time_column(record_type layout) {
   for (size_t i = 0; i < layout.fields.size(); ++i)
-    if (has_attribute(layout.fields[i].type, "time"))
+    if (has_attribute(layout.fields[i].type, "timestamp"))
       return i;
   return caf::none;
 }
@@ -46,7 +46,7 @@ event to_event(const table_slice& slice, id eid, type event_layout,
   // Assign event timestamp.
   if (timestamp_column) {
     auto& xs = caf::get<vector>(e.data());
-    auto ts = caf::get<timestamp>(xs[*timestamp_column]);
+    auto ts = caf::get<time>(xs[*timestamp_column]);
     e.timestamp(ts);
   }
   return e;

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -541,11 +541,11 @@ struct data_congruence_checker {
     return true;
   }
 
-  bool operator()(const timespan_type&, timespan) const {
+  bool operator()(const duration_type&, duration) const {
     return true;
   }
 
-  bool operator()(const timestamp_type&, timestamp) const {
+  bool operator()(const time_type&, time) const {
     return true;
   }
 
@@ -784,8 +784,8 @@ const char* kind_tbl[] = {
   "int",
   "count",
   "real",
-  "timespan",
-  "timestamp",
+  "duration",
+  "time",
   "string",
   "pattern",
   "address",

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -779,24 +779,9 @@ std::string to_digest(const type& x) {
 namespace {
 
 const char* kind_tbl[] = {
-  "none",
-  "bool",
-  "int",
-  "count",
-  "real",
-  "duration",
-  "time",
-  "string",
-  "pattern",
-  "address",
-  "subnet",
-  "port",
-  "enumeration",
-  "vector",
-  "set",
-  "map",
-  "record",
-  "alias",
+  "none",        "bool",   "int",     "count",   "real",   "duration",
+  "time",        "string", "pattern", "address", "subnet", "port",
+  "enumeration", "vector", "set",     "map",     "record", "alias",
 };
 
 using caf::detail::tl_size;

--- a/libvast/src/value_index_factory.cpp
+++ b/libvast/src/value_index_factory.cpp
@@ -55,7 +55,7 @@ value_index_ptr make(type x) {
 template <class T>
 value_index_ptr make_arithmetic(type x) {
   static_assert(detail::is_any_v<T, integer_type, count_type, real_type,
-                timespan_type, timestamp_type>);
+                                 duration_type, time_type>);
   using concrete_data = type_to_data<T>;
   using value_index_type = arithmetic_index<concrete_data>;
   if (auto base = parse_base(x))
@@ -89,8 +89,8 @@ void factory_traits<value_index>::initialize() {
   add_arithmetic_index_factory<integer_type>();
   add_arithmetic_index_factory<count_type>();
   add_arithmetic_index_factory<real_type>();
-  add_arithmetic_index_factory<timespan_type>();
-  add_arithmetic_index_factory<timestamp_type>();
+  add_arithmetic_index_factory<duration_type>();
+  add_arithmetic_index_factory<time_type>();
   add_value_index_factory<address_type, address_index>();
   add_value_index_factory<subnet_type, subnet_index>();
   add_value_index_factory<port_type, port_index>();

--- a/libvast/test/event.cpp
+++ b/libvast/test/event.cpp
@@ -59,10 +59,10 @@ TEST(basics) {
   REQUIRE(caf::holds_alternative<record_type>(e.type()));
   MESSAGE("meta data");
   CHECK_EQUAL(e.id(), 123456789ull);
-  auto now = timestamp::clock::now();
+  auto now = time::clock::now();
   e.timestamp(now);
   CHECK_EQUAL(e.timestamp(), now);
-  e.timestamp(timestamp{});
+  e.timestamp(vast::time{});
 }
 
 TEST(flattening) {

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -207,17 +207,17 @@ TEST(validation - attribute extractor) {
   expr = to<expression>("#type == zeek.conn");
   REQUIRE(expr);
   CHECK(!caf::visit(validator{}, *expr));
-  // The "time" attribute extractor requires a timestamp operand.
-  expr = to<expression>("#time < now");
+  // The "timestamp" attribute extractor requires a timestamp operand.
+  expr = to<expression>("#timestamp < now");
   REQUIRE(expr);
   CHECK(caf::visit(validator{}, *expr));
-  expr = to<expression>("#time < 2017-06-16");
+  expr = to<expression>("#timestamp < 2017-06-16");
   REQUIRE(expr);
   CHECK(caf::visit(validator{}, *expr));
-  expr = to<expression>("#time > -42");
+  expr = to<expression>("#timestamp > -42");
   REQUIRE(expr);
   CHECK(!caf::visit(validator{}, *expr));
-  expr = to<expression>("#time > -42 secs");
+  expr = to<expression>("#timestamp > -42 secs");
   REQUIRE(expr);
   CHECK(!caf::visit(validator{}, *expr));
 }

--- a/libvast/test/expression_evaluation.cpp
+++ b/libvast/test/expression_evaluation.cpp
@@ -51,7 +51,7 @@ struct fixture : fixtures::events {
     e0 = event::make(vector{"babba", 1.337, 42u, 100, "bar", -4.8}, foo);
     e1 = event::make(vector{"yadda", vector{false, "baz"}}, bar);
     MESSAGE("event meta data queries");
-    auto tp = to<timestamp>("2014-01-16+05:30:12");
+    auto tp = to<vast::time>("2014-01-16+05:30:12");
     REQUIRE(tp);
     e.timestamp(*tp);
     auto t = alias_type{}.name("foo"); // nil type, for meta data only
@@ -71,10 +71,11 @@ struct fixture : fixtures::events {
 FIXTURE_SCOPE(evaluation_tests, fixture)
 
 TEST(evaluation - attributes) {
-  auto ast = to<expression>("#time == 2014-01-16+05:30:12");
+  auto ast = to<expression>("#timestamp == 2014-01-16+05:30:12");
   REQUIRE(ast);
   CHECK(caf::visit(event_evaluator{e}, *ast));
-  ast = to<expression>("#time == 2015-01-16+05:30:12"); // slight data change
+  // slight data change
+  ast = to<expression>("#timestamp == 2015-01-16+05:30:12");
   REQUIRE(ast);
   CHECK(!caf::visit(event_evaluator{e}, *ast));
   ast = to<expression>("#type == \"foo\"");
@@ -166,7 +167,7 @@ TEST(evaluation - table slice rows) {
     return unbox(caf::visit(type_resolver{layout}, ast));
   };
   // Run some checks on various rows.
-  CHECK(evaluate_at(*slice, 0, tailored("#time < 2009-12-18+00:00:00")));
+  CHECK(evaluate_at(*slice, 0, tailored("#timestamp < 2009-12-18+00:00:00")));
   CHECK(evaluate_at(*slice, 0, tailored("orig_h == 192.168.1.102")));
   CHECK(evaluate_at(*slice, 0, tailored(":addr == 192.168.1.102")));
   CHECK(evaluate_at(*slice, 1, tailored("orig_h != 192.168.1.102")));

--- a/libvast/test/expression_parseable.cpp
+++ b/libvast/test/expression_parseable.cpp
@@ -26,7 +26,7 @@
 using namespace vast;
 using namespace std::string_literals;
 
-using vast::system::time_atom;
+using vast::system::timestamp_atom;
 using vast::system::type_atom;
 
 TEST(parseable/printable - predicate) {
@@ -67,11 +67,11 @@ TEST(parseable/printable - predicate) {
   CHECK(pred.rhs == data{-4.8});
   CHECK_EQUAL(to_string(pred), str);
   // LHS: data, RHS: time
-  str = "now > #time";
+  str = "now > #timestamp";
   CHECK(parsers::predicate(str, pred));
   CHECK(caf::holds_alternative<data>(pred.lhs));
   CHECK(pred.op == greater);
-  CHECK(pred.rhs == attribute_extractor{time_atom::value});
+  CHECK(pred.rhs == attribute_extractor{timestamp_atom::value});
   str = "x.a_b == y.c_d";
   CHECK(parsers::predicate(str, pred));
   CHECK(pred.lhs == key_extractor{"x.a_b"});
@@ -95,8 +95,8 @@ TEST(parseable - expression) {
   CHECK(parsers::expr("x == 42 && ! :port == 53/udp && x == 42", expr));
   CHECK_EQUAL(expr, expression(conjunction{p1, negation{p2}, p1}));
   CHECK(parsers::expr("x > 0 && x < 42 && a.b == x.y", expr));
-  CHECK(parsers::expr("#time > 2018-07-04+12:00:00.0 "
-                      "&& #time < 2018-07-04+23:55:04.0",
+  CHECK(parsers::expr("#timestamp > 2018-07-04+12:00:00.0 "
+                      "&& #timestamp < 2018-07-04+23:55:04.0",
                       expr));
   auto x = caf::get_if<conjunction>(&expr);
   REQUIRE(x);

--- a/libvast/test/format/json.cpp
+++ b/libvast/test/format/json.cpp
@@ -31,7 +31,7 @@ using namespace std::string_literals;
 
 namespace {
 
-auto http = record_type{{"ts", timestamp_type{}},
+auto http = record_type{{"ts", time_type{}},
                         {"uid", string_type{}},
                         {"id.orig_h", address_type{}},
                         {"id.orig_p", port_type{}},
@@ -80,13 +80,13 @@ TEST(json to data) {
                             {"a", address_type{}},
                             {"p", port_type{}},
                             {"sn", subnet_type{}},
-                            {"t", timestamp_type{}},
-                            {"d", timespan_type{}},
-                            {"d2", timespan_type{}},
+                            {"t", time_type{}},
+                            {"d", duration_type{}},
+                            {"d2", duration_type{}},
                             {"e", enumeration_type{{"FOO", "BAR", "BAZ"}}},
                             {"sc", set_type{count_type{}}},
                             {"vp", vector_type{port_type{}}},
-                            {"vt", vector_type{timestamp_type{}}},
+                            {"vt", vector_type{time_type{}}},
                             {"rec", record_type{{"c", count_type{}},
                                                 {"s", string_type{}}}},
                             {"msa", map_type{string_type{}, address_type{}}},
@@ -141,7 +141,7 @@ TEST(json reader) {
   CHECK_EQUAL(err, caf::none);
   CHECK_EQUAL(num, 9);
   CHECK(slices[1]->at(0, 0)
-        == data{unbox(to<timestamp>("2011-08-12T14:59:11.994970Z"))});
+        == data{unbox(to<vast::time>("2011-08-12T14:59:11.994970Z"))});
   CHECK(slices[1]->at(0, 18) == vector{data{"text/html"}});
 }
 

--- a/libvast/test/format/writer.cpp
+++ b/libvast/test/format/writer.cpp
@@ -37,7 +37,7 @@ auto last_csv_http_log_line = R"__(zeek.http,2009-11-19+07:17:28.829,"rydI6puScN
 
 auto first_ascii_bgpdump_txt_line = R"__(<2018-01-24+11:05:17.0, 27.111.229.79, 17639, "1", "3">)__";
 
-auto first_json_bgpdump_txt_line = R"__({"timestamp": 1516791917, "source_ip": "27.111.229.79", "source_as": 17639, "old_state": "1", "new_state": "3"})__";
+auto first_json_bgpdump_txt_line = R"__({"time": 1516791917, "source_ip": "27.111.229.79", "source_as": 17639, "old_state": "1", "new_state": "3"})__";
 
 auto first_zeek_conn_log_line = R"__({"ts": 1258531221.486539, "uid": "Pii6cUUq1v4", "id.orig_h": "192.168.1.102", "id.orig_p": 68, "id.resp_h": "192.168.1.1", "id.resp_p": 67, "proto": "udp", "service": null, "duration": 0.16382, "orig_bytes": 301, "resp_bytes": 300, "conn_state": "SF", "local_orig": null, "missed_bytes": 0, "history": "Dd", "orig_pkts": 1, "orig_ip_bytes": 329, "resp_pkts": 1, "resp_ip_bytes": 328, "tunnel_parents": []})__";
 // clang-format on

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -199,10 +199,10 @@ TEST(zeek data parsing) {
   CHECK(d == integer{-49329});
   CHECK(zeek_parse(count_type{}, "49329"s, d));
   CHECK(d == count{49329});
-  CHECK(zeek_parse(timestamp_type{}, "1258594163.566694", d));
-  auto ts = duration_cast<timespan>(double_seconds{1258594163.566694});
-  CHECK(d == timestamp{ts});
-  CHECK(zeek_parse(timespan_type{}, "1258594163.566694", d));
+  CHECK(zeek_parse(time_type{}, "1258594163.566694", d));
+  auto ts = duration_cast<vast::duration>(double_seconds{1258594163.566694});
+  CHECK(d == vast::time{ts});
+  CHECK(zeek_parse(duration_type{}, "1258594163.566694", d));
   CHECK(d == ts);
   CHECK(zeek_parse(string_type{}, "\\x2afoo*"s, d));
   CHECK(d == "*foo*");

--- a/libvast/test/json.cpp
+++ b/libvast/test/json.cpp
@@ -200,8 +200,8 @@ TEST(printable) {
 
 TEST(conversion) {
   using namespace std::chrono;
-  auto since_epoch = timespan{1258532203657267968ll};
-  auto ts = timestamp{since_epoch};
+  auto since_epoch = vast::duration{1258532203657267968ll};
+  auto ts = vast::time{since_epoch};
   auto fractional_ts = duration_cast<double_seconds>(since_epoch).count();
   CHECK_EQUAL(to_json(true), json{true});
   CHECK_EQUAL(to_json(4.2), json{4.2});

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -42,7 +42,7 @@ constexpr size_t num_events_per_parttion = 25;
 
 const vast::time epoch;
 
-vast::time get_timestamp(caf::optional<data_view> element){
+vast::time get_timestamp(caf::optional<data_view> element) {
   return materialize(caf::get<view<vast::time>>(*element));
 }
 

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -40,10 +40,10 @@ namespace {
 constexpr size_t num_partitions = 4;
 constexpr size_t num_events_per_parttion = 25;
 
-const timestamp epoch;
+const vast::time epoch;
 
-timestamp get_timestamp(caf::optional<data_view> element){
-  return materialize(caf::get<view<timestamp>>(*element));
+vast::time get_timestamp(caf::optional<data_view> element){
+  return materialize(caf::get<view<vast::time>>(*element));
 }
 
 // Builds a chain of events that are 1s apart, where consecutive chunks of
@@ -53,16 +53,15 @@ struct generator {
 
   explicit generator(std::string name, size_t first_event_id)
     : offset(first_event_id) {
-    layout = record_type{
-      {"timestamp", timestamp_type{}.attributes({{"time"}})},
-      {"content", string_type{}}
-    }.name(std::move(name));
+    layout = record_type{{"timestamp", time_type{}.attributes({{"timestamp"}})},
+                         {"content", string_type{}}}
+               .name(std::move(name));
   }
 
   table_slice_ptr operator()(size_t num) {
     auto builder = default_table_slice_builder::make(layout);
     for (size_t i = 0; i < num; ++i) {
-      timestamp ts = epoch + std::chrono::seconds(i + offset);
+      vast::time ts = epoch + std::chrono::seconds(i + offset);
       builder->add(make_data_view(ts));
       builder->add(make_data_view("foo"));
     }
@@ -77,8 +76,8 @@ struct generator {
 
 // A closed interval of time.
 struct interval {
-  timestamp from;
-  timestamp to;
+  vast::time from;
+  vast::time to;
 };
 
 struct mock_partition {
@@ -146,7 +145,7 @@ struct fixture {
   }
 
   auto attr_time_query(std::string_view hhmmss) {
-    std::string q = "#time == 1970-01-01+";
+    std::string q = "#timestamp == 1970-01-01+";
     q += hhmmss;
     q += ".0";
     return meta_idx.lookup(unbox(to<expression>(q)));
@@ -163,10 +162,10 @@ struct fixture {
   }
 
   auto attr_time_query(std::string_view hhmmss_from, std::string_view hhmmss_to) {
-    std::string q = "#time >= 1970-01-01+";
+    std::string q = "#timestamp >= 1970-01-01+";
     q += hhmmss_from;
     q += ".0";
-    q += " && #time <= 1970-01-01+";
+    q += " && #timestamp <= 1970-01-01+";
     q += hhmmss_to;
     q += ".0";
     return lookup(q);

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -640,19 +640,19 @@ TEST(dynamic bytes) {
 
 // -- time --------------------------------------------------------------------
 
-TEST(timestamp - now) {
-  timestamp ts;
-  CHECK(parsers::timestamp("now", ts));
-  CHECK(ts > timestamp::min()); // must be greater than the UNIX epoch
+TEST(time - now) {
+  vast::time ts;
+  CHECK(parsers::time("now", ts));
+  CHECK(ts > time::min()); // must be greater than the UNIX epoch
 }
 
-TEST(timestamp - YMD) {
+TEST(time - YMD) {
   using namespace std::chrono;
-  timestamp ts;
-  CHECK(parsers::timestamp("2017-08-13", ts));
+  vast::time ts;
+  CHECK(parsers::time("2017-08-13", ts));
   auto utc_secs = seconds{1502582400};
   CHECK_EQUAL(ts.time_since_epoch(), utc_secs);
-  CHECK(parsers::timestamp("2017-08-13+21:10:42", ts));
+  CHECK(parsers::time("2017-08-13+21:10:42", ts));
   utc_secs = std::chrono::seconds{1502658642};
   CHECK_EQUAL(ts.time_since_epoch(), utc_secs);
 }

--- a/libvast/test/printable.cpp
+++ b/libvast/test/printable.cpp
@@ -329,7 +329,7 @@ TEST(data) {
   CHECK_TO_STRING(i, "+42");
   data s{std::string{"foobar"}};
   CHECK_TO_STRING(s, "\"foobar\"");
-  data d{timespan{512}};
+  data d{duration{512}};
   CHECK_TO_STRING(d, "512.0ns");
   data v{vector{r, b, c, i, s, d}};
   CHECK_TO_STRING(v, "[12.21, T, 23, +42, \"foobar\", 512.0ns]");
@@ -353,8 +353,8 @@ TEST(std::chrono::duration) {
 
 TEST(std::chrono::time_point) {
   using namespace std::chrono_literals;
-  CHECK_TO_STRING(timestamp{0s}, "1970-01-01+00:00:00.0");
-  CHECK_TO_STRING(timestamp{1502658642123456us}, "2017-08-13+21:10:42.123");
+  CHECK_TO_STRING(vast::time{0s}, "1970-01-01+00:00:00.0");
+  CHECK_TO_STRING(vast::time{1502658642123456us}, "2017-08-13+21:10:42.123");
 }
 
 // -- API ---------------------------------------------------------------------

--- a/libvast/test/synopsis.cpp
+++ b/libvast/test/synopsis.cpp
@@ -24,7 +24,7 @@
 
 #include "vast/bool_synopsis.hpp"
 #include "vast/synopsis_factory.hpp"
-#include "vast/timestamp_synopsis.hpp"
+#include "vast/time_synopsis.hpp"
 
 using namespace std::chrono_literals;
 using namespace vast;
@@ -32,32 +32,33 @@ using namespace vast::test;
 
 namespace {
 
-const timestamp epoch;
+const vast::time epoch;
 
 } // namespace <anonymous>
 
 TEST(min-max synopsis) {
+  using vast::time;
   using namespace nft;
   factory<synopsis>::initialize();
-  auto x = factory<synopsis>::make(timestamp_type{}, synopsis_options{});
+  auto x = factory<synopsis>::make(time_type{}, synopsis_options{});
   REQUIRE_NOT_EQUAL(x, nullptr);
-  x->add(timestamp{epoch + 4s});
-  x->add(timestamp{epoch + 7s});
+  x->add(time{epoch + 4s});
+  x->add(time{epoch + 7s});
   auto verify = verifier{x};
   MESSAGE("[4,7] op 0");
-  timestamp zero = epoch + 0s;
+  time zero = epoch + 0s;
   verify(zero, {N, N, N, N, N, N, F, T, F, F, T, T});
   MESSAGE("[4,7] op 4");
-  timestamp four = epoch + 4s;
+  time four = epoch + 4s;
   verify(four, {N, N, N, N, N, N, T, F, F, T, T, T});
   MESSAGE("[4,7] op 6");
-  timestamp six = epoch + 6s;
+  time six = epoch + 6s;
   verify(six, {N, N, N, N, N, N, T, F, T, T, T, T});
   MESSAGE("[4,7] op 7");
-  timestamp seven = epoch + 7s;
+  time seven = epoch + 7s;
   verify(seven, {N, N, N, N, N, N, T, F, T, T, F, T});
   MESSAGE("[4,7] op 9");
-  timestamp nine = epoch + 9s;
+  time nine = epoch + 9s;
   verify(nine, {N, N, N, N, N, N, F, T, T, T, F, F});
   MESSAGE("[4,7] op {0, 4}");
   auto zero_four = data{set{zero, four}};
@@ -88,7 +89,7 @@ TEST(serialization) {
   synopsis_options empty;
   CHECK_ROUNDTRIP(synopsis_ptr{});
   CHECK_ROUNDTRIP_DEREF(factory<synopsis>::make(bool_type{}, empty));
-  CHECK_ROUNDTRIP_DEREF(factory<synopsis>::make(timestamp_type{}, empty));
+  CHECK_ROUNDTRIP_DEREF(factory<synopsis>::make(time_type{}, empty));
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -292,7 +292,7 @@ TEST(single partition zeek conn log lookup) {
     CHECK_EQUAL(rank(query("id.resp_p == 53/?")), 3u);
     CHECK_EQUAL(rank(query("id.resp_p == 137/?")), 5u);
     CHECK_EQUAL(rank(query("id.resp_p == 53/? || id.resp_p == 137/?")), 8u);
-    CHECK_EQUAL(rank(query("#time > 1970-01-01")), zeek_conn_log.size());
+    CHECK_EQUAL(rank(query("#timestamp > 1970-01-01")), zeek_conn_log.size());
     CHECK_EQUAL(rank(query("proto == \"udp\"")), 20u);
     CHECK_EQUAL(rank(query("proto == \"tcp\"")), 0u);
     CHECK_EQUAL(rank(query("uid == \"nkCxlvNN8pi\"")), 1u);

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -31,7 +31,7 @@ namespace {
 
 constexpr std::string_view uuid_str = "423b45a1-c217-4f99-ba43-9e3fc3285cd3";
 
-constexpr std::string_view query_str = "#time < 1 week ago";
+constexpr std::string_view query_str = "#timestamp < 1 week ago";
 
 struct mock_index_state {
   static inline constexpr const char* name = "mock-index";

--- a/libvast/test/time.cpp
+++ b/libvast/test/time.cpp
@@ -27,82 +27,82 @@ using namespace std::chrono_literals;
 namespace {
 
 template <class Input, class T>
-void check_timespan(const Input& str, T x) {
-  timespan t;
-  CHECK(parsers::timespan(str, t));
-  CHECK_EQUAL(t, duration_cast<timespan>(x));
+void check_duration(const Input& str, T x) {
+  vast::duration t;
+  CHECK(parsers::duration(str, t));
+  CHECK_EQUAL(t, duration_cast<vast::duration>(x));
 }
 
 } // namespace <anonymous>
 
 TEST(positive durations) {
   MESSAGE("nanoseconds");
-  check_timespan("42 nsecs", 42ns);
-  check_timespan("42nsec", 42ns);
-  check_timespan("42ns", 42ns);
-  check_timespan("42ns", 42ns);
+  check_duration("42 nsecs", 42ns);
+  check_duration("42nsec", 42ns);
+  check_duration("42ns", 42ns);
+  check_duration("42ns", 42ns);
   MESSAGE("microseconds");
-  check_timespan("42 usecs", 42us);
-  check_timespan("42usec", 42us);
-  check_timespan("42us", 42us);
+  check_duration("42 usecs", 42us);
+  check_duration("42usec", 42us);
+  check_duration("42us", 42us);
   MESSAGE("milliseconds");
-  check_timespan("42 msecs", 42ms);
-  check_timespan("42msec", 42ms);
-  check_timespan("42ms", 42ms);
+  check_duration("42 msecs", 42ms);
+  check_duration("42msec", 42ms);
+  check_duration("42ms", 42ms);
   MESSAGE("seconds");
-  check_timespan("42 secs", 42s);
-  check_timespan("42sec", 42s);
-  check_timespan("42s", 42s);
+  check_duration("42 secs", 42s);
+  check_duration("42sec", 42s);
+  check_duration("42s", 42s);
   MESSAGE("minutes");
-  check_timespan("42 mins", 42min);
-  check_timespan("42min", 42min);
-  check_timespan("42m", 42min);
+  check_duration("42 mins", 42min);
+  check_duration("42min", 42min);
+  check_duration("42m", 42min);
   MESSAGE("hours");
-  check_timespan("42 hours", 42h);
-  check_timespan("42hour", 42h);
-  check_timespan("42h", 42h);
+  check_duration("42 hours", 42h);
+  check_duration("42hour", 42h);
+  check_duration("42h", 42h);
 }
 
 TEST(negative durations) {
-  check_timespan("-42ns", -42ns);
-  check_timespan("-42h", -42h);
+  check_duration("-42ns", -42ns);
+  check_duration("-42h", -42h);
 }
 
 TEST(fractional durations) {
-  check_timespan("3.54s", 3540ms);
-  check_timespan("-42.001ms", -42001us);
+  check_duration("3.54s", 3540ms);
+  check_duration("-42.001ms", -42001us);
 }
 
 TEST(compound durations) {
-  check_timespan("3m42s10ms", 3min + 42s + 10ms);
-  check_timespan("3s42s10ms", 3s + 42s + 10ms);
-  check_timespan("42s3m10ms", 3min + 42s + 10ms);
-  check_timespan("-10m8ms1ns", -10min + 8ms + 1ns);
+  check_duration("3m42s10ms", 3min + 42s + 10ms);
+  check_duration("3s42s10ms", 3s + 42s + 10ms);
+  check_duration("42s3m10ms", 3min + 42s + 10ms);
+  check_duration("-10m8ms1ns", -10min + 8ms + 1ns);
   MESSAGE("no intermediate signs");
-  auto p = parsers::timespan >> parsers::eoi;
+  auto p = parsers::duration >> parsers::eoi;
   CHECK(!p("-10m-8ms1ns"));
 }
 
-timespan to_hours(timespan ts) {
+vast::duration to_hours(vast::duration ts) {
   return duration_cast<hours>(ts) % 24;
 }
 
-timespan to_minutes(timespan ts) {
+vast::duration to_minutes(vast::duration ts) {
   return duration_cast<minutes>(ts) % 60;
 }
 
-timespan to_seconds(timespan ts) {
+vast::duration to_seconds(vast::duration ts) {
   return duration_cast<seconds>(ts) % 60;
 }
 
-timespan to_microseconds(timespan ts) {
+vast::duration to_microseconds(vast::duration ts) {
   return duration_cast<microseconds>(ts) % 1'000'000;
 }
 
-TEST(ymdshms timestamp parser) {
-  timestamp ts;
+TEST(ymdshms time parser) {
+  vast::time ts;
   MESSAGE("YYYY-MM-DD+HH:MM:SS.ssss+HH");
-  CHECK(parsers::timestamp("2012-08-12+23:55:04.001234+01", ts));
+  CHECK(parsers::time("2012-08-12+23:55:04.001234+01", ts));
   auto sd = floor<days>(ts);
   auto t = ts - sd;
   CHECK(sd == years{2012} / 8 / 13);
@@ -111,7 +111,7 @@ TEST(ymdshms timestamp parser) {
   CHECK(to_seconds(t) == seconds{4});
   CHECK(to_microseconds(t) == microseconds{1234});
   MESSAGE("YYYY-MM-DD+HH:MM:SS.ssss");
-  CHECK(parsers::timestamp("2012-08-12+23:55:04.001234", ts));
+  CHECK(parsers::time("2012-08-12+23:55:04.001234", ts));
   sd = floor<days>(ts);
   t = ts - sd;
   CHECK(sd == years{2012} / 8 / 12);
@@ -120,7 +120,7 @@ TEST(ymdshms timestamp parser) {
   CHECK(to_seconds(t) == seconds{4});
   CHECK(to_microseconds(t) == microseconds{1234});
   MESSAGE("YYYY-MM-DD+HH:MM:SS-HH:MM");
-  CHECK(parsers::timestamp("2012-08-12+23:55:04-00:30", ts));
+  CHECK(parsers::time("2012-08-12+23:55:04-00:30", ts));
   sd = floor<days>(ts);
   t = ts - sd;
   CHECK(sd == years{2012} / 8 / 12);
@@ -128,7 +128,7 @@ TEST(ymdshms timestamp parser) {
   CHECK_EQUAL(to_minutes(t), minutes{25});
   CHECK(to_seconds(t) == seconds{4});
   MESSAGE("YYYY-MM-DD+HH:MM:SS");
-  CHECK(parsers::timestamp("2012-08-12+23:55:04", ts));
+  CHECK(parsers::time("2012-08-12+23:55:04", ts));
   sd = floor<days>(ts);
   t = ts - sd;
   CHECK(sd == years{2012} / 8 / 12);
@@ -137,7 +137,7 @@ TEST(ymdshms timestamp parser) {
   CHECK(to_seconds(t) == seconds{4});
   // TODO: Fix timezone offset without divider
   MESSAGE("YYYY-MM-DD+HH:MM+HHMM");
-  CHECK(parsers::timestamp("2012-08-12+23:55+0130", ts));
+  CHECK(parsers::time("2012-08-12+23:55+0130", ts));
   sd = floor<days>(ts);
   t = ts - sd;
   CHECK(sd == years{2012} / 8 / 13);
@@ -145,7 +145,7 @@ TEST(ymdshms timestamp parser) {
   CHECK_EQUAL(to_minutes(t), minutes{25});
   CHECK(to_seconds(t) == seconds{0});
   MESSAGE("YYYY-MM-DD+HH:MM");
-  CHECK(parsers::timestamp("2012-08-12+23:55", ts));
+  CHECK(parsers::time("2012-08-12+23:55", ts));
   sd = floor<days>(ts);
   t = ts - sd;
   CHECK(sd == years{2012} / 8 / 12);
@@ -153,7 +153,7 @@ TEST(ymdshms timestamp parser) {
   CHECK(to_minutes(t) == minutes{55});
   CHECK(to_seconds(t) == seconds{0});
   MESSAGE("YYYY-MM-DD+HH");
-  CHECK(parsers::timestamp("2012-08-12+23", ts));
+  CHECK(parsers::time("2012-08-12+23", ts));
   sd = floor<days>(ts);
   t = ts - sd;
   CHECK(sd == years{2012} / 8 / 12);
@@ -161,7 +161,7 @@ TEST(ymdshms timestamp parser) {
   CHECK(to_minutes(t) == minutes{0});
   CHECK(to_seconds(t) == seconds{0});
   MESSAGE("YYYY-MM-DD");
-  CHECK(parsers::timestamp("2012-08-12", ts));
+  CHECK(parsers::time("2012-08-12", ts));
   sd = floor<days>(ts);
   t = ts - sd;
   CHECK(sd == years{2012} / 8 / 12);
@@ -169,7 +169,7 @@ TEST(ymdshms timestamp parser) {
   CHECK(to_minutes(t) == minutes{0});
   CHECK(to_seconds(t) == seconds{0});
   MESSAGE("YYYY-MM");
-  CHECK(parsers::timestamp("2012-08", ts));
+  CHECK(parsers::time("2012-08", ts));
   sd = floor<days>(ts);
   t = ts - sd;
   CHECK(sd == years{2012} / 8 / 1);
@@ -178,33 +178,33 @@ TEST(ymdshms timestamp parser) {
   CHECK(to_seconds(t) == seconds{0});
 }
 
-TEST(unix epoch timestamp parser) {
-  timestamp ts;
-  CHECK(parsers::timestamp("@1444040673", ts));
+TEST(unix epoch time parser) {
+  vast::time ts;
+  CHECK(parsers::time("@1444040673", ts));
   CHECK(ts.time_since_epoch() == 1444040673s);
-  CHECK(parsers::timestamp("@1398933902.686337", ts));
+  CHECK(parsers::time("@1398933902.686337", ts));
   CHECK(ts.time_since_epoch() == double_seconds{1398933902.686337});
 }
 
-TEST(now timestamp parser) {
-  timestamp ts;
-  CHECK(parsers::timestamp("now", ts));
-  CHECK(ts > timestamp::clock::now() - minutes{1});
-  CHECK(ts < timestamp::clock::now() + minutes{1});
-  CHECK(parsers::timestamp("now - 1m", ts));
-  CHECK(ts < timestamp::clock::now());
-  CHECK(parsers::timestamp("now + 1m", ts));
-  CHECK(ts > timestamp::clock::now());
+TEST(now time parser) {
+  vast::time ts;
+  CHECK(parsers::time("now", ts));
+  CHECK(ts > time::clock::now() - minutes{1});
+  CHECK(ts < time::clock::now() + minutes{1});
+  CHECK(parsers::time("now - 1m", ts));
+  CHECK(ts < time::clock::now());
+  CHECK(parsers::time("now + 1m", ts));
+  CHECK(ts > time::clock::now());
 }
 
-TEST(ago timestamp parser) {
-  timestamp ts;
-  CHECK(parsers::timestamp("10 days ago", ts));
-  CHECK(ts < timestamp::clock::now());
+TEST(ago time parser) {
+  vast::time ts;
+  CHECK(parsers::time("10 days ago", ts));
+  CHECK(ts < time::clock::now());
 }
 
-TEST(in timestamp parser) {
-  timestamp ts;
-  CHECK(parsers::timestamp("in 1 year", ts));
-  CHECK(ts > timestamp::clock::now());
+TEST(in time parser) {
+  vast::time ts;
+  CHECK(parsers::time("in 1 year", ts));
+  CHECK(ts > time::clock::now());
 }

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -160,8 +160,8 @@ TEST(serialization) {
   CHECK_ROUNDTRIP(integer_type{});
   CHECK_ROUNDTRIP(count_type{});
   CHECK_ROUNDTRIP(real_type{});
-  CHECK_ROUNDTRIP(timespan_type{});
-  CHECK_ROUNDTRIP(timestamp_type{});
+  CHECK_ROUNDTRIP(duration_type{});
+  CHECK_ROUNDTRIP(time_type{});
   CHECK_ROUNDTRIP(string_type{});
   CHECK_ROUNDTRIP(pattern_type{});
   CHECK_ROUNDTRIP(address_type{});
@@ -178,8 +178,8 @@ TEST(serialization) {
   CHECK_ROUNDTRIP(type{integer_type{}});
   CHECK_ROUNDTRIP(type{count_type{}});
   CHECK_ROUNDTRIP(type{real_type{}});
-  CHECK_ROUNDTRIP(type{timespan_type{}});
-  CHECK_ROUNDTRIP(type{timestamp_type{}});
+  CHECK_ROUNDTRIP(type{duration_type{}});
+  CHECK_ROUNDTRIP(type{time_type{}});
   CHECK_ROUNDTRIP(type{string_type{}});
   CHECK_ROUNDTRIP(type{pattern_type{}});
   CHECK_ROUNDTRIP(type{address_type{}});
@@ -472,8 +472,8 @@ TEST(type_check) {
   TYPE_CHECK(integer_type{}, 42);
   TYPE_CHECK(count_type{}, 42u);
   TYPE_CHECK(real_type{}, 4.2);
-  TYPE_CHECK(timespan_type{}, timespan{0});
-  TYPE_CHECK(timestamp_type{}, timestamp{});
+  TYPE_CHECK(duration_type{}, duration{0});
+  TYPE_CHECK(time_type{}, vast::time{});
   TYPE_CHECK(string_type{}, "foo"s);
   TYPE_CHECK(pattern_type{}, pattern{"foo"});
   TYPE_CHECK(address_type{}, address{});
@@ -509,8 +509,8 @@ TEST(printable) {
   CHECK_EQUAL(to_string(integer_type{}), "int");
   CHECK_EQUAL(to_string(count_type{}), "count");
   CHECK_EQUAL(to_string(real_type{}), "real");
-  CHECK_EQUAL(to_string(timespan_type{}), "duration");
-  CHECK_EQUAL(to_string(timestamp_type{}), "time");
+  CHECK_EQUAL(to_string(duration_type{}), "duration");
+  CHECK_EQUAL(to_string(time_type{}), "time");
   CHECK_EQUAL(to_string(string_type{}), "string");
   CHECK_EQUAL(to_string(pattern_type{}), "pattern");
   CHECK_EQUAL(to_string(address_type{}), "addr");

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -134,10 +134,11 @@ TEST(floating-point with custom binner) {
   CHECK_EQUAL(to_string(unbox(result)), "1110111");
 }
 
-TEST(timespan) {
+TEST(duration) {
   using namespace std::chrono;
   // Default binning gives granularity of seconds.
-  auto idx = arithmetic_index<timespan>{timespan_type{}, base::uniform<64>(10)};
+  auto idx = arithmetic_index<vast::duration>{duration_type{},
+                                              base::uniform<64>(10)};
   MESSAGE("append");
   REQUIRE(idx.append(make_data_view(milliseconds(1000))));
   REQUIRE(idx.append(make_data_view(milliseconds(2000))));
@@ -154,35 +155,35 @@ TEST(timespan) {
   CHECK_EQUAL(to_string(unbox(twelve)), "011011");
 }
 
-TEST(timestamp) {
-  arithmetic_index<timestamp> idx{timestamp_type{}, base::uniform<64>(10)};
-  auto ts = to<timestamp>("2014-01-16+05:30:15");
+TEST(time) {
+  arithmetic_index<vast::time> idx{time_type{}, base::uniform<64>(10)};
+  auto ts = to<vast::time>("2014-01-16+05:30:15");
   MESSAGE("append");
   REQUIRE(idx.append(make_data_view(unbox(ts))));
-  ts = to<timestamp>("2014-01-16+05:30:12");
+  ts = to<vast::time>("2014-01-16+05:30:12");
   REQUIRE(idx.append(make_data_view(unbox(ts))));
-  ts = to<timestamp>("2014-01-16+05:30:15");
+  ts = to<vast::time>("2014-01-16+05:30:15");
   REQUIRE(idx.append(make_data_view(unbox(ts))));
-  ts = to<timestamp>("2014-01-16+05:30:18");
+  ts = to<vast::time>("2014-01-16+05:30:18");
   REQUIRE(idx.append(make_data_view(unbox(ts))));
-  ts = to<timestamp>("2014-01-16+05:30:15");
+  ts = to<vast::time>("2014-01-16+05:30:15");
   REQUIRE(idx.append(make_data_view(unbox(ts))));
-  ts = to<timestamp>("2014-01-16+05:30:19");
+  ts = to<vast::time>("2014-01-16+05:30:19");
   REQUIRE(idx.append(make_data_view(unbox(ts))));
   MESSAGE("lookup");
-  ts = to<timestamp>("2014-01-16+05:30:15");
+  ts = to<vast::time>("2014-01-16+05:30:15");
   auto fifteen = idx.lookup(equal, make_data_view(unbox(ts)));
   CHECK(to_string(unbox(fifteen)) == "101010");
-  ts = to<timestamp>("2014-01-16+05:30:20");
+  ts = to<vast::time>("2014-01-16+05:30:20");
   auto twenty = idx.lookup(less, make_data_view(unbox(ts)));
   CHECK(to_string(unbox(twenty)) == "111111");
-  ts = to<timestamp>("2014-01-16+05:30:18");
+  ts = to<vast::time>("2014-01-16+05:30:18");
   auto eighteen = idx.lookup(greater_equal, make_data_view(unbox(ts)));
   CHECK(to_string(unbox(eighteen)) == "000101");
   MESSAGE("serialization");
   std::vector<char> buf;
   CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
-  arithmetic_index<timestamp> idx2{timestamp_type{}, base::uniform<64>(10)};
+  arithmetic_index<vast::time> idx2{time_type{}, base::uniform<64>(10)};
   CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   eighteen = idx2.lookup(greater_equal, make_data_view(unbox(ts)));
   CHECK(to_string(*eighteen) == "000101");

--- a/libvast/vast/concept/parseable/vast/data.hpp
+++ b/libvast/vast/concept/parseable/vast/data.hpp
@@ -48,8 +48,8 @@ private:
     auto x = ws >> p >> ws;
     auto kvp = x >> "->" >> x;
     // clang-format off
-    p = parsers::timestamp
-      | parsers::timespan
+    p = parsers::time
+      | parsers::duration
       | parsers::net
       | parsers::port
       | parsers::addr

--- a/libvast/vast/concept/parseable/vast/type.hpp
+++ b/libvast/vast/concept/parseable/vast/type.hpp
@@ -82,19 +82,21 @@ struct type_parser : parser<type_parser> {
       = ('#' >> parsers::identifier >> -('=' >> parsers::qq_str)) ->* to_attr;
     static auto attr_list = *(ws >> attr);
     // Basic types
+    // clang-format off
     static auto basic_type_parser
       = "bool" >> attr_list      ->* to_basic_type<bool_type>
       | "int" >> attr_list       ->* to_basic_type<integer_type>
       | "count" >> attr_list     ->* to_basic_type<count_type>
       | "real" >> attr_list      ->* to_basic_type<real_type>
-      | "duration" >> attr_list  ->* to_basic_type<timespan_type>
-      | "time" >> attr_list      ->* to_basic_type<timestamp_type>
+      | "duration" >> attr_list  ->* to_basic_type<duration_type>
+      | "time" >> attr_list      ->* to_basic_type<time_type>
       | "string" >> attr_list    ->* to_basic_type<string_type>
       | "pattern" >> attr_list   ->* to_basic_type<pattern_type>
       | "addr" >> attr_list      ->* to_basic_type<address_type>
       | "subnet" >> attr_list    ->* to_basic_type<subnet_type>
       | "port" >> attr_list      ->* to_basic_type<port_type>
       ;
+    // clang-format on
     // Enumeration
     using enum_tuple = std::tuple<
       std::vector<std::string>,

--- a/libvast/vast/concept/printable/std/chrono.hpp
+++ b/libvast/vast/concept/printable/std/chrono.hpp
@@ -149,7 +149,7 @@ struct time_point_printer : printer<time_point_printer<Clock, Duration>> {
                  << '+' << num2 << ':' << num2 << ':' << num2
                  << '.' << num;
     auto sd = floor<days>(tp);
-    auto [Y, M, D] = from_days(duration_cast<days>(sd - timestamp{}));
+    auto [Y, M, D] = from_days(duration_cast<days>(sd - time{}));
     auto t = tp - sd;
     auto h = duration_cast<hours>(t);
     auto m = duration_cast<minutes>(t - h);

--- a/libvast/vast/concept/printable/vast/type.hpp
+++ b/libvast/vast/concept/printable/vast/type.hpp
@@ -71,8 +71,8 @@ VAST_DEFINE_BASIC_TYPE_PRINTER(bool_type, "bool")
 VAST_DEFINE_BASIC_TYPE_PRINTER(integer_type, "int")
 VAST_DEFINE_BASIC_TYPE_PRINTER(count_type, "count")
 VAST_DEFINE_BASIC_TYPE_PRINTER(real_type, "real")
-VAST_DEFINE_BASIC_TYPE_PRINTER(timespan_type, "duration")
-VAST_DEFINE_BASIC_TYPE_PRINTER(timestamp_type, "time")
+VAST_DEFINE_BASIC_TYPE_PRINTER(duration_type, "duration")
+VAST_DEFINE_BASIC_TYPE_PRINTER(time_type, "time")
 VAST_DEFINE_BASIC_TYPE_PRINTER(string_type, "string")
 VAST_DEFINE_BASIC_TYPE_PRINTER(pattern_type, "pattern")
 VAST_DEFINE_BASIC_TYPE_PRINTER(address_type, "addr")
@@ -138,8 +138,8 @@ struct type_printer : printer<type_printer<Policy>> {
              | integer_type_printer{}
              | count_type_printer{}
              | real_type_printer{}
-             | timespan_type_printer{}
-             | timestamp_type_printer{}
+             | duration_type_printer{}
+             | time_type_printer{}
              | string_type_printer{}
              | pattern_type_printer{}
              | address_type_printer{}

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -64,8 +64,8 @@ using to_data_type = std::conditional_t<
           std::string,
           std::conditional_t<
                std::is_same_v<T, caf::none_t>
-            || std::is_same_v<T, timespan>
-            || std::is_same_v<T, timestamp>
+            || std::is_same_v<T, duration>
+            || std::is_same_v<T, time>
             || std::is_same_v<T, pattern>
             || std::is_same_v<T, address>
             || std::is_same_v<T, subnet>
@@ -102,8 +102,8 @@ public:
     integer,
     count,
     real,
-    timespan,
-    timestamp,
+    duration,
+    time,
     std::string,
     pattern,
     address,
@@ -132,7 +132,7 @@ public:
   /// Constructs data from a `std::chrono::duration`.
   /// @param x The duration to construct data from.
   template <class Rep, class Period>
-  data(std::chrono::duration<Rep, Period> x) : data_{timespan{x}} {
+  data(std::chrono::duration<Rep, Period> x) : data_{duration{x}} {
     // nop
   }
 
@@ -193,8 +193,8 @@ VAST_DATA_TRAIT(bool);
 VAST_DATA_TRAIT(integer);
 VAST_DATA_TRAIT(count);
 VAST_DATA_TRAIT(real);
-VAST_DATA_TRAIT(timespan);
-VAST_DATA_TRAIT(timestamp);
+VAST_DATA_TRAIT(duration);
+VAST_DATA_TRAIT(time);
 VAST_DATA_TRAIT(pattern);
 VAST_DATA_TRAIT(address);
 VAST_DATA_TRAIT(subnet);

--- a/libvast/vast/event.hpp
+++ b/libvast/vast/event.hpp
@@ -76,11 +76,11 @@ public:
 
   /// Sets the event timestamp.
   /// @param ts The event timestamp.
-  void timestamp(vast::timestamp ts);
+  void timestamp(time ts);
 
   /// Retrieves the event timestamp.
   /// @returns The event timestamp.
-  vast::timestamp timestamp() const;
+  time timestamp() const;
 
   friend bool operator==(const event& x, const event& y);
   friend bool operator<(const event& x, const event& y);
@@ -92,7 +92,7 @@ public:
 
 private:
   vast::id id_ = invalid_id;
-  vast::timestamp timestamp_;
+  time timestamp_;
 };
 
 bool convert(const event& e, json& j);
@@ -103,4 +103,3 @@ bool convert(const event& e, json& j);
 event flatten(const event& e);
 
 } // namespace vast
-

--- a/libvast/vast/format/bgpdump.hpp
+++ b/libvast/vast/format/bgpdump.hpp
@@ -37,10 +37,10 @@ struct bgpdump_parser : parser<bgpdump_parser> {
     using parsers::u64;
     using namespace std::chrono;
     static auto str = +(any - '|');
-    static auto time = u64->*[](count x) { return timestamp{seconds(x)}; };
+    static auto time = u64->*[](count x) { return vast::time{seconds(x)}; };
     static auto head
       = "BGP4MP|" >> time >> '|' >> str >> '|' >> addr >> '|' >> u64 >> '|';
-    timestamp ts;
+    vast::time ts;
     std::string update;
     vast::address source_ip;
     count source_as;

--- a/libvast/vast/format/mrt.hpp
+++ b/libvast/vast/format/mrt.hpp
@@ -1205,7 +1205,7 @@ public:
 
   private:
     reader& parent_;
-    vast::timestamp timestamp_;
+    time timestamp_;
     size_t produced_;
   };
 

--- a/libvast/vast/format/pcap.hpp
+++ b/libvast/vast/format/pcap.hpp
@@ -124,7 +124,7 @@ private:
   uint64_t max_age_;
   uint64_t expire_interval_;
   uint64_t last_expire_ = 0;
-  timestamp last_timestamp_ = timestamp::min();
+  time last_timestamp_ = time::min();
   int64_t pseudo_realtime_;
   std::string input_;
 };

--- a/libvast/vast/format/zeek.hpp
+++ b/libvast/vast/format/zeek.hpp
@@ -72,7 +72,7 @@ struct zeek_parser {
   }
 
   bool operator()(const time_type&) const {
-    static auto p = parsers::real ->* [](real x) {
+    static auto p = parsers::real->*[](real x) {
       auto i = std::chrono::duration_cast<duration>(double_seconds(x));
       return time{i};
     };
@@ -80,7 +80,7 @@ struct zeek_parser {
   }
 
   bool operator()(const duration_type&) const {
-    static auto p = parsers::real ->* [](real x) {
+    static auto p = parsers::real->*[](real x) {
       return std::chrono::duration_cast<duration>(double_seconds(x));
     };
     return parse(p);
@@ -150,14 +150,14 @@ struct zeek_parser_factory {
   }
 
   result_type operator()(const time_type&) const {
-    return parsers::real ->* [](real x) {
+    return parsers::real->*[](real x) {
       auto i = std::chrono::duration_cast<duration>(double_seconds(x));
       return time{i};
     };
   }
 
   result_type operator()(const duration_type&) const {
-    return parsers::real ->* [](real x) {
+    return parsers::real->*[](real x) {
       return std::chrono::duration_cast<duration>(double_seconds(x));
     };
   }

--- a/libvast/vast/format/zeek.hpp
+++ b/libvast/vast/format/zeek.hpp
@@ -71,17 +71,17 @@ struct zeek_parser {
     return parse(p);
   }
 
-  bool operator()(const timestamp_type&) const {
+  bool operator()(const time_type&) const {
     static auto p = parsers::real ->* [](real x) {
-      auto i = std::chrono::duration_cast<timespan>(double_seconds(x));
-      return timestamp{i};
+      auto i = std::chrono::duration_cast<duration>(double_seconds(x));
+      return time{i};
     };
     return parse(p);
   }
 
-  bool operator()(const timespan_type&) const {
+  bool operator()(const duration_type&) const {
     static auto p = parsers::real ->* [](real x) {
-      return std::chrono::duration_cast<timespan>(double_seconds(x));
+      return std::chrono::duration_cast<duration>(double_seconds(x));
     };
     return parse(p);
   }
@@ -149,16 +149,16 @@ struct zeek_parser_factory {
     return parsers::u64 ->* [](count x) { return x; };
   }
 
-  result_type operator()(const timestamp_type&) const {
+  result_type operator()(const time_type&) const {
     return parsers::real ->* [](real x) {
-      auto i = std::chrono::duration_cast<timespan>(double_seconds(x));
-      return timestamp{i};
+      auto i = std::chrono::duration_cast<duration>(double_seconds(x));
+      return time{i};
     };
   }
 
-  result_type operator()(const timespan_type&) const {
+  result_type operator()(const duration_type&) const {
     return parsers::real ->* [](real x) {
-      return std::chrono::duration_cast<timespan>(double_seconds(x));
+      return std::chrono::duration_cast<duration>(double_seconds(x));
     };
   }
 

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -75,8 +75,8 @@ struct segment_header;
 struct set_type;
 struct string_type;
 struct subnet_type;
-struct timespan_type;
-struct timestamp_type;
+struct duration_type;
+struct time_type;
 struct vector_type;
 
 // -- templates ----------------------------------------------------------------

--- a/libvast/vast/system/accountant.hpp
+++ b/libvast/vast/system/accountant.hpp
@@ -30,8 +30,7 @@ namespace vast::system {
 
 struct data_point {
   std::string key;
-  caf::variant<std::string, timespan, timestamp, int64_t, uint64_t, double>
-    value;
+  caf::variant<std::string, duration, time, int64_t, uint64_t, double> value;
 };
 
 template <class Inspector>
@@ -58,8 +57,8 @@ using performance_report = std::vector<performance_sample>;
 using accountant_type = caf::typed_actor<
   caf::reacts_to<announce_atom, std::string>,
   caf::reacts_to<std::string, std::string>,
-  caf::reacts_to<std::string, timespan>,
-  caf::reacts_to<std::string, timestamp>,
+  caf::reacts_to<std::string, duration>,
+  caf::reacts_to<std::string, time>,
   caf::reacts_to<std::string, int64_t>,
   caf::reacts_to<std::string, uint64_t>,
   caf::reacts_to<std::string, double>,

--- a/libvast/vast/system/atoms.hpp
+++ b/libvast/vast/system/atoms.hpp
@@ -107,7 +107,7 @@ using exporter_atom = caf::atom_constant<caf::atom("exporter")>;
 using importer_atom = caf::atom_constant<caf::atom("importer")>;
 
 // Attributes
-using time_atom = caf::atom_constant<caf::atom("time")>;
+using timestamp_atom = caf::atom_constant<caf::atom("timestamp")>;
 using type_atom = caf::atom_constant<caf::atom("type")>;
 
 } // namespace vast::system

--- a/libvast/vast/system/instrumentation.hpp
+++ b/libvast/vast/system/instrumentation.hpp
@@ -27,13 +27,12 @@ namespace vast::system {
 using stopwatch = std::chrono::steady_clock;
 
 struct measurement : public detail::addable<measurement> {
-  using timespan = vast::timespan;
-  timespan duration = timespan::zero();
+  vast::duration duration = vast::duration::zero();
   uint64_t events = 0;
 
   measurement() = default;
 
-  measurement(timespan d, uint64_t e) : duration{d}, events{e} {
+  measurement(vast::duration d, uint64_t e) : duration{d}, events{e} {
     // nop
   }
 
@@ -60,7 +59,7 @@ struct timer {
 
   void stop(uint64_t events) {
     auto stop = stopwatch::now();
-    auto elapsed = std::chrono::duration_cast<measurement::timespan>(stop - start_);
+    auto elapsed = std::chrono::duration_cast<duration>(stop - start_);
     m_ += {elapsed, events};
   }
 
@@ -95,7 +94,7 @@ struct atomic_timer {
 
   void stop(uint64_t events) {
     auto stop = stopwatch::now();
-    auto elapsed = std::chrono::duration_cast<measurement::timespan>(stop - start_);
+    auto elapsed = std::chrono::duration_cast<duration>(stop - start_);
 #ifdef VAST_MEASUREMENT_MUTEX_WORKAROUND
     std::unique_lock<std::mutex> lock{m_.mutex};
     m_ += measurement{elapsed, events};

--- a/libvast/vast/system/query_status.hpp
+++ b/libvast/vast/system/query_status.hpp
@@ -24,7 +24,7 @@ namespace vast::system {
 
 /// Statistics about a query.
 struct query_status {
-  timespan runtime;            ///< Current runtime.
+  duration runtime;            ///< Current runtime.
   size_t expected = 0;         ///< Expected ID sets from INDEX.
   size_t scheduled = 0;        ///< Scheduled partitions (ID sets) at INDEX.
   size_t received = 0;         ///< Received ID sets from INDEX.

--- a/libvast/vast/time.hpp
+++ b/libvast/vast/time.hpp
@@ -44,19 +44,19 @@ using sys_days = sys_time<days>;
 using sys_seconds = sys_time<std::chrono::seconds>;
 
 /// A duration in time with nanosecond resolution.
-using caf::timespan;
+using duration = caf::timespan;
 
 /// An absolute point in time with nanosecond resolution. It is capable to
 /// represent +/- 292 years around the UNIX epoch.
-using caf::timestamp;
+using time = caf::timestamp;
 
 /// A helper type to represent fractional time stamps in type `double`.
 using double_seconds = std::chrono::duration<double, std::ratio<1>>;
 
-bool convert(timespan dur, double& d);
-bool convert(timespan dur, json& j);
+bool convert(duration dur, double& d);
+bool convert(duration dur, json& j);
 
-bool convert(timestamp tp, double& d);
-bool convert(timestamp tp, json& j);
+bool convert(time tp, double& d);
+bool convert(time tp, json& j);
 
 } // namespace vast

--- a/libvast/vast/time_synopsis.hpp
+++ b/libvast/vast/time_synopsis.hpp
@@ -11,21 +11,18 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include "vast/timestamp_synopsis.hpp"
+#pragma once
+
+#include "vast/min_max_synopsis.hpp"
+#include "vast/synopsis.hpp"
 
 namespace vast {
 
-timestamp_synopsis::timestamp_synopsis(vast::type x)
-  : min_max_synopsis<timestamp>{std::move(x), timestamp::max(),
-                                timestamp::min()} {
-  // nop
-}
+class time_synopsis final : public min_max_synopsis<time> {
+public:
+  time_synopsis(vast::type x);
 
-bool timestamp_synopsis::equals(const synopsis& other) const noexcept {
-  if (typeid(other) != typeid(timestamp_synopsis))
-    return false;
-  auto& dref = static_cast<const timestamp_synopsis&>(other);
-  return type() == dref.type() && min() == dref.min() && max() == dref.max();
-}
+  bool equals(const synopsis& other) const noexcept override;
+};
 
 } // namespace vast

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -57,8 +57,8 @@ using concrete_types = caf::detail::type_list<
   integer_type,
   count_type,
   real_type,
-  timespan_type,
-  timestamp_type,
+  duration_type,
+  time_type,
   string_type,
   pattern_type,
   address_type,
@@ -417,11 +417,11 @@ struct real_type final : basic_type<real_type> {};
 
 /// A type for time durations.
 /// @relates type
-struct timespan_type final : basic_type<timespan_type> {};
+struct duration_type final : basic_type<duration_type> {};
 
 /// A type for absolute points in time.
 /// @relates type
-struct timestamp_type final : basic_type<timestamp_type> {};
+struct time_type final : basic_type<time_type> {};
 
 /// A string type for sequence of characters.
 struct string_type final : basic_type<string_type> {};
@@ -705,8 +705,8 @@ VAST_TYPE_TRAIT(bool);
 VAST_TYPE_TRAIT(integer);
 VAST_TYPE_TRAIT(count);
 VAST_TYPE_TRAIT(real);
-VAST_TYPE_TRAIT(timespan);
-VAST_TYPE_TRAIT(timestamp);
+VAST_TYPE_TRAIT(duration);
+VAST_TYPE_TRAIT(time);
 VAST_TYPE_TRAIT(pattern);
 VAST_TYPE_TRAIT(address);
 VAST_TYPE_TRAIT(subnet);
@@ -977,8 +977,8 @@ VAST_DEFINE_HASH_SPECIALIZATION(bool_type);
 VAST_DEFINE_HASH_SPECIALIZATION(integer_type);
 VAST_DEFINE_HASH_SPECIALIZATION(count_type);
 VAST_DEFINE_HASH_SPECIALIZATION(real_type);
-VAST_DEFINE_HASH_SPECIALIZATION(timespan_type);
-VAST_DEFINE_HASH_SPECIALIZATION(timestamp_type);
+VAST_DEFINE_HASH_SPECIALIZATION(duration_type);
+VAST_DEFINE_HASH_SPECIALIZATION(time_type);
 VAST_DEFINE_HASH_SPECIALIZATION(string_type);
 VAST_DEFINE_HASH_SPECIALIZATION(pattern_type);
 VAST_DEFINE_HASH_SPECIALIZATION(address_type);

--- a/libvast/vast/view.hpp
+++ b/libvast/vast/view.hpp
@@ -56,8 +56,8 @@ VAST_VIEW_TRAIT(bool);
 VAST_VIEW_TRAIT(integer);
 VAST_VIEW_TRAIT(count);
 VAST_VIEW_TRAIT(real);
-VAST_VIEW_TRAIT(timespan);
-VAST_VIEW_TRAIT(timestamp);
+VAST_VIEW_TRAIT(duration);
+VAST_VIEW_TRAIT(time);
 VAST_VIEW_TRAIT(port);
 VAST_VIEW_TRAIT(address);
 VAST_VIEW_TRAIT(subnet);
@@ -148,8 +148,8 @@ using data_view = caf::variant<
   view<integer>,
   view<count>,
   view<real>,
-  view<timespan>,
-  view<timestamp>,
+  view<duration>,
+  view<time>,
   view<std::string>,
   view<pattern>,
   view<address>,
@@ -406,8 +406,8 @@ private:
 template <class T>
 view<T> make_view(const T& x) {
   constexpr auto directly_constructible = detail::is_any_v<
-    T, caf::none_t, bool, integer, count, real, timespan, timestamp,
-    std::string, pattern, address, subnet, port, enumeration>;
+    T, caf::none_t, bool, integer, count, real, duration, time, std::string,
+    pattern, address, subnet, port, enumeration>;
   if constexpr (directly_constructible) {
     return x;
   } else if constexpr (std::is_same_v<T, vector>) {

--- a/libvast_test/src/events.cpp
+++ b/libvast_test/src/events.cpp
@@ -43,7 +43,7 @@ namespace fixtures {
 namespace {
 
 // 2000-01-01 (GMT), just to not use 0 here.
-constexpr timestamp epoch = timestamp{timespan{946684800}};
+constexpr vast::time epoch = vast::time{duration{946684800}};
 
 std::vector<event> make_ascending_integers(size_t count) {
   std::vector<event> result;

--- a/libvast_test/src/table_slices.cpp
+++ b/libvast_test/src/table_slices.cpp
@@ -37,7 +37,7 @@ table_slices::table_slices() {
   layout = record_type{
     {"a", bool_type{}},           {"b", integer_type{}},
     {"c", count_type{}},          {"d", real_type{}},
-    {"e", timespan_type{}},       {"f", timestamp_type{}},
+    {"e", duration_type{}},       {"f", time_type{}},
     {"g", string_type{}},         {"h", pattern_type{}},
     {"i", address_type{}},        {"j", subnet_type{}},
     {"k", port_type{}},           {"l", vector_type{count_type{}}},

--- a/schema/suricata.schema
+++ b/schema/suricata.schema
@@ -1,5 +1,5 @@
 type suricata.component.common = record{
-  timestamp: time #time,
+  timestamp: time #timestamp,
   flow_id: count,
   pcap_cnt: count,
   src_ip: addr,
@@ -28,7 +28,7 @@ type suricata.component.app_proto = record{
 }
 
 type suricata.alert = record{
-  timestamp: time #time,
+  timestamp: time #timestamp,
   flow_id: count,
   pcap_cnt: count,
   src_ip: addr,
@@ -58,7 +58,7 @@ type suricata.alert = record{
 }
 
 type suricata.dhcp = record{
-  timestamp: time #time,
+  timestamp: time #timestamp,
   flow_id: count,
   pcap_cnt: count,
   src_ip: addr,
@@ -82,7 +82,7 @@ type suricata.dhcp = record{
 }
 
 type suricata.dns = record{
-  timestamp: time #time,
+  timestamp: time #timestamp,
   flow_id: count,
   pcap_cnt: count,
   src_ip: addr,
@@ -105,7 +105,7 @@ type suricata.dns = record{
 }
 
 type suricata.http = record{
-  timestamp: time #time,
+  timestamp: time #timestamp,
   flow_id: count,
   pcap_cnt: count,
   src_ip: addr,
@@ -131,7 +131,7 @@ type suricata.http = record{
 }
 
 type suricata.fileinfo = record{
-  timestamp: time #time,
+  timestamp: time #timestamp,
   flow_id: count,
   pcap_cnt: count,
   src_ip: addr,
@@ -170,7 +170,7 @@ type suricata.fileinfo = record{
 }
 
 type suricata.flow = record{
-  timestamp: time #time,
+  timestamp: time #timestamp,
   flow_id: count,
   pcap_cnt: count,
   src_ip: addr,
@@ -184,7 +184,7 @@ type suricata.flow = record{
 }
 
 type suricata.netflow = record{
-  timestamp: time #time,
+  timestamp: time #timestamp,
   flow_id: count,
   pcap_cnt: count,
   src_ip: addr,
@@ -204,7 +204,7 @@ type suricata.netflow = record{
 }
 
 type suricata.tls = record{
-  timestamp: time #time,
+  timestamp: time #timestamp,
   flow_id: count,
   pcap_cnt: count,
   src_ip: addr,

--- a/scripts/integration/default_set.yaml
+++ b/scripts/integration/default_set.yaml
@@ -141,7 +141,7 @@ tests:
       - command: import -N json -s @./misc/schema/zeek-conn.schema -t zeek.conn
         input: data/json/conn.log.json.gz
       - command: export -N ascii 'duration > 6s'
-      - command: export -N ascii '#time >= 2011-08-15T03:48'
+      - command: export -N ascii '#timestamp >= 2011-08-15T03:48'
   Node suricata alert:
     tags: [node, import-export, suricata, eve]
     steps:

--- a/scripts/integration/misc/schema/zeek-conn.schema
+++ b/scripts/integration/misc/schema/zeek-conn.schema
@@ -1,5 +1,5 @@
 type zeek.conn = record{
-  ts: time #time,
+  ts: time #timestamp,
   uid: string,
   id: record {orig_h: addr, orig_p: port, resp_h: addr, resp_p: port},
   proto: string,


### PR DESCRIPTION
To stay consistent with the type names in schema files, I've also renamed the type `time` to `timestamp`. For example, our Zeek schema now reads:

```
type zeek.conn = record{
  ts: timestamp #timestamp,
  uid: string,
  ...
}
```