### PR TITLE
Improve unit testing

### DIFF
--- a/libvast/src/system/table_indexer.cpp
+++ b/libvast/src/system/table_indexer.cpp
@@ -38,7 +38,6 @@ table_indexer::table_indexer(partition* parent, const record_type& layout)
     measurements_(layout.fields.size()),
     last_flush_size_(0),
     skip_mask_(0) {
-  VAST_ASSERT(partition_ != nullptr);
   VAST_ASSERT(layout.fields.size() > 0);
   VAST_TRACE(VAST_ARG(type_erased_layout_));
   // Compute which fields to skip.
@@ -56,6 +55,7 @@ table_indexer::~table_indexer() noexcept {
 
 caf::expected<table_indexer> table_indexer::make(partition* parent,
                                                  const record_type& layout) {
+  VAST_ASSERT(parent != nullptr);
   auto ret = table_indexer{parent, layout};
   if (auto err = ret.init())
     return err;

--- a/libvast/test/format/json.cpp
+++ b/libvast/test/format/json.cpp
@@ -154,10 +154,10 @@ TEST_DISABLED(suricata) {
     slices.emplace_back(std::move(ptr));
   };
   auto [err, num] = reader.read(2, 5, add_slice);
-  CHECK_EQUAL(err, caf::none);
-  CHECK_EQUAL(num, 2);
-  CHECK_EQUAL(slices[0]->rows(), 2);
+  CHECK_EQUAL(err, ec::end_of_input);
+  REQUIRE_EQUAL(num, 2);
   CHECK_EQUAL(slices[0]->columns(), 36);
+  CHECK_EQUAL(slices[0]->rows(), 2);
   CHECK(slices[0]->at(0, 19) == view<count>{4520});
 }
 

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -29,6 +29,7 @@
 #include "vast/detail/spawn_container_source.hpp"
 #include "vast/event.hpp"
 #include "vast/ids.hpp"
+#include "vast/system/evaluator.hpp"
 #include "vast/system/indexer.hpp"
 #include "vast/table_slice.hpp"
 
@@ -77,12 +78,16 @@ struct fixture : fixtures::dummy_index {
     min_running_actors = sys.registry().running();
   }
 
-  partition_ptr make_partition() {
-    return idx_state->make_partition();
+  void make_partition() {
+    put = idx_state->make_partition();
   }
 
-  partition_ptr make_partition(uuid id) {
-    return idx_state->make_partition(std::move(id));
+  void make_partition(uuid id) {
+    put = idx_state->make_partition(std::move(id));
+  }
+
+  void reset_partition() {
+    put.reset();
   }
 
   /// @returns how many dummy INDEXER actors are currently running.
@@ -102,6 +107,48 @@ struct fixture : fixtures::dummy_index {
     rec(skip_field<string_type>{"x"}, field<real_type>{"y"}),
   };
 
+  void use_real_indexer_actors() {
+    // For this test, we use actual INDEXER actors.
+    idx_state->factory = system::spawn_indexer;
+  }
+
+  // @pre called inside of a `run_in_index` block
+  ids query(std::string_view query_str) {
+    VAST_ASSERT(put != nullptr);
+    auto expr = unbox(to<expression>(query_str));
+    auto eval = sys.spawn(system::evaluator, expr, put->eval(expr));
+    self->send(eval, self);
+    run();
+    ids result;
+    bool got_done_atom = false;
+    while (!self->mailbox().empty())
+      self->receive([&](const ids& hits) { result |= hits; },
+                    [&](system::done_atom) { got_done_atom = true; });
+    if (!got_done_atom)
+      FAIL("evaluator failed to send 'done'");
+    return result;
+  }
+
+  void ingest(std::vector<table_slice_ptr> slices) {
+    VAST_ASSERT(put != nullptr);
+    VAST_ASSERT(slices.size() > 0);
+    VAST_ASSERT(std::none_of(slices.begin(), slices.end(),
+                             [](auto slice) { return slice == nullptr; }));
+    auto layout = slices[0]->layout();
+    auto& tbl = unbox(put->get_or_add(layout)).first;
+    if (auto err = tbl.init())
+      FAIL("tbl.init failed: " << sys.render(err));
+    for (auto& slice : slices)
+      tbl.add(slice);
+    tbl.spawn_indexers();
+    tbl.for_each_indexer([&](auto& hdl) { anon_send(hdl, slices); });
+    run();
+  }
+
+  void ingest(table_slice_ptr slice) {
+    ingest(std::vector{slice});
+  }
+
   static constexpr size_t total_noskip_fields = 4;
 
   /// Directory where the manager is supposed to persist its state.
@@ -112,6 +159,9 @@ struct fixture : fixtures::dummy_index {
 
   /// Some UUID for the partition.
   uuid partition_id = uuid::random();
+
+  /// Partition-under-test.
+  partition_ptr put;
 };
 
 } // namespace <anonymous>
@@ -122,7 +172,7 @@ TEST(lazy initialization) {
   MESSAGE("create new partition");
   uuid id;
   run_in_index([&] {
-    auto put = make_partition();
+    make_partition();
     id = put->id();
     CHECK_EQUAL(put->dirty(), false);
     MESSAGE("add lazily initialized table indexers");
@@ -131,14 +181,16 @@ TEST(lazy initialization) {
     CHECK_EQUAL(put->dirty(), true);
     CHECK_EQUAL(sorted_strings(put->layouts()), sorted_strings(layouts));
     CHECK_EQUAL(running_indexers(), 0u);
+    reset_partition();
   });
   MESSAGE("re-load partition from disk");
   run_in_index([&] {
-    auto put = make_partition(id);
+    make_partition(id);
     CHECK_EQUAL(put->dirty(), false);
     CHECK_EQUAL(put->init(), caf::none);
     CHECK_EQUAL(sorted_strings(put->layouts()), sorted_strings(layouts));
     CHECK_EQUAL(running_indexers(), 0u);
+    reset_partition();
   });
 }
 
@@ -146,7 +198,7 @@ TEST(eager initialization) {
   MESSAGE("create new partition");
   uuid id;
   run_in_index([&] {
-    auto put = make_partition();
+    make_partition();
     id = put->id();
     MESSAGE("add eagerly initialized table indexers");
     for (auto& x : layouts) {
@@ -156,139 +208,102 @@ TEST(eager initialization) {
     }
     CHECK_EQUAL(sorted_strings(put->layouts()), sorted_strings(layouts));
     CHECK_EQUAL(running_indexers(), total_noskip_fields);
+    reset_partition();
   });
   MESSAGE("partition destructor must have stopped all INDEXER actors");
   run();
   CHECK_EQUAL(running_indexers(), 0u);
   MESSAGE("re-load partition from disk");
   run_in_index([&] {
-    auto put = make_partition(id);
+    make_partition(id);
     CHECK_EQUAL(put->init(), caf::none);
     CHECK_EQUAL(sorted_strings(put->layouts()), sorted_strings(layouts));
     CHECK_EQUAL(running_indexers(), 0u);
+    reset_partition();
   });
 }
 
-/*
+TEST(zeek conn log http slices) {
+  use_real_indexer_actors();
+  MESSAGE("scrutinize each zeek conn log slice individually");
+  // Pre-computed via:
+  //
+  //  bro-cut service < test/logs/zeek/conn.log \
+  //    | awk '{ if ($1 == "http") ++n; if (NR % 100 == 0) { print n; n = 0 } }\
+  //           END { print n }' \
+  //    | paste -s -d , -
+  //
+  // The full list of results is:
+  //
+  //   13, 16, 20, 22, 31, 11, 14, 28, 13, 42, 45, 52, 59, 54, 59, 59, 51,
+  //   29, 21, 31, 20, 28, 9,  56, 48, 57, 32, 53, 25, 31, 25, 44, 38, 55,
+  //   40, 23, 31, 27, 23, 59, 23, 2,  62, 29, 1,  5,  7,  0,  10, 5,  52,
+  //   39, 2,  0,  9,  8,  0,  13, 4,  2,  13, 2,  36, 33, 17, 48, 50, 27,
+  //   44, 9,  94, 63, 74, 66, 5,  54, 21, 7,  2,  3,  21, 7,  2,  14, 7,
+  //
+  // However, we only check the first 10 values, because the test otherwise
+  // takes too long with a runtime of ~12s.
+  std::vector<size_t> num_hits{13, 16, 20, 22, 31, 11, 14, 28, 13, 42};
+  auto expr = unbox(to<expression>("service == \"http\""));
+  for (size_t index = 0; index < num_hits.size(); ++index) {
+    run_in_index([&] {
+      make_partition();
+      ingest(zeek_full_conn_log_slices[index]);
+      CHECK_EQUAL(rank(query("service == \"http\"")), num_hits[index]);
+      reset_partition();
+    });
+    run();
+  }
+}
+
 TEST(integer rows lookup) {
-  MESSAGE("generate partition for flat integer type");
-  put = make_partition();
-  MESSAGE("ingest test data (integers)");
-  integer_type col_type;
-  record_type layout{{"value", col_type}};
-  auto rows = make_rows(1, 2, 3, 1, 2, 3, 1, 2, 3);
-  auto slice = default_table_slice::make(layout, rows);
-  std::vector<table_slice_ptr> slices{slice};
-  detail::spawn_container_source(sys, std::move(slices),
-                                 unbox(put->manager().get_or_add(layout))
-                                   .first);
-  run();
-  MESSAGE("verify partition content");
-  auto res = [&](auto... args) {
-    return make_ids({args...}, rows.size());
-  };
-  CHECK_EQUAL(query(":int == +1"), res(0u, 3u, 6u));
-  CHECK_EQUAL(query(":int == +2"), res(1u, 4u, 7u));
-  CHECK_EQUAL(query("value == +3"), res(2u, 5u, 8u));
-  CHECK_EQUAL(query(":int == +4"), res());
-  CHECK_EQUAL(query(":int != +1"), res(1u, 2u, 4u, 5u, 7u, 8u));
-  CHECK_EQUAL(query("!(:int == +1)"), res(1u, 2u, 4u, 5u, 7u, 8u));
-  CHECK_EQUAL(query(":int > +1 && :int < +3"), res(1u, 4u, 7u));
+  use_real_indexer_actors();
+  run_in_index([&] {
+    MESSAGE("generate partition for flat integer type");
+    make_partition();
+    MESSAGE("ingest test data (integers)");
+    integer_type col_type;
+    record_type layout{{"value", col_type}};
+    auto rows = make_rows(1, 2, 3, 1, 2, 3, 1, 2, 3);
+    ingest(default_table_slice::make(layout, rows));
+    MESSAGE("verify partition content");
+    auto res = [&](auto... args) { return make_ids({args...}, rows.size()); };
+    CHECK_EQUAL(query(":int == +1"), res(0u, 3u, 6u));
+    CHECK_EQUAL(query(":int == +2"), res(1u, 4u, 7u));
+    CHECK_EQUAL(query("value == +3"), res(2u, 5u, 8u));
+    CHECK_EQUAL(query(":int == +4"), ids());
+    CHECK_EQUAL(query(":int != +1"), res(1u, 2u, 4u, 5u, 7u, 8u));
+    CHECK_EQUAL(query("!(:int == +1)"), res(1u, 2u, 4u, 5u, 7u, 8u));
+    CHECK_EQUAL(query(":int > +1 && :int < +3"), res(1u, 4u, 7u));
+  });
 }
 
 TEST(single partition zeek conn log lookup) {
+  use_real_indexer_actors();
   MESSAGE("generate partiton for zeek conn log");
-  put = make_partition();
-  MESSAGE("ingest zeek conn logs");
-  auto layout = zeek_conn_log_layout();
-  auto indexer = unbox(put->manager().get_or_add(layout)).first;
-  detail::spawn_container_source(sys, zeek_conn_log_slices, indexer);
-  run();
-  MESSAGE("verify partition content");
-  auto res = [&](auto... args) {
-    return make_ids({args...}, zeek_conn_log.size());
-  };
-  CHECK_EQUAL(rank(query("id.resp_p == 53/?")), 3u);
-  CHECK_EQUAL(rank(query("id.resp_p == 137/?")), 5u);
-  CHECK_EQUAL(rank(query("id.resp_p == 53/? || id.resp_p == 137/?")), 8u);
-  CHECK_EQUAL(rank(query("&time > 1970-01-01")), zeek_conn_log.size());
-  CHECK_EQUAL(rank(query("proto == \"udp\"")), 20u);
-  CHECK_EQUAL(rank(query("proto == \"tcp\"")), 0u);
-  CHECK_EQUAL(rank(query("uid == \"nkCxlvNN8pi\"")), 1u);
-  CHECK_EQUAL(rank(query("orig_bytes < 400")), 17u);
-  CHECK_EQUAL(rank(query("orig_bytes < 400 && proto == \"udp\"")), 17u);
-  CHECK_EQUAL(rank(query(":addr == fe80::219:e3ff:fee7:5d23")), 1u);
-  CHECK_EQUAL(query(":addr == 192.168.1.104"), res(5u, 6u, 9u, 11u));
-  CHECK_EQUAL(rank(query("service == \"dns\"")), 11u);
-  CHECK_EQUAL(rank(query("service == \"dns\" && :addr == 192.168.1.102")), 4u);
+  run_in_index([&] {
+    make_partition();
+    MESSAGE("ingest zeek conn logs");
+    ingest(zeek_conn_log_slices);
+    MESSAGE("verify partition content");
+    auto res = [&](auto... args) {
+      return make_ids({args...}, zeek_conn_log.size());
+    };
+    CHECK_EQUAL(rank(query("id.resp_p == 53/?")), 3u);
+    CHECK_EQUAL(rank(query("id.resp_p == 137/?")), 5u);
+    CHECK_EQUAL(rank(query("id.resp_p == 53/? || id.resp_p == 137/?")), 8u);
+    CHECK_EQUAL(rank(query("#time > 1970-01-01")), zeek_conn_log.size());
+    CHECK_EQUAL(rank(query("proto == \"udp\"")), 20u);
+    CHECK_EQUAL(rank(query("proto == \"tcp\"")), 0u);
+    CHECK_EQUAL(rank(query("uid == \"nkCxlvNN8pi\"")), 1u);
+    CHECK_EQUAL(rank(query("orig_bytes < 400")), 17u);
+    CHECK_EQUAL(rank(query("orig_bytes < 400 && proto == \"udp\"")), 17u);
+    CHECK_EQUAL(rank(query(":addr == fe80::219:e3ff:fee7:5d23")), 1u);
+    CHECK_EQUAL(query(":addr == 192.168.1.104"), res(5u, 6u, 9u, 11u));
+    CHECK_EQUAL(rank(query("service == \"dns\"")), 11u);
+    CHECK_EQUAL(rank(query("service == \"dns\" && :addr == 192.168.1.102")),
+                4u);
+  });
 }
-
-TEST(multiple partitions zeek conn log lookup no messaging) {
-  // This test bypasses any messaging by reaching directly into the state of
-  // each INDEXER actor.
-  using indexer_type = caf::stateful_actor<indexer_state>;
-  MESSAGE("ingest zeek conn logs into partitions of size " << slice_size);
-  std::vector<partition_ptr> partitions;
-  auto layout = zeek_conn_log_layout();
-  for (auto& slice : zeek_conn_log_slices) {
-    auto ptr = make_partition(uuid::random());
-    CHECK_EQUAL(exists(ptr->dir()), false);
-    CHECK_EQUAL(ptr->dirty(), false);
-    auto indexers = unbox(ptr->manager().get_or_add(layout)).first;
-    run();
-    for (auto& idx_hdl : indexers) {
-      auto& idx = deref<indexer_type>(idx_hdl);
-      idx.initialize();
-      auto& col = idx.state.col;
-      CHECK_EQUAL(col.dirty(), false);
-      col.add(slice);
-      CHECK_EQUAL(col.dirty(), true);
-    }
-    CHECK_EQUAL(ptr->dirty(), true);
-    partitions.emplace_back(std::move(ptr));
-  }
-  MESSAGE("make sure all partitions have different IDs, paths, and INDEXERs");
-  std::set<uuid> id_set;
-  std::set<path> path_set;
-  std::set<caf::actor> indexer_set;
-  for (size_t i = 0; i < partitions.size(); ++i) {
-    auto& part = partitions[i];
-    CHECK(id_set.emplace(part->id()).second);
-    CHECK(path_set.emplace(part->dir()).second);
-    part->manager().for_each([&](const caf::actor& idx_hdl) {
-      CHECK(indexer_set.emplace(idx_hdl).second);
-    });
-  }
-  MESSAGE("verify partition content");
-  auto res = [&](auto... args) {
-    return make_ids({args...}, zeek_conn_log.size());
-  };
-  auto query_all = [&](std::string_view expr_str) {
-    ids result;
-    auto expr = unbox(to<expression>(expr_str));
-    for (auto& part : partitions) {
-      part->manager().for_each([&](const caf::actor& idx_hdl) {
-        auto& tbl = deref<indexer_type>(idx_hdl).state.tbl;
-        result |= unbox(tbl.lookup(expr));
-      });
-    }
-    return result;
-  };
-  CHECK_EQUAL(rank(query_all("id.resp_p == 53/?")), 3u);
-  CHECK_EQUAL(rank(query_all("id.resp_p == 137/?")), 5u);
-  CHECK_EQUAL(rank(query_all("id.resp_p == 53/? || id.resp_p == 137/?")), 8u);
-  CHECK_EQUAL(rank(query_all("&time > 1970-01-01")), zeek_conn_log.size());
-  CHECK_EQUAL(rank(query_all("proto == \"udp\"")), 20u);
-  CHECK_EQUAL(rank(query_all("proto == \"tcp\"")), 0u);
-  CHECK_EQUAL(rank(query_all("uid == \"nkCxlvNN8pi\"")), 1u);
-  CHECK_EQUAL(rank(query_all("orig_bytes < 400")), 17u);
-  CHECK_EQUAL(rank(query_all("orig_bytes < 400 && proto == \"udp\"")), 17u);
-  CHECK_EQUAL(rank(query_all(":addr == fe80::219:e3ff:fee7:5d23")), 1u);
-  CHECK_EQUAL(query_all(":addr == 192.168.1.104"), res(5u, 6u, 9u, 11u));
-  CHECK_EQUAL(rank(query_all("service == \"dns\"")), 11u);
-  CHECK_EQUAL(rank(query_all("service == \"dns\" && :addr == 192.168.1.102")),
-              4u);
-}
-*/
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/system/table_indexer.cpp
+++ b/libvast/test/system/table_indexer.cpp
@@ -16,183 +16,42 @@
 #include "vast/system/table_indexer.hpp"
 
 #include "vast/test/test.hpp"
-#include "vast/test/fixtures/actor_system_and_events.hpp"
 
-#include "vast/bitmap.hpp"
-#include "vast/concept/parseable/to.hpp"
-#include "vast/concept/parseable/vast/expression.hpp"
-#include "vast/concept/printable/stream.hpp"
-#include "vast/concept/printable/vast/error.hpp"
-#include "vast/concept/printable/vast/event.hpp"
-#include "vast/concept/printable/vast/expression.hpp"
-#include "vast/default_table_slice.hpp"
+#include "vast/test/fixtures/events.hpp"
 
-/*
+#include "vast/table_slice.hpp"
 
+using vast::system::table_indexer;
 using namespace vast;
 
-namespace {
+FIXTURE_SCOPE(table_indexer_tests, fixtures::events)
 
-struct fixture : fixtures::deterministic_actor_system_and_events {
-  ids query(std::string_view what) {
-    return unbox(tbl->lookup(unbox(to<expression>(what))));
-  }
-
-  void init(table_indexer&& new_tbl) {
-    REQUIRE_EQUAL(tbl, nullptr);
-    tbl = std::make_unique<table_indexer>(std::move(new_tbl));
-  }
-
-  void init(expected<table_indexer>&& new_tbl) {
-    if (!new_tbl)
-      FAIL("error: " << new_tbl.error());
-    init(std::move(*new_tbl));
-  }
-
-  void add(table_slice_ptr x) {
-    auto err = tbl->add(x);
-    if (err)
-      FAIL("error: " << err);
-  }
-
-  std::unique_ptr<table_indexer> tbl;
-};
-
-} // namespace <anonymous>
-
-FIXTURE_SCOPE(table_indexer_tests, fixture)
-
-TEST(integer values) {
-  MESSAGE("generate table layout for flat integer type");
-  integer_type column_type;
-  auto layout = record_type{{"value", column_type}}.name("int_log");
-  init(make_table_indexer(sys, directory, layout));
-  MESSAGE("ingest test data (integers)");
-  auto rows = make_rows(1, 2, 3, 1, 2, 3, 1, 2, 3);
-  auto slice = default_table_slice::make(layout, rows);
-  REQUIRE_NOT_EQUAL(slice.get(), nullptr);
-  REQUIRE_EQUAL(slice->columns(), 1u);
-  REQUIRE_EQUAL(slice->rows(), rows.size());
-  add(slice);
-  auto res = [&](auto... args) {
-    return make_ids({args...}, rows.size());
-  };
-  MESSAGE("verify table index");
-  auto verify = [&] {
-    CHECK_EQUAL(query("value == +1"), res(0u, 3u, 6u));
-    CHECK_EQUAL(query(":int == +1"), res(0u, 3u, 6u));
-    CHECK_EQUAL(query(":int == +2"), res(1u, 4u, 7u));
-    CHECK_EQUAL(query(":int == +3"), res(2u, 5u, 8u));
-    CHECK_EQUAL(query(":int == +4"), res());
-    CHECK_EQUAL(query(":int != +1"), res(1u, 2u, 4u, 5u, 7u, 8u));
-    CHECK_EQUAL(query("!(:int == +1)"), res(1u, 2u, 4u, 5u, 7u, 8u));
-    CHECK_EQUAL(query(":int > +1 && :int < +3"), res(1u, 4u, 7u));
-    CHECK_EQUAL(query("&type == \"int_log\""), make_ids({{0, 9}}));
-  };
-  verify();
-  MESSAGE("(automatically) persist table index and restore from disk");
-  tbl.reset();
-  init(make_table_indexer(sys, directory, layout));
-  MESSAGE("verify table index again");
-  verify();
-}
-
-TEST(record type) {
-  MESSAGE("generate table layout for record type");
-  record_type layout {
-    {"x.a", integer_type{}},
-    {"x.b", bool_type{}},
-    {"y.a", string_type{}},
-  };
-  init(make_table_indexer(sys, directory, layout));
-  MESSAGE("ingest test data (records)");
-  auto mk_row = [&](int x, bool y, std::string z) {
-    return vector{x, y, std::move(z)};
-  };
-  // Some test data.
-  std::vector<vector> rows{mk_row(1, true, "abc"),     mk_row(10, false, "def"),
-                           mk_row(5, true, "hello"),   mk_row(1, true, "d e f"),
-                           mk_row(15, true, "world"),  mk_row(5, true, "bar"),
-                           mk_row(10, false, "a b c"), mk_row(10, false, "baz"),
-                           mk_row(5, false, "foo"),    mk_row(1, true, "test")};
-  auto slice = default_table_slice::make(layout, rows);
-  REQUIRE_EQUAL(slice->rows(), rows.size());
-  REQUIRE_EQUAL(slice->columns(), 3u);
-  add(slice);
-  auto res = [&](auto... args) {
-    return make_ids({args...}, rows.size());
-  };
-  MESSAGE("verify table index");
-  auto verify = [&] {
-    CHECK_EQUAL(query("x.a == +1"), res(0u, 3u, 9u));
-    CHECK_EQUAL(query("x.a > +1"), res(1u, 2u, 4u, 5u, 6u, 7u, 8u));
-    CHECK_EQUAL(query("x.a > +1 && x.b == T"), res(2u, 4u, 5u));
-  };
-  verify();
-  MESSAGE("(automatically) persist table index and restore from disk");
-  tbl.reset();
-  init(make_table_indexer(sys, directory, layout));
-  MESSAGE("verify table index again");
-  verify();
-}
-
-TEST(zeek conn logs) {
-  MESSAGE("generate table layout for zeek conn logs");
-  auto layout = zeek_conn_log_layout();
-  init(make_table_indexer(sys, directory, layout));
-  MESSAGE("ingest test data (zeek conn log)");
-  for (auto slice : zeek_conn_log_slices)
-    add(slice);
-  MESSAGE("verify table index");
-  auto verify = [&] {
-    CHECK_EQUAL(rank(query("id.resp_p == 53/?")), 3u);
-    CHECK_EQUAL(rank(query("id.resp_p == 137/?")), 5u);
-    CHECK_EQUAL(rank(query("id.resp_p == 53/? || id.resp_p == 137/?")), 8u);
-    CHECK_EQUAL(rank(query("&time > 1970-01-01")), zeek_conn_log.size());
-    CHECK_EQUAL(rank(query("proto == \"udp\"")), 20u);
-    CHECK_EQUAL(rank(query("proto == \"tcp\"")), 0u);
-    CHECK_EQUAL(rank(query("uid == \"nkCxlvNN8pi\"")), 1u);
-    CHECK_EQUAL(rank(query("orig_bytes < 400")), 17u);
-    CHECK_EQUAL(rank(query("orig_bytes < 400 && proto == \"udp\"")), 17u);
-    CHECK_EQUAL(rank(query(":addr == fe80::219:e3ff:fee7:5d23")), 1u);
-    CHECK_EQUAL(rank(query(":addr == 192.168.1.104")), 4u);
-    CHECK_EQUAL(rank(query("service == \"dns\"")), 11u);
-    CHECK_EQUAL(rank(query("service == \"dns\" && :addr == 192.168.1.102")),
-                4u);
-  };
-  verify();
-  MESSAGE("(automatically) persist table index and restore from disk");
-  tbl.reset();
-  init(make_table_indexer(sys, directory, layout));
-  MESSAGE("verify table index again");
-  verify();
-}
-
-TEST_DISABLED(zeek conn log http slices) {
-  MESSAGE("scrutinize each zeek conn log slice individually");
-  // Pre-computed via:
-  //  zeek-cut service < test/logs/zeek/conn.log \
-  //    | awk '{ if ($1 == "http") ++n; if (NR % 100 == 0) { print n; n = 0 } }\
-  //           END { print n }' \
-  //    | paste -s -d , -
-  std::vector<size_t> hits{
-    13, 16, 20, 22, 31, 11, 14, 28, 13, 42, 45, 52, 59, 54, 59, 59, 51,
-    29, 21, 31, 20, 28, 9,  56, 48, 57, 32, 53, 25, 31, 25, 44, 38, 55,
-    40, 23, 31, 27, 23, 59, 23, 2,  62, 29, 1,  5,  7,  0,  10, 5,  52,
-    39, 2,  0,  9,  8,  0,  13, 4,  2,  13, 2,  36, 33, 17, 48, 50, 27,
-    44, 9,  94, 63, 74, 66, 5,  54, 21, 7,  2,  3,  21, 7,  2,  14, 7
-  };
-  auto layout = zeek_conn_log_layout();
-  REQUIRE_EQUAL(std::accumulate(hits.begin(), hits.end(), size_t(0)), 2386u);
-  for (size_t slice_id = 0; slice_id < hits.size(); ++slice_id) {
-    tbl.reset();
-    rm(directory);
-    init(make_table_indexer(sys, directory, layout));
-    add(zeek_conn_log_slices[slice_id]);
-    CHECK_EQUAL(rank(query("service == \"http\"")), hits[slice_id]);
-  }
+TEST(zeek conn log) {
+  // Initializing table_indexer with `nullptr` as parent means we must not call
+  // any of these functions:
+  // - init()
+  // - flush_to_disk()
+  // - state()
+  // - indexer_at()
+  // - row_ids_file()
+  // - spawn_indexers()
+  // - partition_dir()
+  // - base_dir()
+  // - data_dir()
+  // These functions are tested as part of the `partition` test suite.
+  table_indexer tbl{nullptr, zeek_conn_log_slices[0]->layout()};
+  CHECK_EQUAL(tbl.dirty(), false);
+  CHECK_EQUAL(tbl.columns(), zeek_conn_log_slices[0]->columns());
+  CHECK_EQUAL(tbl.row_ids(), ids());
+  CHECK_EQUAL(tbl.indexers().size(), zeek_conn_log_slices[0]->columns());
+  CHECK_EQUAL(tbl.layout(), zeek_conn_log_slices[0]->layout());
+  for (auto& slice : zeek_conn_log_slices)
+    tbl.add(slice);
+  CHECK_EQUAL(tbl.dirty(), true);
+  CHECK_EQUAL(rank(tbl.row_ids()), zeek_conn_log.size());
+  // Make sure the destructor does not try to flush to disk.
+  tbl.set_clean();
+  CHECK_EQUAL(tbl.dirty(), false);
 }
 
 FIXTURE_SCOPE_END()
-
-*/

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -16,10 +16,11 @@
 #include "vast/test/test.hpp"
 #include "vast/test/fixtures/events.hpp"
 
-#include "vast/value_index.hpp"
-#include "vast/value_index_factory.hpp"
 #include "vast/load.hpp"
 #include "vast/save.hpp"
+#include "vast/table_slice.hpp"
+#include "vast/value_index.hpp"
+#include "vast/value_index_factory.hpp"
 
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/address.hpp"
@@ -511,41 +512,33 @@ TEST(none values) {
   CHECK_EQUAL(to_string(unbox(bm)), "01100011100001111111100");
 }
 
-namespace {
-
-auto orig_h(const event& x) {
-  auto& log_entry = caf::get<vector>(x.data());
-  auto& conn_id = caf::get<vector>(log_entry[2]);
-  return make_view(caf::get<address>(conn_id[0]));
-}
-
-} // namespace <anonymous>
-
 // This test uncovered a regression that ocurred when computing the rank of a
 // bitmap representing conn.log events. The culprit was the EWAH bitmap
 // encoding, because swapping out ewah_bitmap for null_bitmap in address_index
 // made the bug disappear.
-TEST_DISABLED(regression - build an address index from zeek events) {
+TEST(regression - build an address index from zeek events) {
   // Populate the index with data up to the critical point.
   address_index idx{address_type{}};
-  for (auto i = 0; i < 6464; ++i) {
-    auto& x = zeek_conn_log[i];
-    CHECK(idx.append(orig_h(x), x.id()));
+  size_t row_id = 0;
+  for (auto& slice : zeek_full_conn_log_slices) {
+    for (size_t row = 0; row < slice->rows(); ++row) {
+      // Column 2 is orig_h.
+      if (!idx.append(slice->at(row, 2), row_id))
+        FAIL("appending to the value_index failed!");
+      if (++row_id == 6464) {
+        // The last ID should be 720 at this point.
+        auto addr = unbox(to<data>("169.254.225.22"));
+        auto before = unbox(idx.lookup(equal, make_data_view(addr)));
+        CHECK_EQUAL(rank(before), 4u);
+        CHECK_EQUAL(select(before, -1), id{720});
+      }
+    }
   }
-  // This is where we are in trouble: the last ID should be 720, but the bogus
-  // test reports 6452.
+  // Checking again after ingesting all events must not change the outcome.
   auto addr = unbox(to<data>("169.254.225.22"));
   auto before = unbox(idx.lookup(equal, make_data_view(addr)));
   CHECK_EQUAL(rank(before), 4u);
   CHECK_EQUAL(select(before, -1), id{720});
-  auto& x = zeek_conn_log[6464];
-  // After adding another event, the correct state is restored again and the
-  // bug doesn't show up anymore.
-  CHECK(idx.append(orig_h(x), x.id()));
-  auto after = unbox(idx.lookup(equal, make_data_view(addr)));
-  CHECK_EQUAL(rank(after), 4u);
-  CHECK_EQUAL(select(after, -1), id{720});
-  CHECK_NOT_EQUAL(select(after, -1), id{6452});
 }
 
 // This was the first attempt in figuring out where the bug sat. I didn't fire.
@@ -566,106 +559,119 @@ TEST(regression - checking the result single bitmap) {
   CHECK_EQUAL(bm.size(), 6465u);
 }
 
-TEST_DISABLED(regression - manual address bitmap index from bitmaps) {
+TEST(regression - manual address bitmap index from bitmaps) {
   MESSAGE("populating index");
   std::array<ewah_bitmap, 32> idx;
-  for (auto n = 0; n < 6464; ++n) {
-    auto x = orig_h(zeek_conn_log[n]);
-    for (auto i = 0u; i < 4; ++i) {
-      auto byte = x.data()[i + 12];
-      for (auto j = 0u; j < 8; ++j)
-        idx[(i * 8) + j].append_bits((byte >> j) & 1, 1);
+  size_t row_id = 0;
+  for (auto& slice : zeek_full_conn_log_slices) {
+    for (size_t row = 0; row < slice->rows(); ++row) {
+      // Column 2 is orig_h.
+      auto x = caf::get<view<address>>(slice->at(row, 2));
+      for (auto i = 0u; i < 4; ++i) {
+        auto byte = x.data()[i + 12];
+        for (auto j = 0u; j < 8; ++j)
+          idx[(i * 8) + j].append_bits((byte >> j) & 1, 1);
+      }
+      if (++row_id == 6464) {
+        auto addr = unbox(to<address>("169.254.225.22"));
+        auto result = ewah_bitmap{idx[0].size(), true};
+        REQUIRE_EQUAL(result.size(), 6464u);
+        for (auto i = 0u; i < 4; ++i) {
+          auto byte = addr.data()[i + 12];
+          for (auto j = 0u; j < 8; ++j) {
+            auto& bm = idx[(i * 8) + j];
+            result &= ((byte >> j) & 1) ? bm : ~bm;
+          }
+        }
+        CHECK_EQUAL(rank(result), 4u);
+        CHECK_EQUAL(select(result, -1), id{720});
+        // Done testing, we're only interested in the first 6464 rows.
+        return;
+      }
     }
   }
-  MESSAGE("querying 169.254.225.22");
-  auto x = *to<address>("169.254.225.22");
-  auto result = ewah_bitmap{idx[0].size(), true};
-  REQUIRE_EQUAL(result.size(), 6464u);
-  for (auto i = 0u; i < 4; ++i) {
-    auto byte = x.data()[i + 12];
-    for (auto j = 0u; j < 8; ++j) {
-      auto& bm = idx[(i * 8) + j];
-      result &= ((byte >> j) & 1) ? bm : ~bm;
-    }
-  }
-  CHECK_EQUAL(rank(result), 4u);
-  CHECK_EQUAL(select(result, -1), id{720});
 }
 
-TEST_DISABLED(regression - manual address bitmap index from 4 byte indexes) {
+TEST(regression - manual address bitmap index from 4 byte indexes) {
   using byte_index = bitmap_index<uint8_t, bitslice_coder<ewah_bitmap>>;
   std::array<byte_index, 4> idx;
   idx.fill(byte_index{8});
+  size_t row_id = 0;
   MESSAGE("populating index");
-  for (auto n = 0; n < 6464; ++n) {
-    auto x = orig_h(zeek_conn_log[n]);
-    for (auto i = 0u; i < 4; ++i) {
-      auto byte = x.data()[i + 12];
-      idx[i].append(byte);
+  for (auto& slice : zeek_full_conn_log_slices) {
+    for (size_t row = 0; row < slice->rows(); ++row) {
+      // Column 2 is orig_h.
+      auto x = caf::get<view<address>>(slice->at(row, 2));
+      for (auto i = 0u; i < 4; ++i) {
+        auto byte = x.data()[i + 12];
+        idx[i].append(byte);
+      }
+      if (++row_id == 6464) {
+        MESSAGE("querying 169.254.225.22");
+        auto x = unbox(to<address>("169.254.225.22"));
+        auto result = ewah_bitmap{idx[0].size(), true};
+        REQUIRE_EQUAL(result.size(), 6464u);
+        for (auto i = 0u; i < 4; ++i) {
+          auto byte = x.data()[i + 12];
+          result &= idx[i].lookup(equal, byte);
+        }
+        CHECK_EQUAL(rank(result), 4u);
+        CHECK_EQUAL(select(result, -1), id{720});
+        // Done testing, we're only interested in the first 6464 rows.
+        return;
+      }
     }
   }
-  MESSAGE("querying 169.254.225.22");
-  auto x = *to<address>("169.254.225.22");
-  auto result = ewah_bitmap{idx[0].size(), true};
-  REQUIRE_EQUAL(result.size(), 6464u);
-  for (auto i = 0u; i < 4; ++i) {
-    auto byte = x.data()[i + 12];
-    result &= idx[i].lookup(equal, byte);
-  }
-  CHECK_EQUAL(rank(result), 4u);
-  CHECK_EQUAL(select(result, -1), id{720});
 }
 
-namespace {
-
-auto service(const event& log) {
-  auto& xs = caf::get<vector>(log.data());
-  return make_view(xs[4]);
-}
-
-bool is_http(view<data> x) {
-  return caf::get<view<std::string>>(x) == "http";
-}
-
-} // namespace <anonymous>
-
-TEST_DISABLED(regression - zeek conn log service http) {
+TEST(regression - zeek conn log service http) {
   // The number of occurrences of the 'service == "http"' in the conn.log,
   // sliced in batches of 100. Pre-computed via:
   //  zeek-cut service < test/logs/zeek/conn.log
   //    | awk '{ if ($1 == "http") ++n; if (NR % 100 == 0) { print n; n = 0 } }
   //           END { print n }'
   //    | paste -s -d , -
+  auto is_http = [](auto x) {
+    return caf::get<view<std::string>>(x) == "http";
+  };
   std::vector<size_t> http_per_100_events{
     13, 16, 20, 22, 31, 11, 14, 28, 13, 42, 45, 52, 59, 54, 59, 59, 51,
     29, 21, 31, 20, 28, 9,  56, 48, 57, 32, 53, 25, 31, 25, 44, 38, 55,
     40, 23, 31, 27, 23, 59, 23, 2,  62, 29, 1,  5,  7,  0,  10, 5,  52,
     39, 2,  0,  9,  8,  0,  13, 4,  2,  13, 2,  36, 33, 17, 48, 50, 27,
-    44, 9,  94, 63, 74, 66, 5,  54, 21, 7,  2,  3,  21, 7,  2,  14, 7
+    44, 9,  94, 63, 74, 66, 5,  54, 21, 7,  2,  3,  21, 7,  2,  14, 7,
   };
-  std::vector<std::pair<value_index_ptr, ids>> slices;
-  slices.reserve(http_per_100_events.size());
-  for (size_t i = 0; i < zeek_conn_log.size(); ++i) {
-    if (i % 100 == 0)
-      slices.emplace_back(factory<value_index>::make(string_type{}),
-                          ids(i, false));
-    auto& [idx, expected] = slices.back();
-    auto x = service(zeek_conn_log[i]);
-    idx->append(x, i);
-    expected.append_bit(is_http(x));
+  auto& slices = zeek_full_conn_log_slices;
+  REQUIRE_EQUAL(slices.size(), http_per_100_events.size());
+  REQUIRE(std::all_of(slices.begin(), prev(slices.end()),
+                      [](auto& slice) { return slice->rows() == 100; }));
+  std::vector<std::pair<value_index_ptr, ids>> slice_stats;
+  slice_stats.reserve(slices.size());
+  size_t row_id = 0;
+  for (auto& slice : slices) {
+    slice_stats.emplace_back(factory<value_index>::make(string_type{}),
+                             ids(row_id, false));
+    auto& [idx, expected] = slice_stats.back();
+    for (size_t row = 0; row < slice->rows(); ++row) {
+      // Column 7 is service.
+      auto x = slice->at(row, 7);
+      idx->append(x, row_id);
+      expected.append_bit(is_http(x));
+      ++row_id;
+    }
   }
-  for (size_t i = 0; i < slices.size(); ++i) {
+  for (size_t i = 0; i < slice_stats.size(); ++i) {
     MESSAGE("verifying batch [" << (i * 100) << ',' << (i * 100) + 100 << ')');
-    auto& [idx, expected] = slices[i];
+    auto& [idx, expected] = slice_stats[i];
     auto result = unbox(idx->lookup(equal, make_data_view("http")));
     CHECK_EQUAL(rank(result), http_per_100_events[i]);
   }
 }
 
-TEST_DISABLED(regression - manual value index for zeek conn log service http) {
+TEST(regression - manual value index for zeek conn log service http) {
   // Setup string size bitmap index.
-  using length_bitmap_index =
-    bitmap_index<uint32_t, multi_level_coder<range_coder<ids>>>;
+  using length_bitmap_index = bitmap_index<uint32_t,
+                                           multi_level_coder<range_coder<ids>>>;
   auto length = length_bitmap_index{base::uniform(10, 3)};
   // Setup one bitmap index per character.
   using char_bitmap_index = bitmap_index<uint8_t, bitslice_coder<ewah_bitmap>>;
@@ -674,8 +680,11 @@ TEST_DISABLED(regression - manual value index for zeek conn log service http) {
   // Manually build a failing slice: [8000,8100).
   ewah_bitmap none;
   ewah_bitmap mask;
-  for (auto i = 8000; i < 8100; ++i)
-    caf::visit(detail::overload(
+  // Get the slice that contains the events for [8000,8100).
+  auto slice = zeek_full_conn_log_slices[80];
+  for (size_t row = 0; row < slice->rows(); ++row) {
+    auto i = 8000 + row;
+    auto f = detail::overload(
       [&](caf::none_t) {
         none.append_bits(false, i - none.size());
         none.append_bit(true);
@@ -694,10 +703,10 @@ TEST_DISABLED(regression - manual value index for zeek conn log service http) {
         mask.append_bits(false, i - mask.size());
         mask.append_bit(true);
       },
-      [&](auto) {
-        FAIL("unexpected service type");
-      }
-    ), service(zeek_conn_log[i]));
+      [&](auto) { FAIL("unexpected service type"); });
+    // Column 7 is service.
+    caf::visit(f, slice->at(row, 7));
+  }
   REQUIRE_EQUAL(rank(mask), 100u);
   // Perform a manual index lookup for "http".
   auto http = "http"s;

--- a/libvast/vast/system/table_indexer.hpp
+++ b/libvast/vast/system/table_indexer.hpp
@@ -128,19 +128,20 @@ public:
   /// @param x Table slice for ingestion.
   void add(const table_slice_ptr& x);
 
-private:
-  // -- constructor ------------------------------------------------------------
-
-  /// @pre `parent != nullptr`
-  table_indexer(partition* parent, const record_type& layout);
-
-  // -- utility functions ------------------------------------------------------
+  /// @cond PRIVATE
 
   /// Marks the state as clean, i.e. persistet.
   /// @post `dirty() == false`
   void set_clean() noexcept {
     last_flush_size_ = row_ids_.size();
   }
+
+  table_indexer(partition* parent, const record_type& layout);
+
+  /// @endcond
+
+private:
+  // -- utility functions ------------------------------------------------------
 
   /// @returns whether the meta indexer skips given column
   auto skips_column(size_t column) const noexcept {


### PR DESCRIPTION
- Reinstate the regression test in `value_index`
- Fix a segfault in a (disabled) JSON format test (the test itself still fails)
- Bring back several tests in the `partition`
- Test `table_indexer` as good as possible without parent