### PR TITLE
 Add root command option to set verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🎁 Configuring how much status information gets printed to STDERR previously
+  required obscure config settings. From now on, users can simply use
+  `--verbosity=<level>`, where `<level>` is one of `quiet`, `error`, `warn`,
+  `info`, `debug`, or `trace`. However, `debug` and `trace` are only available
+  on debug builds (otherwise they fall back to `info` output level).
+
 - 🎁 The query expression language now supports *data predicates*, which are a
   shorthand for a type extractor in combination with an equality operator. For
   example, the data predicate `6.6.6.6` is the same as `:addr == 6.6.6.6`.

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -131,6 +131,10 @@ bool init_config(caf::actor_system_config& cfg, const command::invocation& from,
   };
   // Merge all CLI settings into the actor_system settings.
   merge_settings(from.options, cfg.content);
+  // Allow users to use `system.verbosity` to configure console verbosity.
+  if (auto value = caf::get_if<caf::atom_value>(&from.options,
+                                                "system.verbosity"))
+    cfg.set("logger.console-verbosity", *value);
   // Adjust logger file name unless the user overrides the default.
   auto default_fn = caf::defaults::logger::file_name;
   if (caf::get_or(cfg, "logger.file-name", default_fn) == default_fn) {

--- a/libvast/src/system/default_application.cpp
+++ b/libvast/src/system/default_application.cpp
@@ -49,6 +49,7 @@
 namespace vast::system {
 
 default_application::default_application() {
+  using caf::atom_value;
   // Returns default options for commands.
   auto opts = [](std::string_view category = "global") {
     return command::opts(category);
@@ -62,6 +63,8 @@ default_application::default_application() {
   root.options = opts("?system")
                    .add<std::string>("config-file",
                                      "path to a configuration file")
+                   .add<atom_value>("verbosity",
+                                    "output verbosity level on the console")
                    .add<std::vector<std::string>>("schema-paths",
                                                   schema_paths_help)
                    .add<std::string>("directory,d",
@@ -87,8 +90,7 @@ default_application::default_application() {
   // Add "import" command and its children.
   import_ = add(nullptr, "import", "imports data from STDIN or file",
                 opts("?import")
-                  .add<caf::atom_value>("table-slice-type,t",
-                                        "table slice type")
+                  .add<atom_value>("table-slice-type,t", "table slice type")
                   .add<bool>("node,N",
                              "spawn a node instead of connecting to one")
                   .add<bool>("blocking,b",

--- a/libvast/src/system/default_configuration.cpp
+++ b/libvast/src/system/default_configuration.cpp
@@ -25,72 +25,17 @@
 
 namespace vast::system {
 
-path make_log_dirname() {
-  auto dir_name = caf::deep_to_string(caf::make_timestamp());
-  dir_name += '#';
-  dir_name += std::to_string(detail::process_id());
-  return path{"log"} / dir_name;
-}
-
-default_configuration::default_configuration(std::string application_name)
-  : application_name{std::move(application_name)} {
+default_configuration::default_configuration() {
   // Tweak default logging options.
+  using caf::atom;
   set("logger.component-blacklist",
-      caf::make_config_value_list(caf::atom("caf"), caf::atom("caf_flow"),
-                                  caf::atom("caf_stream")));
-  set("logger.console-verbosity", caf::atom("INFO"));
-  set("logger.console", caf::atom("COLORED"));
-  set("logger.file-verbosity", caf::atom("DEBUG"));
+      caf::make_config_value_list(atom("caf"), atom("caf_flow"),
+                                  atom("caf_stream")));
+  set("logger.console-verbosity", atom("INFO"));
+  set("logger.console", atom("COLORED"));
+  set("logger.file-verbosity", atom("DEBUG"));
   // Allow VAST clusters to form a mesh.
   set("middleman.enable-automatic-connections", true);
-}
-
-caf::error default_configuration::setup_log_file() {
-  // Adjust logger file name unless the user overrides the default..
-  auto default_fn = caf::defaults::logger::file_name;
-  if (caf::get_or(*this, "logger.file-name", default_fn) != default_fn)
-    return caf::none;
-  // Get proper directory path.
-  path base_dir = get_or(*this, "system.directory",
-                         defaults::system::directory);
-  auto log_dir = base_dir / make_log_dirname();
-  // Create the log directory first, which we need to create the symlink
-  // afterwards.
-  if (!exists(log_dir))
-    if (auto res = mkdir(log_dir); !res)
-      return res.error();
-  // Create user-friendly symlink to current log directory.
-  auto link_dir = log_dir.chop(-1) / "current";
-  if (exists(link_dir))
-    if (!rm(link_dir))
-      return make_error(ec::filesystem_error, "cannot remove log symlink");
-  if (auto err = create_symlink(log_dir.trim(-1), link_dir))
-    return err;
-  // Store full path to the log file in config.
-  auto log_file = log_dir / application_name + ".log";
-  set("logger.file-name", log_file.str());
-  return caf::none;
-}
-
-void default_configuration::merge_settings(const caf::settings& from,
-                                           caf::settings& to) {
-  for (auto& [key, value] : from)
-    if (caf::holds_alternative<caf::settings>(value)) {
-      merge_settings(caf::get<caf::settings>(value), to[key].as_dictionary());
-    } else {
-      to.insert_or_assign(key, value);
-    }
-}
-
-// Parses the options from the root command and adds them to the global
-// configuration.
-caf::error default_configuration::merge_root_options(system::application& app) {
-  // Delegate to the root command for argument parsing.
-  caf::settings options;
-  app.root.options.parse(options, command_line.begin(), command_line.end());
-  // Move everything into the system-wide options.
-  merge_settings(options, content);
-  return caf::none;
 }
 
 } // namespace vast::system

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -168,6 +168,19 @@ public:
 command::invocation parse(const command& root, command::argument_iterator first,
                           command::argument_iterator last);
 
+/// Prepares `cfg` before using it to initialize an `actor_system` with it.
+/// This includes: (1) merging all settings from parsed CLI settings to `cfg`,
+/// (2) setting up the log file, and (3) overriding CAF settings with system
+/// settings where necessary, e.g., `system.verbosity` overrides
+/// `logger.console-verbosity`.
+/// @param cfg The config that should reflect all settings in `from`.
+/// @param from Result of parsed CLI arguments.
+/// @param error_output Destination for writing human-readable error output.
+///                     Only used when returning `false`.
+/// @returns `true` if all steps were successful, otherwise `false`.
+bool init_config(caf::actor_system_config& cfg, const command::invocation& from,
+                 std::ostream& error_output);
+
 /// Runs the command and blocks until execution completes.
 /// @returns a type-erased result or a wrapped `caf::error`.
 /// @relates command

--- a/libvast/vast/system/default_configuration.hpp
+++ b/libvast/vast/system/default_configuration.hpp
@@ -23,12 +23,7 @@
 namespace vast::system {
 
 struct default_configuration : system::configuration {
-  default_configuration(std::string application_name);
-  caf::error setup_log_file();
-  caf::error merge_root_options(system::application& app);
-  void merge_settings(const caf::settings& from, caf::settings& to);
-
-  std::string application_name;
+  default_configuration();
 };
 
 } // namespace vast::system

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -41,7 +41,7 @@ using namespace vast::system;
 
 int main(int argc, char** argv) {
   // CAF scaffold.
-  default_configuration cfg{"vast"};
+  default_configuration cfg;
   if (auto err = cfg.parse(argc, argv)) {
     std::cerr << "failed to parse configuration: " << to_string(err)
               << std::endl;
@@ -49,11 +49,6 @@ int main(int argc, char** argv) {
   }
   // Application setup.
   default_application app;
-  if (auto err = cfg.merge_root_options(app)) {
-    std::cerr << "failed to parse global CLI options: " << to_string(err)
-              << std::endl;
-    return EXIT_FAILURE;
-  }
   app.root.description = "manage a VAST topology";
   app.root.name = argv[0];
   // We're only interested in the application name, not in its path. For
@@ -74,10 +69,8 @@ int main(int argc, char** argv) {
     return EXIT_SUCCESS;
   }
   // Initialize actor system (and thereby CAF's logger).
-  if (auto err = cfg.setup_log_file()) {
-    std::cerr << "failed to setup log file: " << to_string(err) << std::endl;
+  if (!init_config(cfg, invocation, std::cerr))
     return EXIT_FAILURE;
-  }
   caf::actor_system sys{cfg};
   // Get filesystem path to the executable.
   auto binary = detail::objectpath();


### PR DESCRIPTION
- Consolidate various initialization steps that we needed in both VAST and Tenzir to streamline the startup sequence and make commands more easily extendible
- Improve user experience by allowing users to change the verbosity via `--verbosity=<level>` instead of `--ca#logger.console-verbosity=<level>`