### PR TITLE
Enable field-based access of table-slice columns

### DIFF
--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -13,7 +13,6 @@
 
 #include "vast/table_slice.hpp"
 
-#include <stdexcept>
 #include <unordered_map>
 
 #include <caf/actor_system.hpp>

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -106,12 +106,13 @@ table_slice::column_view table_slice::column(size_t index) const {
   return {*this, index};
 }
 
-table_slice::column_view table_slice::column(std::string_view name) const {
+caf::optional<table_slice::column_view>
+table_slice::column(std::string_view name) const {
   auto& fields = header_.layout.fields;
   for (size_t index = 0; index < fields.size(); ++index)
     if (fields[index].name == name)
-      return {*this, index};
-  throw std::logic_error("invalid column name");
+      return column_view{*this, index};
+  return caf::none;
 }
 
 caf::error table_slice::load(chunk_ptr chunk) {

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -13,6 +13,7 @@
 
 #include "vast/table_slice.hpp"
 
+#include <stdexcept>
 #include <unordered_map>
 
 #include <caf/actor_system.hpp>
@@ -55,6 +56,26 @@ auto cap (size_type pos, size_type num, size_type last) {
 
 } // namespace <anonymous>
 
+table_slice::column_view::column_view(const table_slice& slice, size_t column)
+  : slice_(slice), column_(column) {
+  // nop
+}
+
+data_view table_slice::column_view::operator[](size_t row) const {
+  VAST_ASSERT(row < rows());
+  return slice_.at(row, column_);
+}
+
+table_slice::row_view::row_view(const table_slice& slice, size_t row)
+  : slice_(slice), row_(row) {
+  // nop
+}
+
+data_view table_slice::row_view::operator[](size_t column) const {
+  VAST_ASSERT(column < columns());
+  return slice_.at(row_, column);
+}
+
 table_slice::table_slice(table_slice_header header)
   : header_{std::move(header)} {
   // nop
@@ -73,6 +94,24 @@ record_type table_slice::layout(size_type first_column,
   std::vector<record_field> sub_records{layout().fields.begin() + col_begin,
                                         layout().fields.begin() + col_end};
   return record_type{std::move(sub_records)};
+}
+
+table_slice::row_view table_slice::row(size_t index) const {
+  VAST_ASSERT(index < rows());
+  return {*this, index};
+}
+
+table_slice::column_view table_slice::column(size_t index) const {
+  VAST_ASSERT(index < columns());
+  return {*this, index};
+}
+
+table_slice::column_view table_slice::column(std::string_view name) const {
+  auto& fields = header_.layout.fields;
+  for (size_t index = 0; index < fields.size(); ++index)
+    if (fields[index].name == name)
+      return {*this, index};
+  throw std::logic_error("invalid column name");
 }
 
 caf::error table_slice::load(chunk_ptr chunk) {

--- a/libvast/test/format/pcap.cpp
+++ b/libvast/test/format/pcap.cpp
@@ -89,9 +89,9 @@ TEST(PCAP read/write 1) {
   auto src_field = slice->at(43, 1);
   auto src = unbox(caf::get_if<view<address>>(&src_field));
   CHECK_EQUAL(src, unbox(to<address>("192.168.1.1")));
-  auto id_column = slice->column("community_id");
+  auto community_id_column = unbox(slice->column("community_id"));
   for (size_t row = 0; row < 44; ++row)
-    CHECK_EQUAL(id_column[row], community_ids[row]);
+    CHECK_EQUAL(community_id_column[row], community_ids[row]);
   MESSAGE("write out read packets");
   auto file = "vast-unit-test-nmap-vsn.pcap";
   format::pcap::writer writer{file};

--- a/libvast/test/format/pcap.cpp
+++ b/libvast/test/format/pcap.cpp
@@ -33,7 +33,7 @@ namespace {
 
 // Baseline computed via `./community-id.py nmap_vsn.pcap` from the
 // repository https://github.com/corelight/community-id-spec.
-std::string_view communit_ids[] = {
+std::string_view community_ids[] = {
   "1:S2JPnyxVrN68D+w4ZMxKNeyQoNI=", "1:S2JPnyxVrN68D+w4ZMxKNeyQoNI=",
   "1:holOOTgd0/2k/ojauB8VsMbd2pI=", "1:holOOTgd0/2k/ojauB8VsMbd2pI=",
   "1:Vzc86YWBMwkcA1dPNrPN6t5hvj4=", "1:QbjD7ZBgS/i6o4RS0ovLWNhArt0=",
@@ -89,12 +89,9 @@ TEST(PCAP read/write 1) {
   auto src_field = slice->at(43, 1);
   auto src = unbox(caf::get_if<view<address>>(&src_field));
   CHECK_EQUAL(src, unbox(to<address>("192.168.1.1")));
-  auto community_id_at = [&](size_t row) {
-    auto id_field = slice->at(row, 5);
-    return unbox(caf::get_if<view<std::string>>(&id_field));
-  };
+  auto id_column = slice->column("community_id");
   for (size_t row = 0; row < 44; ++row)
-    CHECK_EQUAL(community_id_at(row), communit_ids[row]);
+    CHECK_EQUAL(id_column[row], community_ids[row]);
   MESSAGE("write out read packets");
   auto file = "vast-unit-test-nmap-vsn.pcap";
   format::pcap::writer writer{file};

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -116,6 +116,30 @@ TEST(random integer slices) {
   CHECK_LESS_EQUAL(*highest, 200);
 }
 
+TEST(column view) {
+  auto sut = zeek_conn_log_slices[0];
+  CHECK_EQUAL(sut->column("ts").column(), 0u);
+  for (size_t column = 0; column < sut->columns(); ++column) {
+    auto cview = sut->column(column);
+    CHECK_EQUAL(cview.column(), column);
+    CHECK_EQUAL(cview.rows(), sut->rows());
+    for (size_t row = 0; row < cview.rows(); ++row)
+      CHECK_EQUAL(cview[row], sut->at(row, column));
+  }
+}
+
+TEST(row view) {
+  auto sut = zeek_conn_log_slices[0];
+  CHECK_EQUAL(sut->column("ts").column(), 0u);
+  for (size_t row = 0; row < sut->rows(); ++row) {
+    auto rview = sut->row(row);
+    CHECK_EQUAL(rview.row(), row);
+    CHECK_EQUAL(rview.columns(), sut->columns());
+    for (size_t column = 0; column < rview.columns(); ++column)
+      CHECK_EQUAL(rview[column], sut->at(row, column));
+  }
+}
+
 TEST(select all) {
   auto sut = zeek_full_conn_log_slices.front();
   sut.unshared().offset(100);

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -118,7 +118,7 @@ TEST(random integer slices) {
 
 TEST(column view) {
   auto sut = zeek_conn_log_slices[0];
-  CHECK_EQUAL(sut->column("ts").column(), 0u);
+  CHECK_EQUAL(unbox(sut->column("ts")).column(), 0u);
   for (size_t column = 0; column < sut->columns(); ++column) {
     auto cview = sut->column(column);
     CHECK_EQUAL(cview.column(), column);
@@ -130,7 +130,6 @@ TEST(column view) {
 
 TEST(row view) {
   auto sut = zeek_conn_log_slices[0];
-  CHECK_EQUAL(sut->column("ts").column(), 0u);
   for (size_t row = 0; row < sut->rows(); ++row) {
     auto rview = sut->row(row);
     CHECK_EQUAL(rview.row(), row);

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -40,6 +40,62 @@ public:
 
   static constexpr size_type npos = std::numeric_limits<size_type>::max();
 
+  /// Convenience helper for traversing a column.
+  class column_view {
+  public:
+    column_view(const table_slice& slice, size_t column);
+
+    /// @returns the data at given row.
+    data_view operator[](size_t row) const;
+
+    /// @returns the number of rows in the slice.
+    size_t rows() const noexcept {
+      return slice_.rows();
+    }
+
+    /// @returns the viewed table slice.
+    const table_slice& slice() const noexcept {
+      return slice_;
+    }
+
+    /// @returns the viewed column.
+    size_t column() const noexcept {
+      return column_;
+    }
+
+  private:
+    const table_slice& slice_;
+    size_t column_;
+  };
+
+  /// Convenience helper for traversing a row.
+  class row_view {
+  public:
+    row_view(const table_slice& slice, size_t row);
+
+    /// @returns the data at given column.
+    data_view operator[](size_t column) const;
+
+    /// @returns the number of columns in the slice.
+    size_t columns() const noexcept {
+      return slice_.columns();
+    }
+
+    /// @returns the viewed table slice.
+    const table_slice& slice() const noexcept {
+      return slice_;
+    }
+
+    /// @returns the viewed row.
+    size_t row() const noexcept {
+      return row_;
+    }
+
+  private:
+    const table_slice& slice_;
+    size_t row_;
+  };
+
   // -- constructors, destructors, and assignment operators --------------------
 
   ~table_slice() override;
@@ -103,10 +159,22 @@ public:
     return header_.rows;
   }
 
+  /// @returns a row view for the given `index`.
+  /// @pre `row < rows()`
+  row_view row(size_t index) const;
+
   /// @returns the number of rows in the slice.
   size_type columns() const noexcept {
     return header_.layout.fields.size();
   }
+
+  /// @returns a column view for the given `index`.
+  /// @pre `column < columns()`
+  column_view column(size_t index) const;
+
+  /// @returns a view for the column with given `name`.
+  /// @pre there is a c such that `c == column_name(name)`
+  column_view column(std::string_view name) const;
 
   /// @returns the offset in the ID space.
   id offset() const noexcept {

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -21,6 +21,7 @@
 #include <caf/allowed_unsafe_message_type.hpp>
 #include <caf/fwd.hpp>
 #include <caf/make_copy_on_write.hpp>
+#include <caf/optional.hpp>
 #include <caf/ref_counted.hpp>
 
 #include "vast/fwd.hpp"
@@ -172,9 +173,9 @@ public:
   /// @pre `column < columns()`
   column_view column(size_t index) const;
 
-  /// @returns a view for the column with given `name`.
-  /// @pre there is a c such that `c == column_name(name)`
-  column_view column(std::string_view name) const;
+  /// @returns a view for the column with given `name` on success, or `none` if
+  ///          no column matches the `name`.
+  caf::optional<column_view> column(std::string_view name) const;
 
   /// @returns the offset in the ID space.
   id offset() const noexcept {


### PR DESCRIPTION
The new visitors for row- and column-based access provide a more intuitive API to use table slices programmatically, especially in unit tests.